### PR TITLE
Make all docs headers clicky for perma-linking

### DIFF
--- a/.changeset/7dea9798/changes.json
+++ b/.changeset/7dea9798/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/website", "type": "patch" }], "dependents": [] }

--- a/.changeset/7dea9798/changes.md
+++ b/.changeset/7dea9798/changes.md
@@ -1,0 +1,1 @@
+- Make all docs headers clicky for perma-linking.

--- a/website/src/components/markdown/Heading.js
+++ b/website/src/components/markdown/Heading.js
@@ -19,10 +19,33 @@ const Heading = ({ as: Tag, children, ...props }) => (
       color: colors.N100,
       lineHeight: 1,
       marginBottom: '0.66em',
+      '&:hover a': {
+        opacity: 0.5,
+      },
     }}
     id={dashcase(children)}
     {...props}
   >
+    <a
+      href={`#${dashcase(children)}`}
+      css={{
+        display: 'inline-block',
+        width: 0,
+        overflow: 'visible',
+        transform: 'scaleX(-1)',
+        // This provides some space between the components, while still ensuring
+        // they take up a single continuous space to avoid hover flicker.
+        marginLeft: '-0.2em',
+        paddingLeft: '0.2em',
+        fontSize: '0.7em',
+        opacity: 0,
+        '&:hover': {
+          opacity: 0.8,
+        },
+      }}
+    >
+      🔗
+    </a>
     {children}
   </Tag>
 );


### PR DESCRIPTION
Closes #891

![clicky-titles](https://user-images.githubusercontent.com/612020/54865499-58c3e600-4dba-11e9-9267-9ada3c7c27ee.gif)
