### PR TITLE
Implement custom Admin UI pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,6 +186,7 @@
     "react-radios": "^1.1.0",
     "react-scrolllock": "^4.0.1",
     "react-select": "2.3.0",
+    "react-sparklines": "^1.7.0",
     "react-toast-notifications": "^1.2.0",
     "react-transition-group": "^2.6.1",
     "react-uid": "^2.2.0",

--- a/packages/admin-ui/client/providers/Router.js
+++ b/packages/admin-ui/client/providers/Router.js
@@ -4,9 +4,10 @@ import { prefixURL } from 'next-prefixed';
 import React, { Component } from 'react';
 import NextRouter, { withRouter as nextWithRouter } from 'next/router';
 
+import { customPages } from '../FIELD_TYPES';
 import router from '../router';
 
-export const routes = router(process.env.assetPrefix);
+export const routes = router(process.env.assetPrefix, customPages);
 
 export const Link = ({ route, params, ...props }) => (
   <NextLink {...props} {...route && routes[route].to(params)} />

--- a/packages/admin-ui/server/admin/pages/custom.js
+++ b/packages/admin-ui/server/admin/pages/custom.js
@@ -1,0 +1,37 @@
+import React, { Component } from 'react';
+import dynamic from 'next/dynamic';
+import { mapKeys } from '@keystone-alpha/utils';
+
+import PageError from '../client/components/PageError';
+import PageLoading from '../client/components/PageLoading';
+import { loadView, customPages } from '../client/FIELD_TYPES';
+
+const Loading = ({ error, pastDelay }) => {
+  // avoid flash-of-loading-component
+  if (!pastDelay) return null;
+  if (error) {
+    return (
+      <PageError>
+        {process.env.NODE_ENV === 'production'
+          ? 'There was an error loading the page'
+          : error.message || error.toString()}
+      </PageError>
+    );
+  }
+  return <PageLoading />;
+};
+
+const customPageComponents = mapKeys(customPages, ({ component, ssr = true }) =>
+  dynamic(() => loadView(component), { loading: Loading, ssr })
+);
+
+export default class CustomPage extends Component {
+  static getInitialProps({ query }) {
+    return { path: query.path };
+  }
+
+  render() {
+    const Page = customPageComponents[this.props.path];
+    return <Page />;
+  }
+}

--- a/packages/admin-ui/server/next-plugin-keystone.js
+++ b/packages/admin-ui/server/next-plugin-keystone.js
@@ -3,11 +3,15 @@ const withBundleAnalyzer = require('@zeit/next-bundle-analyzer');
 const withTranspileModules = require('@weco/next-plugin-transpile-modules');
 
 module.exports = (nextConfig = {}) => {
-  const { analyze, assetPrefix, adminMeta, webpack } = nextConfig;
+  const { analyze, assetPrefix, adminMeta, customPages = {}, webpack } = nextConfig;
   return withBundleAnalyzer(
     withTranspileModules({
       ...nextConfig,
-      transpileModules: ['@keystone-alpha', '@arch-ui'],
+      transpileModules: [
+        '@keystone-alpha',
+        '@arch-ui',
+        ...Object.values(customPages).map(({ component }) => component),
+      ],
       // Output bundle analysis
       ...(analyze && {
         analyzeServer: true,

--- a/test-projects/basic/custom-pages/report-new-posts.js
+++ b/test-projects/basic/custom-pages/report-new-posts.js
@@ -1,0 +1,16 @@
+/** @jsx jsx */
+
+import { jsx, css } from '@emotion/core';
+import React from 'react';
+import { Sparklines, SparklinesLine } from 'react-sparklines';
+
+export default () => {
+  return (
+    <section css={css`margin: 2rem;`}>
+      <h1>New Posts Report</h1>
+      <Sparklines data={[5, 10, 5, 20, 8, 15]}>
+        <SparklinesLine />
+      </Sparklines>
+    </section>
+  );
+};

--- a/test-projects/basic/custom-pages/report-new-users.js
+++ b/test-projects/basic/custom-pages/report-new-users.js
@@ -1,0 +1,28 @@
+/** @jsx jsx */
+
+import { jsx, css } from '@emotion/core';
+import React from 'react';
+import { createPortal } from 'react-dom';
+import { Sparklines, SparklinesLine } from 'react-sparklines';
+
+export default () => {
+  return createPortal(
+    <section
+      css={css`
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translateY(-50%);
+        padding: 2rem;
+        border: 1px solid black;
+        box-shadow: 0px 0px 100px -20px rgba(0, 0, 0, 0.8);
+      `}
+    >
+      <h1>New Users Report</h1>
+      <Sparklines data={[5, 10, 5, 20, 8, 15]}>
+        <SparklinesLine color="#fa7e17" />
+      </Sparklines>
+    </section>,
+    document.body
+  );
+};

--- a/test-projects/basic/index.js
+++ b/test-projects/basic/index.js
@@ -153,7 +153,38 @@ keystone.createList('SomeLongNamedList', {
   },
 });
 
-const admin = new AdminUI(keystone);
+const admin = new AdminUI(keystone, {
+  pages: [
+    {
+      label: 'Posts',
+      children: [{ listKey: 'Post' }, { listKey: 'PostCategory', label: 'Categories' }],
+    },
+    {
+      label: 'Accounts',
+      children: ['User'],
+    },
+    {
+      label: 'Reports',
+      children: [
+        {
+          label: 'New Posts',
+          path: '/report/new-posts',
+          component: require.resolve('./custom-pages/report-new-posts'),
+        },
+        {
+          label: 'New Users',
+          path: '/report/new-users',
+          component: require.resolve('./custom-pages/report-new-users'),
+          ssr: false,
+        },
+      ],
+    },
+    {
+      label: 'Other',
+      children: ['SomeLongNamedList'],
+    },
+  ],
+});
 
 module.exports = {
   keystone,

--- a/test-projects/basic/package.json
+++ b/test-projects/basic/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "dev": "node -r dotenv-safe/config `yarn bin`/keystone | sed -l -e 's/:\\s*undefined\\s*,/:null,/g' | tee out.log | pino-colada",
-    "build": "ANALYZE_DIR=analysis NODE_ENV=development node -r dotenv-safe/config `yarn bin`/keystone build --out dist",
+    "build": "ANALYZE_DIR=analysis NODE_ENV=production node -r dotenv-safe/config `yarn bin`/keystone build --out dist",
     "start": "NODE_ENV=production node -r dotenv-safe/config `yarn bin`/keystone",
     "cypress:run:cmd": "TZ=UTC node -r dotenv-safe/config `which cypress` run",
     "cypress:open:cmd": "TZ=UTC node -r dotenv-safe/config `which cypress` open",
@@ -24,13 +24,13 @@
     "@keystone-alpha/adapter-mongoose": "^1.0.3",
     "@keystone-alpha/admin-ui": "^3.0.2",
     "@keystone-alpha/core": "^2.0.1",
-    "@keystone-alpha/keystone": "^0.0.0",
     "@keystone-alpha/fields": "^3.0.1",
     "@keystone-alpha/file-adapters": "^1.0.1",
     "@keystone-alpha/keystone": "^1.0.4",
     "@keystone-alpha/server": "^2.0.2",
     "date-fns": "^1.30.1",
-    "react": "^16.8.4"
+    "react": "^16.8.4",
+    "react-sparklines": "^1.7.0"
   },
   "devDependencies": {
     "@keystone-alpha/test-utils": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16966,6 +16966,13 @@ react-sortable-hoc@^0.8.3:
     invariant "^2.2.1"
     prop-types "^15.5.7"
 
+react-sparklines@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/react-sparklines/-/react-sparklines-1.7.0.tgz#9b1d97e8c8610095eeb2ad658d2e1fcf91f91a60"
+  integrity sha512-bJFt9K4c5Z0k44G8KtxIhbG+iyxrKjBZhdW6afP+R7EnIq+iKjbWbEFISrf3WKNFsda+C46XAfnX0StS5fbDcg==
+  dependencies:
+    prop-types "^15.5.10"
+
 react-toast-notifications@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/react-toast-notifications/-/react-toast-notifications-1.3.1.tgz#76386c08d0a039d8ed153ceebeb19dd6f88ede34"


### PR DESCRIPTION
Built on top of the `next.js` work in the `cli-build-squashed-renamed` branch.

This page 👇 is Server Side Rendered, only 16 lines long, uses Emotion, an npm component (`react-sparklines`), and works in both dev mode _and_ production built mode.

![custom-pages](https://user-images.githubusercontent.com/612020/54972084-f9462000-4fdd-11e9-87fa-900e5f628a0a.gif)

This is the config:

https://github.com/keystonejs/keystone-5/blob/b624912caefc04adcc5317e798a04b2bed264b59/test-projects/basic/index.js#L169-L173

And this is the "custom page":

https://github.com/keystonejs/keystone-5/blob/b624912caefc04adcc5317e798a04b2bed264b59/test-projects/basic/custom-pages/report-new-posts.js#L1-L16

_NOTE: The tests will fail because they're also failing in the parent branch._

---

## Client Side Only support

It also supports client-side only pages (in case there's just no way you can get the SSR to work):

![custom-pages-no-ssr](https://user-images.githubusercontent.com/612020/54974715-13393000-4fe9-11e9-9961-712ca15c802a.gif)

The config for this looks like:

https://github.com/keystonejs/keystone-5/blob/b624912caefc04adcc5317e798a04b2bed264b59/test-projects/basic/index.js#L174-L179

And to prove it's client-side only code, I used `React.createPortal` targeting `document.body`:

https://github.com/keystonejs/keystone-5/blob/b624912caefc04adcc5317e798a04b2bed264b59/test-projects/basic/custom-pages/report-new-users.js#L1-L28