### PR TITLE
make twitter auth work again

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,6 @@
     "next": "^8.0.3",
     "next-apollo": "^2.0.9",
     "node-fetch": "^2.3.0",
-    "oauth-libre": "^0.9.17",
     "object-hash": "^1.3.1",
     "octicons": "^7.2.0",
     "p-finally": "^1.0.0",

--- a/packages/keystone/package.json
+++ b/packages/keystone/package.json
@@ -24,7 +24,6 @@
     "graphql": "^14.0.2",
     "graphql-tag": "^2.10.1",
     "graphql-type-json": "^0.2.1",
-    "oauth-libre": "^0.9.17",
     "p-waterfall": "^1.0.0",
     "passport": "^0.4.0",
     "passport-twitter": "^1.0.4",

--- a/test-projects/twitter-login/server.js
+++ b/test-projects/twitter-login/server.js
@@ -17,7 +17,7 @@ keystone
     });
 
     if (twitterAuthEnabled) {
-      configureTwitterAuth(keystone, server);
+      configureTwitterAuth(keystoneApp, server);
     }
 
     server.app.use(staticRoute, server.express.static(staticPath));

--- a/test-projects/twitter-login/twitter.js
+++ b/test-projects/twitter-login/twitter.js
@@ -29,15 +29,23 @@ exports.configureTwitterAuth = function(keystone, server) {
     })
   );
 
+  server.app.get('/api/session', (req, res) => {
+    res.json({
+      signedIn: !!req.session.keystoneItemId,
+      userId: req.session.keystoneItemId,
+      name: req.user ? req.user.name : undefined,
+    });
+  });
+
   // Twitter will redirect the user to this URL after approval.
   server.app.get(
     '/auth/twitter/callback',
     twitterAuth.authenticateMiddleware({
-      async verified(item, info, req, res) {
+      async verified(item, { list }, req, res) {
         if (!item) {
           return res.redirect('/auth/twitter/details');
         }
-
+        await keystone.sessionManager.startAuthedSession(req, { item, list });
         res.redirect('/api/session');
       },
       failedVerification(error, req, res) {


### PR DESCRIPTION
this is different than #164, I am just trying to make twitter auth work. I was able to get rid of mongoose specific code (`.populate()` and `.update().exec()`), see #752 

- fix query and update syntax which assumes mongoose only adapter
- fix type due to core name change to keystone
- add missing startAuthedSession inside twitter callback
- add `/api/session` back which broke final redirect earlier.