### PR TITLE
Demo blog improvements

### DIFF
--- a/demo-projects/blog/README.md
+++ b/demo-projects/blog/README.md
@@ -8,8 +8,9 @@ The Blog is a great example and boilerplate for more complex, real-world impleme
 
 To run this project, open your terminal and run `bolt` within the Keystone project root to install all required packages, then run `bolt start blog` to begin running Keystone.
 
-The Keystone Admin UI is reachable from `localhost:3000/admin`. To log in, use the following credentials...
-Username: `admin@keystone.project`
+The Keystone Admin UI is reachable from `localhost:3000/admin`. To log in, use the following credentials:
+
+Username: `admin@keystonejs.com`
 Password: `password`
 
 To see an example Next.js app using Keystone's GraphQl APIs, head to `localhost:3000`.

--- a/demo-projects/blog/config.js
+++ b/demo-projects/blog/config.js
@@ -1,0 +1,5 @@
+const path = require('path');
+
+exports.port = process.env.PORT || 3000;
+exports.staticRoute = '/public'; // The URL portion
+exports.staticPath = path.join(process.cwd(), 'public'); // The local path on disk

--- a/demo-projects/blog/index.js
+++ b/demo-projects/blog/index.js
@@ -1,26 +1,11 @@
 //imports for Keystone app core
 const { AdminUI } = require('@keystone-alpha/admin-ui');
 const { Keystone } = require('@keystone-alpha/keystone');
-const {
-  File,
-  Text,
-  Relationship,
-  Select,
-  Password,
-  Checkbox,
-  CalendarDay,
-  DateTime,
-} = require('@keystone-alpha/fields');
-const Wysiwyg = require('@keystone-alpha/fields-wysiwyg-tinymce');
-const { LocalFileAdapter } = require('@keystone-alpha/file-adapters');
 const PasswordAuthStrategy = require('@keystone-alpha/keystone/auth/Password');
 const { MongooseAdapter } = require('@keystone-alpha/adapter-mongoose');
 
