### PR TITLE
Add audiences to the session to help restrict access to different APIs.

### DIFF
--- a/.changeset/41764051/changes.json
+++ b/.changeset/41764051/changes.json
@@ -1,0 +1,38 @@
+{
+  "releases": [{ "name": "@keystone-alpha/session", "type": "minor" }],
+  "dependents": [
+    {
+      "name": "@keystone-alpha/admin-ui",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/session"]
+    },
+    {
+      "name": "@keystone-alpha/server",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/session"]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-login",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/server",
+        "@keystone-alpha/session"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-twitter-login",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/server",
+        "@keystone-alpha/session"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/api-tests",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/server", "@keystone-alpha/session"]
+    }
+  ]
+}

--- a/.changeset/41764051/changes.md
+++ b/.changeset/41764051/changes.md
@@ -1,0 +1,1 @@
+- `startAuthedSession` now takes an `audiences` paramter, which is attached to the session. `createSessionMiddleware` takes an `audiences` parameter, which is passed through to `startAudthedSession` at `signin`. Added `restrictAudienceMiddleware`, which allows access to an endpoint to be restricted based on which audiences are currently attached to the session.

--- a/.changeset/9439971f/changes.json
+++ b/.changeset/9439971f/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/admin-ui", "type": "patch" }], "dependents": [] }

--- a/.changeset/9439971f/changes.md
+++ b/.changeset/9439971f/changes.md
@@ -1,0 +1,1 @@
+- Add the `admin` audience when signing in via the admin UI session middleware.

