### PR TITLE
Put clickable URLs from quickstart in console

### DIFF
--- a/demo-projects/todo/server.js
+++ b/demo-projects/todo/server.js
@@ -12,7 +12,13 @@ keystone
     return server.start();
   })
   .then(({ port }) => {
-    console.log(`Listening on port ${port}`);
+    console.log(`
+      Success! Your application is available at:
+
+      App URL: http://localhost:${port}
+      Admin URL: http://localhost:${port}/admin
+      GraphQL Playground: http://localhost:${port}/admin/graphiql
+    `);
   })
   .catch(error => {
     console.error(error);


### PR DESCRIPTION
Feel free to close this one, but having the URLs clickable from your terminal is really helpful and I think it really shows the magic of how fast you can get up and running with keystone. 

<img width="819" alt="Screen Shot 2019-03-22 at 9 56 43 AM" src="https://user-images.githubusercontent.com/176013/54827686-f7502a00-4c88-11e9-993f-8c4df3a406b2.png">