-// config
-const path = require('path');
-const staticRoute = '/public'; // The URL portion
-const staticPath = path.join(process.cwd(), 'public'); // The local path on disk
-const getYear = require('date-fns/get_year');
+const { staticRoute, staticPath } = require('./config');
+const { User, Post, PostCategory, Comment } = require('./schema');
 
 const keystone = new Keystone({
   name: 'Keystone Demo Blog',
@@ -32,84 +17,10 @@ const authStrategy = keystone.createAuthStrategy({
   list: 'User',
 });
 
-const fileAdapter = new LocalFileAdapter({
-  directory: `${staticPath}/uploads`,
-  route: `${staticRoute}/uploads`,
-});
-
-const avatarFileAdapter = new LocalFileAdapter({
-  directory: `${staticPath}/avatars`,
-  route: `${staticRoute}/avatars`,
-});
-
-keystone.createList('User', {
-  fields: {
-    name: { type: Text },
-    email: { type: Text, isUnique: true },
-    dob: {
-      type: CalendarDay,
-      format: 'Do MMMM YYYY',
-      yearRangeFrom: 1901,
-      yearRangeTo: getYear(new Date()),
-    },
-    password: { type: Password },
-    isAdmin: { type: Checkbox },
-    avatar: { type: File, adapter: avatarFileAdapter },
-  },
-  labelResolver: item => `${item.name} <${item.email}>`,
-});
-
-keystone.createList('Post', {
-  fields: {
-    title: { type: Text },
-    author: {
-      type: Relationship,
-      ref: 'User',
-    },
-    categories: {
-      type: Relationship,
-      ref: 'PostCategory',
-      many: true,
-    },
-    status: {
-      type: Select,
-      defaultValue: 'draft',
-      options: [{ label: 'Draft', value: 'draft' }, { label: 'Published', value: 'published' }],
-    },
-    body: { type: Wysiwyg },
-    posted: { type: DateTime },
-    image: { type: File, adapter: fileAdapter },
-  },
-  adminConfig: {
-    defaultPageSize: 20,
-    defaultColumns: 'title, status',
-    defaultSort: 'title',
-  },
-  labelResolver: item => item.title,
-});
-
-keystone.createList('PostCategory', {
-  fields: {
-    name: { type: Text },
-    slug: { type: Text },
-  },
-});
-
-keystone.createList('Comment', {
-  fields: {
-    body: { type: Text, isMultiline: true },
-    originalPost: {
-      type: Relationship,
-      ref: 'Post',
-    },
-    author: {
-      type: Relationship,
-      ref: 'User',
-    },
-    posted: { type: DateTime },
-  },
-  labelResolver: item => item.body,
-});
+keystone.createList('User', User);
+keystone.createList('Post', Post);
+keystone.createList('PostCategory', PostCategory);
+keystone.createList('Comment', Comment);
 
 const admin = new AdminUI(keystone, {
   adminPath: '/admin',
@@ -120,14 +31,11 @@ const admin = new AdminUI(keystone, {
       children: [
         { listKey: 'Post' },
         { label: 'Categories', listKey: 'PostCategory' },
-        {
-          label: 'Nested',
-          children: [{ label: 'Comments', listKey: 'Comment' }],
-        },
+        { listKey: 'Comment' },
       ],
     },
     {
-      label: 'Other',
+      label: 'People',
       children: ['User'],
     },
   ],

--- a/demo-projects/blog/initialData.js
+++ b/demo-projects/blog/initialData.js
@@ -1,0 +1,18 @@
+module.exports = {
+  User: [
+    {
+      name: 'Admin User',
+      email: 'admin@keystonejs.com',
+      isAdmin: true,
+      dob: '1990-01-01',
+      password: 'password',
+    },
+    {
+      name: 'Demo User',
+      email: 'user@keystonejs.com',
+      isAdmin: false,
+      dob: '1995-06-09',
+      password: 'password',
+    },
+  ],
+};

--- a/demo-projects/blog/schema.js
+++ b/demo-projects/blog/schema.js
@@ -1,0 +1,94 @@
+const {
+  File,
+  Text,
+  Relationship,
+  Select,
+  Password,
+  Checkbox,
+  CalendarDay,
+  DateTime,
+} = require('@keystone-alpha/fields');
+const Wysiwyg = require('@keystone-alpha/fields-wysiwyg-tinymce');
+const { LocalFileAdapter } = require('@keystone-alpha/file-adapters');
+const getYear = require('date-fns/get_year');
+
+const { staticRoute, staticPath } = require('./config');
+
+const fileAdapter = new LocalFileAdapter({
+  directory: `${staticPath}/uploads`,
+  route: `${staticRoute}/uploads`,
+});
+
+const avatarFileAdapter = new LocalFileAdapter({
+  directory: `${staticPath}/avatars`,
+  route: `${staticRoute}/avatars`,
+});
+
+exports.User = {
+  fields: {
+    name: { type: Text },
+    email: { type: Text, isUnique: true },
+    dob: {
+      type: CalendarDay,
+      format: 'Do MMMM YYYY',
+      yearRangeFrom: 1901,
+      yearRangeTo: getYear(new Date()),
+    },
+    password: { type: Password },
+    isAdmin: { type: Checkbox },
+    avatar: { type: File, adapter: avatarFileAdapter },
+  },
+  labelResolver: item => `${item.name} <${item.email}>`,
+};
+
+exports.Post = {
+  fields: {
+    title: { type: Text },
+    author: {
+      type: Relationship,
+      ref: 'User',
+    },
+    categories: {
+      type: Relationship,
+      ref: 'PostCategory',
+      many: true,
+    },
+    status: {
+      type: Select,
+      defaultValue: 'draft',
+      options: [{ label: 'Draft', value: 'draft' }, { label: 'Published', value: 'published' }],
+    },
+    body: { type: Wysiwyg },
+    posted: { type: DateTime },
+    image: { type: File, adapter: fileAdapter },
+  },
+  adminConfig: {
+    defaultPageSize: 20,
+    defaultColumns: 'title, status',
+    defaultSort: 'title',
+  },
+  labelResolver: item => item.title,
+};
+
+exports.PostCategory = {
+  fields: {
+    name: { type: Text },
+    slug: { type: Text },
+  },
+};
+
+exports.Comment = {
+  fields: {
+    body: { type: Text, isMultiline: true },
+    originalPost: {
+      type: Relationship,
+      ref: 'Post',
+    },
+    author: {
+      type: Relationship,
+      ref: 'User',
+    },
+    posted: { type: DateTime },
+  },
+  labelResolver: item => item.body,
+};

--- a/demo-projects/blog/server.js
+++ b/demo-projects/blog/server.js
@@ -2,28 +2,8 @@ const keystone = require('@keystone-alpha/core');
 const WysiwygField = require('@keystone-alpha/fields-wysiwyg-tinymce');
 const next = require('next');
 
-const { staticRoute, staticPath } = require('./index');
-
-const PORT = process.env.PORT || 3000;
-
-const initialData = {
-  User: [
-    {
-      name: 'Administrator',
-      email: 'admin@keystone.project',
-      isAdmin: true,
-      dob: '1990-01-01',
-      password: 'password',
-    },
-    {
-      name: 'Demo User',
-      email: 'a@demo.user',
-      isAdmin: false,
-      dob: '1995-06-09',
-      password: 'password',
-    },
-  ],
-};
+const { port, staticRoute, staticPath } = require('./config');
+const initialData = require('./initialData');
 
 const nextApp = next({
   dir: 'app',
@@ -31,7 +11,7 @@ const nextApp = next({
   dev: process.env.NODE_ENV !== 'production',
 });
 
-Promise.all([keystone.prepare({ port: PORT }), nextApp.prepare()])
+Promise.all([keystone.prepare({ port }), nextApp.prepare()])
   .then(async ([{ server, keystone: keystoneApp }]) => {
     WysiwygField.bindStaticMiddleware(server);
     server.app.use(staticRoute, server.express.static(staticPath));


### PR DESCRIPTION
I've brought forward some parts of #874 that work now and that I think make the code setting up the blog project clearer.

Hopefully uncontroversial, only thing I'm not totally sold on is the duplication of exporting lists and creating them:

```
const { User, Post, PostCategory, Comment } = require('./schema');

keystone.createList('User', User);
keystone.createList('Post', Post);
keystone.createList('PostCategory', PostCategory);
keystone.createList('Comment', Comment);
```

... it's a bit of repetition, but I think it's ok to be this explicit about all the configuration of keystone in the `index.js` file rather than having a "initLists" function exported from `schema.js`.