### PR TITLE
Docs improvements

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -7,7 +7,7 @@ title: Introduction
 
 Some guides to help you perform various tasks in the KeystoneJS ecosystem.
 
-- [Access Control](../access-control.md)
+- [Access Control](./access-control.md)
 - [Hooks](./hooks.md)
 - [Mutation Lifecycle](./mutation-lifecycle.md)
 - [Performance](./performance.md)

--- a/docs/guides/access-control.md
+++ b/docs/guides/access-control.md
@@ -54,7 +54,7 @@ See [Authentication](../authentication.md).
 
 ## GraphQL Access Control
 
-Access control is about limiting CRUD actions that can be performed based on the
+Access control is about limiting CRUD (Create, Read, Update, Delete) actions that can be performed based on the
 access level of the currently authenticated (or anonymous) user.
 
 For example, the below access control states:

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -12,41 +12,92 @@ _Note on terminology_:
 - _Access Control_ refers to the specific actions an authenticated or anonymous
   user can take. Often referred to as _authorization_ elsewhere.
   The specifics of how this is done is outside the scope of this document.
-  See [Access Control](../access-control.md) for more.
+  See [Access Control](./access-control.md) for more.
 
 ## Admin UI
 
 Username / Password authentication can be enabled on the Admin UI.
 
 > NOTE: Admin Authentication will only restrict access to the Admin _UI_.
+>
 > To also restrict access to the _API_,
-> you must setup [Access Control](../access-control.md) config.
+> you must setup [Access Control](./access-control.md) config.
 
-First, setup [a `PasswordAuthStrategy` instance](#passwordauthstrategy).
+To setup authentication, you must instantiate an _Auth Strategy_, and create a
+list used for authentication in `index.js`:
 
-Then, pass that instance into the Admin UI setup:
+Here, we will setup a `PasswordAuthStrategy` instance:
 
 ```javascript
-const { AdminUI } = require('@keystone-alpha/admin-ui');
-const PasswordAuthStrategy = require('@keystone-alpha/keystone/auth/Password');
+const { AdminUI }         = require('@keystone-alpha/admin-ui');
+const { Text, Password }  = require('@keystone-alpha/fields');
+const PasswordAuth        = require('@keystone-alpha/keystone/auth/Password');
 
 const keystone = // ...
 
-const authStrategy = keystone.createAuthStrategy({
-  type: PasswordAuthStrategy,
-  list: 'User',
+keystone.createList('User', {
+  fields: {
+    username: { type: Text },
+    password: { type: Password },
+  },
 });
 
-const admin = new AdminUI(keystone, {
-  adminPath: '/admin',
-  authStrategy,
+const authStrategy = keystone.createAuthStrategy({
+  type: PasswordAuth,
+  list: 'User',
+  config: {
+    identityField: 'username', // default: 'email'
+    secretField: 'password',   // default: 'password'
+  }
 });
+
+// Enable Admin UI login by adding the authentication strategy
+const admin = new AdminUI(keystone, { authStrategy });
 ```
 
-The Admin UI will then come with the correct routes and checks for
-authentication against the UI.
+Once your Keystone server is restarted, the Admin UI will now enforce
+authentication.
 
-## Strategies
+### Logging in to the Admin UI
 
-Auth strategies are
-[documented in the keystone package](../../packages/keystone/auth/README.md).
+The first time you setup authentication, you may not be able to login. This is
+because there are no `User`s who can do the logging in.
+
+First, disable authentication on the Admin UI by removing `authStrategy` from
+the `new AdminUI()` call:
+
+```diff
+- const admin = new AdminUI(keystone, { authStrategy });
++ const admin = new AdminUI(keystone, { });
+```
+
+Restart your Keystone App, and visit [http://localhost:3000/users](http://localhost:3000/users) - you should now be able to access the Admin UI without logging in.
+
+Next, create a User (be sure to set both a username and password).
+
+Add the `authStrategy` config back to the `new AdminUI()` call
+
+```diff
+- const admin = new AdminUI(keystone, { });
++ const admin = new AdminUI(keystone, { authStrategy });
+```
+
+Restart your Keystone App once more, and try to visit [http://localhost:3000/users](http://localhost:3000/users); you will be presented with the login screen.
+
+Finally; login with the newly created `User`'s credentials.
+
+## API Access Control
+
+Adding Authentication as above will only enable login to the Admin UI, it _will
+not_ restrict API access.
+
+**To also restrict API access, you must setup [Access Control](./access-control.md).**
+
+<!--
+The linked page seems to be skipped by Gatsby. Will re-add this section once
+fixed.
+## Auth Strategies
+
+For more info on Auth strategies, see [the `@keystone-alpha/keystone`
+package](../../packages/keystone/auth/README.md).
+-->

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -7,5 +7,5 @@ title: Introduction
 
 Welcome to the KeystoneJS tutorials. These tutorials are designed to introduce you to the various concepts within Keystone and take you through worked examples.
 
-- [Admin UI](../admin-ui.md)
+- [Admin UI](./admin-ui.md)
 - [Intro To GraphQL](./intro-to-graphql.md)

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -6,3 +6,6 @@ title: Introduction
 # Tutorials
 
 Welcome to the KeystoneJS tutorials. These tutorials are designed to introduce you to the various concepts within Keystone and take you through worked examples.
+
+- [Admin UI](../admin-ui.md)
+- [Intro To GraphQL](./intro-to-graphql.md)

--- a/docs/tutorials/intro-to-graphql.md
+++ b/docs/tutorials/intro-to-graphql.md
@@ -3,6 +3,6 @@ section: tutorials
 title: GraphQL
 ---
 
-# GraphQL
+# Intro To GraphQL
 
 In this tutorial we will introduce you to GraphQL and show you show to use the KeystoneJS GraphQL API to interact with your system.

--- a/packages/keystone/README.md
+++ b/packages/keystone/README.md
@@ -184,3 +184,11 @@ Limitations include:
 
 When these limitations apply to your task at hand, we recommend using the
 GraphQL API instead. It is more verbose, but much more powerful.
+
+<!--
+The linked page seems to be skipped by Gatsby. Will re-add this section once
+fixed.
+## Auth Strategies
+
+For more info on Auth strategies, see [the Authentication Strategies documentation](../../packages/keystone/auth/README.md).
+-->


### PR DESCRIPTION
## Guides

- [x] Homepage "Access Control" link is 404

## Access Control

- [x] "is about limiting CRUD" -> "is about limiting CRUD (Create, Read, Update, Delete)"
- [x] "type: Bool" should be "type: Checkbox"
- [x] "type: Email" should be "type: Text"
- [x] types (Select, Text, Checkbox, Password) should be imported
- [x] Adding demo code results in "GraphQL error: Cannot read property 'isAdmin' of undefined" within AdminUI
- [x] example needs note on setting up authentication (maybe a code example, with link out to docs)

## Authentication

- [x] "a PasswordAuthStrategy instance." 404s - I can't find where it should link to.
- [x] " documented in the keystone package." 404s - I can't find where it should link to.
- [x] Needs note about adding your first user so you can actually login when auth enabled
- [x] Change `read` ACL so admins can access it
- [x] Add note about _no-one_ having access to passwords
- [x] Remove unnecessary `adminPath` from `new AdminUI`
