### PR TITLE
Remove getAuxQueryResolvers method from keystone

### DIFF
--- a/.changeset/09faff34/changes.json
+++ b/.changeset/09faff34/changes.json
@@ -1,0 +1,63 @@
+{
+  "releases": [{ "name": "@keystone-alpha/keystone", "type": "major" }],
+  "dependents": [
+    {
+      "name": "@keystone-alpha/adapter-knex",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/adapter-mongoose",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/test-utils",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-knex",
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/keystone"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-blog",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-todo",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-access-control",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-basic",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-login",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-twitter-login",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/api-tests",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/test-utils",
+        "@keystone-alpha/keystone"
+      ]
+    }
+  ]
+}

--- a/.changeset/09faff34/changes.md
+++ b/.changeset/09faff34/changes.md
@@ -1,0 +1,1 @@
+- Remove keystone.getAuxQueryResolvers method

--- a/packages/admin-ui/CHANGELOG.md
+++ b/packages/admin-ui/CHANGELOG.md
@@ -1,10 +1,12 @@
 # @keystone-alpha/admin-ui
 
 ## 3.0.3
-- [patch] [85cb44a9](https://github.com/keystonejs/keystone-5/commit/85cb44a9):
+
+- [patch][85cb44a9](https://github.com/keystonejs/keystone-5/commit/85cb44a9):
 
   - Introduce `pages` config option
   - Remove `sortListsAlphabetically`
+
 - Updated dependencies [85cb44a9](https://github.com/keystonejs/keystone-5/commit/85cb44a9):
   - @arch-ui/navbar@0.0.4
 

--- a/packages/arch/packages/navbar/CHANGELOG.md
+++ b/packages/arch/packages/navbar/CHANGELOG.md
@@ -1,7 +1,8 @@
 # @arch-ui/navbar
 
 ## 0.0.4
-- [patch] [85cb44a9](https://github.com/keystonejs/keystone-5/commit/85cb44a9):
+
+- [patch][85cb44a9](https://github.com/keystonejs/keystone-5/commit/85cb44a9):
 
   - Add PrimaryNavHeading component and change styles
 

--- a/packages/keystone/Keystone/index.js
+++ b/packages/keystone/Keystone/index.js
@@ -304,7 +304,8 @@ module.exports = class Keystone {
         ...objMerge(firstClassLists.map(list => list.gqlAuxQueryResolvers)),
         ...objMerge(firstClassLists.map(list => list.gqlQueryResolvers)),
         // And the Keystone meta queries must always be available
-        ...this.getAuxQueryResolvers(),
+        _ksListsMeta: (_, args, context) =>
+          this.listsArray.filter(list => list.access.read).map(list => list.listMeta(context)),
       },
 
       Mutation: {
@@ -330,13 +331,6 @@ module.exports = class Keystone {
       ${this.getTypeDefs({ skipAccessControl: true }).join('\n')}
     `;
     fs.writeFileSync(file, schema);
-  }
-
-  getAuxQueryResolvers() {
-    return {
-      _ksListsMeta: (_, args, context) =>
-        this.listsArray.filter(list => list.access.read).map(list => list.listMeta(context)),
-    };
   }
 
   // Create an access context for the given "user" which can be used to call the

--- a/website/CHANGELOG.md
+++ b/website/CHANGELOG.md
@@ -1,7 +1,8 @@
 # @keystone-alpha/website
 
 ## 1.0.4
-- [patch] [2d704f98](https://github.com/keystonejs/keystone-5/commit/2d704f98):
+
+- [patch][2d704f98](https://github.com/keystonejs/keystone-5/commit/2d704f98):
 
   - Make all docs headers clicky for perma-linking.
 


### PR DESCRIPTION
This method was a bit of a weird outlier that didn't serve much purpose. I've moved it inline to reduce the public API surface area.

(Also brings in the result of `yarn format` on some changelogs).