--- a/packages/admin-ui/server/AdminUI.js
+++ b/packages/admin-ui/server/AdminUI.js
@@ -49,9 +49,14 @@ module.exports = class AdminUI {
 
   createSessionMiddleware() {
     const { signinPath, signoutPath, sessionPath } = this.config;
+    // This session allows the user to authenticate as part of the 'admin' audience.
+    // This isn't used by anything just yet. In the near future we will set up the admin-ui
+    // application and api to be non-public.
+    const audiences = ['admin'];
     return createSessionMiddleware(
       { signinPath, signoutPath, sessionPath, successPath: this.adminPath },
-      this.authStrategy
+      this.authStrategy,
+      audiences
     );
   }
 

--- a/packages/server/WebServer/index.js
+++ b/packages/server/WebServer/index.js
@@ -39,7 +39,12 @@ module.exports = class WebServer {
 
     // GraphQL API always exists independent of any adminUI or Session settings
     const { apiPath, graphiqlPath, port } = this.config;
-    this.app.use(createGraphQLMiddleware(server, { apiPath, graphiqlPath, port }));
+    // We currently make the admin UI public. In the future we want to be able
+    // to restrict this to a limited audience, while setting up a separate
+    // public API with much stricter access control.
+    this.app.use(
+      createGraphQLMiddleware(server, { apiPath, graphiqlPath, port }, { isPublic: true })
+    );
 
     if (adminUI) {
       // This must be last as it's the "catch all" which falls into Webpack to

--- a/packages/session/index.js
+++ b/packages/session/index.js
@@ -68,7 +68,7 @@ const formatResponse = (res, htmlResponse, json) =>
 const redirectSuccessfulSignin = (target, req, res) =>
   formatResponse(res, () => res.redirect(target), { success: true });
 
-const signin = (signinPath, successPath, authStrategy) => async (req, res, next) => {
+const signin = (signinPath, successPath, authStrategy, audiences) => async (req, res, next) => {
   try {
     // TODO: How could we support, for example, the twitter auth flow?
     const result = await authStrategy.validate({
@@ -82,7 +82,7 @@ const signin = (signinPath, successPath, authStrategy) => async (req, res, next)
       return formatResponse(res, htmlResponse, { success: false, message: result.message });
     }
 
-    await startAuthedSession(req, result);
+    await startAuthedSession(req, result, audiences);
   } catch (e) {
     return next(e);
   }
@@ -115,7 +115,8 @@ const session = (req, res) => {
 
 const createSessionMiddleware = (
   { signinPath, signoutPath, sessionPath, successPath },
-  authStrategy
+  authStrategy,
+  audiences
 ) => {
   const app = express();
 
@@ -125,7 +126,7 @@ const createSessionMiddleware = (
     signinPath,
     bodyParser.json(),
     bodyParser.urlencoded({ extended: true }),
-    signin(signinPath, successPath, authStrategy)
+    signin(signinPath, successPath, authStrategy, audiences)
   );
 
   // Listen to both POST and GET events, and always sign the user out.
@@ -160,17 +161,39 @@ function populateAuthedItemMiddleware(keystone) {
     }
     req.user = item;
     req.authedListKey = list.key;
+    req.audiences = session.audiences;
 
     next();
   };
 }
 
-function startAuthedSession(req, { item, list }) {
+function restrictAudienceMiddleware({ isPublic, audiences }) {
+  return (req, res, next) => {
+    if (isPublic) {
+      // If the session restriction is marked public, we let everything through.
+      next();
+    } else if (
+      req.audiences &&
+      audiences &&
+      Array.isArray(audiences) &&
+      req.audiences.some(audience => audiences.includes(audience))
+    ) {
+      // Otherwise, if one of the session audiences matches one of the restriction audiences, we let them through.
+      next();
+    } else {
+      // If the don't make it through, we simply respond with a 403 Permission Denied
+      res.status(403).send();
+    }
+  };
+}
+
+function startAuthedSession(req, { item, list }, audiences) {
   return new Promise((resolve, reject) =>
     req.session.regenerate(err => {
       if (err) return reject(err);
       req.session.keystoneListKey = list.key;
       req.session.keystoneItemId = item.id;
+      req.session.audiences = audiences;
       resolve();
     })
   );
@@ -188,6 +211,7 @@ function endAuthedSession(req) {
 module.exports = {
   commonSessionMiddleware,
   createSessionMiddleware,
+  restrictAudienceMiddleware,
   startAuthedSession,
   endAuthedSession,
 };


### PR DESCRIPTION
This PR introduces the concept of a session `audience`.

In order to avoid schema leakage, we want to be able to restrict access to different routes based on currently authenticated "user". This consideration operates at a level above the schema level access control mechanisms.

There are two sides to this implementation. On the first side, we want to make sure `audiences` can be attached to sessions. `startAuthedSession()` now takes an `audiences` parameter and attaches it to the `req.session`. This value should be an array of strings. This in turn is handled by `populateAuthedItemMiddleware` which makes `req.audiences` available to downstream middlewares. `createSessionMiddleware` has been updated to take an `audiences` argument and use this in its calls to `startAuthedSession()`. The admin UI in turn passes in an `audiences` list of [`admin`], meaning that anyone who has logged in via the admin UI session routes will have that `audience` enabled.

The second side of the implementation involves putting in place middleware to check the session `audiences` and deny access unless the logged in user is part of a specific audience. `restrictAudienceMiddleware()` takes `{ public, audiences }` as an argument. If `public` is true, then everyone is passed through. If `audiences` is specified, then the current session must have at least one `audience` in common with this argument. e.g. if `req.audiences = ['a', 'b', 'c']` and `audiences = ['c', 'd', 'e']` then the user would be let in, because they are a member of the `'c'` audience, which is one of the valid audiences.

The `restrictAudienceMiddleware` middleware is used by `createGraphQLMiddleware` to protect all of the graphql endpoints which it sets up. `createGraphQLMiddleware` now also takes `{public, audiences }` as an argument, which it passes directly to `restrictAudienceMiddleware`. We currently call `createGraphQLMiddleware(..., { public: true} )` when setting up the single graphql endpoint supported by Keystone.

This mechanism will allow us to set up multiple graphql endpoints with different session level access control. The exact final API to be exposed in userland to support this is yet to be finalised.

c.f. #931 #874 