### PR TITLE
Update test-utils to not use WebServer

### DIFF
--- a/.changeset/9c52aed6/changes.json
+++ b/.changeset/9c52aed6/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/server", "type": "minor" }], "dependents": [] }

--- a/.changeset/9c52aed6/changes.md
+++ b/.changeset/9c52aed6/changes.md
@@ -1,0 +1,1 @@
+- Expose `createApolloServer` in the public API

--- a/.changeset/a029a331/changes.json
+++ b/.changeset/a029a331/changes.json
@@ -1,0 +1,7 @@
+{
+  "releases": [
+    { "name": "@keystone-alpha/fields", "type": "patch" },
+    { "name": "@keystone-alpha/api-tests", "type": "patch" }
+  ],
+  "dependents": []
+}

--- a/.changeset/a029a331/changes.md
+++ b/.changeset/a029a331/changes.md
@@ -1,0 +1,1 @@
+- Use updated test-utils APIs

--- a/.changeset/db8c1db8/changes.json
+++ b/.changeset/db8c1db8/changes.json
@@ -1,0 +1,15 @@
+{
+  "releases": [{ "name": "@keystone-alpha/test-utils", "type": "major" }],
+  "dependents": [
+    {
+      "name": "@keystone-alpha/fields",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/test-utils"]
+    },
+    {
+      "name": "@keystone-alpha/api-tests",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields", "@keystone-alpha/test-utils"]
+    }
+  ]
+}

--- a/.changeset/db8c1db8/changes.md
+++ b/.changeset/db8c1db8/changes.md
@@ -1,0 +1,3 @@
+- Remove `runQuery` from API.
+- `matchFilter` takes `keystone` as the first parameter, rather than `server`.
+- `graphqlRequest` takes a `keystone` parameter, and no longer takes `server`.

--- a/api-tests/DateTime.test.js
+++ b/api-tests/DateTime.test.js
@@ -102,7 +102,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const postedAt = '2018-08-31T06:49:07.000Z';
 
           // Create an item that does the linking
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -113,6 +113,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     `,
           });
 
+          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('createPost.postedAt', postedAt);
         })
       );

--- a/api-tests/DateTime.test.js
+++ b/api-tests/DateTime.test.js
@@ -21,14 +21,12 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     describe('DateTime type', () => {
       test(
         'is present in the schema',
-        runner(setupKeystone, async ({ server: { server } }) => {
+        runner(setupKeystone, async ({ keystone }) => {
           // Introspection query
           const {
-            body: {
-              data: { __schema },
-            },
+            data: { __schema },
           } = await graphqlRequest({
-            server,
+            keystone,
             query: `
         query {
           __schema {
@@ -77,14 +75,14 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
       test(
         'response is serialized as a String',
-        runner(setupKeystone, async ({ server: { server }, create }) => {
+        runner(setupKeystone, async ({ keystone, create }) => {
           const postedAt = '2018-08-31T06:49:07.000Z';
 
           const createPost = await create('Post', { postedAt });
 
           // Create an item that does the linking
-          const { body } = await graphqlRequest({
-            server,
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
         query {
           Post(where: { id: "${createPost.id}" }) {
@@ -94,18 +92,18 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     `,
           });
 
-          expect(body).toHaveProperty('data.Post.postedAt', postedAt);
+          expect(data).toHaveProperty('Post.postedAt', postedAt);
         })
       );
 
       test(
         'input type is accepted as a String',
-        runner(setupKeystone, async ({ server: { server } }) => {
+        runner(setupKeystone, async ({ keystone }) => {
           const postedAt = '2018-08-31T06:49:07.000Z';
 
           // Create an item that does the linking
-          const { body } = await graphqlRequest({
-            server,
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
         mutation {
           createPost(data: { postedAt: "${postedAt}" }) {
@@ -115,22 +113,21 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     `,
           });
 
-          expect(body).not.toHaveProperty('errors');
-          expect(body).toHaveProperty('data.createPost.postedAt', postedAt);
+          expect(data).toHaveProperty('createPost.postedAt', postedAt);
         })
       );
 
       test(
         'correctly overrides with new value',
-        runner(setupKeystone, async ({ server: { server }, create }) => {
+        runner(setupKeystone, async ({ keystone, create }) => {
           const postedAt = '2018-08-31T06:49:07.000Z';
           const updatedPostedAt = '2018-12-07T05:54:00.556Z';
 
           const createPost = await create('Post', { postedAt });
 
           // Create an item that does the linking
-          const { body } = await graphqlRequest({
-            server,
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
         mutation {
           updatePost(id: "${createPost.id}", data: { postedAt: "${updatedPostedAt}" }) {
@@ -140,20 +137,20 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     `,
           });
 
-          expect(body).toHaveProperty('data.updatePost.postedAt', updatedPostedAt);
+          expect(data).toHaveProperty('updatePost.postedAt', updatedPostedAt);
         })
       );
 
       test(
         'allows replacing date with null',
-        runner(setupKeystone, async ({ server: { server }, create }) => {
+        runner(setupKeystone, async ({ keystone, create }) => {
           const postedAt = '2018-08-31T06:49:07.000Z';
 
           const createPost = await create('Post', { postedAt });
 
           // Create an item that does the linking
-          const { body } = await graphqlRequest({
-            server,
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
         mutation {
           updatePost(id: "${createPost.id}", data: { postedAt: null }) {
@@ -163,16 +160,16 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     `,
           });
 
-          expect(body).toHaveProperty('data.updatePost.postedAt', null);
+          expect(data).toHaveProperty('updatePost.postedAt', null);
         })
       );
 
       test(
         'allows initialising to null',
-        runner(setupKeystone, async ({ server: { server } }) => {
+        runner(setupKeystone, async ({ keystone }) => {
           // Create an item that does the linking
-          const { body } = await graphqlRequest({
-            server,
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
         mutation {
           createPost(data: { postedAt: null }) {
@@ -182,21 +179,21 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     `,
           });
 
-          expect(body).toHaveProperty('data.createPost.postedAt', null);
+          expect(data).toHaveProperty('createPost.postedAt', null);
         })
       );
 
       test(
         'Does not get clobbered when updating unrelated field',
-        runner(setupKeystone, async ({ server: { server }, create }) => {
+        runner(setupKeystone, async ({ keystone, create }) => {
           const postedAt = '2018-08-31T06:49:07.000Z';
           const title = 'Hello world';
 
           const createPost = await create('Post', { postedAt, title });
 
           // Create an item that does the linking
-          const { body } = await graphqlRequest({
-            server,
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
         mutation {
           updatePost(id: "${createPost.id}", data: { title: "Something else" }) {
@@ -206,7 +203,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     `,
           });
 
-          expect(body).toHaveProperty('data.updatePost.postedAt', postedAt);
+          expect(data).toHaveProperty('updatePost.postedAt', postedAt);
         })
       );
     });

--- a/api-tests/auth-header.test.js
+++ b/api-tests/auth-header.test.js
@@ -104,9 +104,9 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     describe('Auth testing', () => {
       test(
         'Gives access denied when not logged in',
-        runner(setupKeystone, async ({ server: { server } }) => {
+        runner(setupKeystone, async ({ keystone, server }) => {
           // seed the db
-          await server.keystone.createItems(initialData);
+          await keystone.createItems(initialData);
           return supertest(server.app)
             .set('Accept', 'application/json')
             .post('/admin/api', { query: '{ allUsers { id } }' })
@@ -122,8 +122,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       describe('logged in', () => {
         test(
           'Allows access with bearer token',
-          runner(setupKeystone, async ({ server: { server } }) => {
-            await server.keystone.createItems(initialData);
+          runner(setupKeystone, async ({ keystone, server }) => {
+            await keystone.createItems(initialData);
             const { success, token } = await login(
               server,
               initialData.User[0].email,
@@ -149,8 +149,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
         test(
           'Allows access with cookie',
-          runner(setupKeystone, async ({ server: { server } }) => {
-            await server.keystone.createItems(initialData);
+          runner(setupKeystone, async ({ keystone, server }) => {
+            await keystone.createItems(initialData);
             const { success, token } = await login(
               server,
               initialData.User[0].email,

--- a/api-tests/fields.test.js
+++ b/api-tests/fields.test.js
@@ -32,11 +32,11 @@ describe('Test CRUD for all fields', () => {
                 };
                 return setupServer({ name, adapterName, createLists });
               },
-              async ({ server, ...rest }) => {
+              async ({ keystone, ...rest }) => {
                 // Populate the database before running the tests
-                await server.keystone.createItems({ [listName]: mod.initItems() });
+                await keystone.createItems({ [listName]: mod.initItems() });
 
-                return testFn({ server, adapterName, ...rest });
+                return testFn({ keystone, adapterName, ...rest });
               }
             );
 

--- a/api-tests/queries-access-control/meta.test.js
+++ b/api-tests/queries-access-control/meta.test.js
@@ -40,7 +40,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         `'access' field returns results`,
         runner(setupKeystone, async ({ keystone }) => {
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
           query {
@@ -56,6 +56,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
+          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('_CompaniesMeta.access');
           expect(data._CompaniesMeta.access).toMatchObject({
             create: true,
@@ -69,7 +70,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         `'schema' field returns results`,
         runner(setupKeystone, async ({ keystone }) => {
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
           query {
@@ -87,6 +88,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
+          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('_CompaniesMeta.schema');
           expect(data._CompaniesMeta.schema).toMatchObject({
             type: 'Company',
@@ -107,7 +109,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         `'access' field returns results`,
         runner(setupKeystone, async ({ keystone }) => {
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
           query {
@@ -124,6 +126,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
+          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('_ksListsMeta');
           expect(data._ksListsMeta).toMatchObject([
             {
@@ -151,7 +154,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         'returns results for all visible lists',
         runner(setupKeystone, async ({ keystone }) => {
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
           query {
@@ -170,6 +173,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
+          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('_ksListsMeta');
           expect(data._ksListsMeta).toMatchObject([
             {

--- a/api-tests/queries-access-control/meta.test.js
+++ b/api-tests/queries-access-control/meta.test.js
@@ -39,9 +39,9 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     describe('_FooMeta query for individual list meta data', () => {
       test(
         `'access' field returns results`,
-        runner(setupKeystone, async ({ server: { server } }) => {
-          const query = await graphqlRequest({
-            server,
+        runner(setupKeystone, async ({ keystone }) => {
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
           query {
             _CompaniesMeta {
@@ -56,9 +56,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(query.body).not.toHaveProperty('errors');
-          expect(query.body).toHaveProperty('data._CompaniesMeta.access');
-          expect(query.body.data._CompaniesMeta.access).toMatchObject({
+          expect(data).toHaveProperty('_CompaniesMeta.access');
+          expect(data._CompaniesMeta.access).toMatchObject({
             create: true,
             read: true,
             update: true,
@@ -69,9 +68,9 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
       test(
         `'schema' field returns results`,
-        runner(setupKeystone, async ({ server: { server } }) => {
-          const query = await graphqlRequest({
-            server,
+        runner(setupKeystone, async ({ keystone }) => {
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
           query {
             _CompaniesMeta {
@@ -88,9 +87,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(query.body).not.toHaveProperty('errors');
-          expect(query.body).toHaveProperty('data._CompaniesMeta.schema');
-          expect(query.body.data._CompaniesMeta.schema).toMatchObject({
+          expect(data).toHaveProperty('_CompaniesMeta.schema');
+          expect(data._CompaniesMeta.schema).toMatchObject({
             type: 'Company',
             queries: ['Company', 'allCompanies', '_allCompaniesMeta'],
             relatedFields: [
@@ -108,9 +106,9 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     describe('_ksListsMeta query for all lists meta data', () => {
       test(
         `'access' field returns results`,
-        runner(setupKeystone, async ({ server: { server } }) => {
-          const query = await graphqlRequest({
-            server,
+        runner(setupKeystone, async ({ keystone }) => {
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
           query {
             _ksListsMeta {
@@ -126,9 +124,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(query.body).not.toHaveProperty('errors');
-          expect(query.body).toHaveProperty('data._ksListsMeta');
-          expect(query.body.data._ksListsMeta).toMatchObject([
+          expect(data).toHaveProperty('_ksListsMeta');
+          expect(data._ksListsMeta).toMatchObject([
             {
               name: 'User',
               access: {
@@ -153,9 +150,9 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
       test(
         'returns results for all visible lists',
-        runner(setupKeystone, async ({ server: { server } }) => {
-          const query = await graphqlRequest({
-            server,
+        runner(setupKeystone, async ({ keystone }) => {
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
           query {
             _ksListsMeta {
@@ -173,9 +170,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(query.body).not.toHaveProperty('errors');
-          expect(query.body).toHaveProperty('data._ksListsMeta');
-          expect(query.body.data._ksListsMeta).toMatchObject([
+          expect(data).toHaveProperty('_ksListsMeta');
+          expect(data._ksListsMeta).toMatchObject([
             {
               name: 'User',
               schema: {

--- a/api-tests/queries/meta.test.js
+++ b/api-tests/queries/meta.test.js
@@ -36,7 +36,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         `'schema' field returns results`,
         runner(setupKeystone, async ({ keystone }) => {
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
           query {
@@ -54,6 +54,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
+          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('_CompaniesMeta.schema');
           expect(data._CompaniesMeta.schema).toMatchObject({
             type: 'Company',
@@ -71,7 +72,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         `'schema.relatedFields' returns empty array when none exist`,
         runner(setupKeystone, async ({ keystone }) => {
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
           query {
@@ -89,6 +90,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
+          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('_PostsMeta.schema');
           expect(data._PostsMeta.schema).toMatchObject({
             type: 'Post',
@@ -103,7 +105,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         'returns results for all lists',
         runner(setupKeystone, async ({ keystone }) => {
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
           query {
@@ -122,6 +124,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
+          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('_ksListsMeta');
           expect(data._ksListsMeta).toMatchObject([
             {

--- a/api-tests/queries/meta.test.js
+++ b/api-tests/queries/meta.test.js
@@ -35,9 +35,9 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     describe('_FooMeta query for individual list meta data', () => {
       test(
         `'schema' field returns results`,
-        runner(setupKeystone, async ({ server: { server } }) => {
-          const query = await graphqlRequest({
-            server,
+        runner(setupKeystone, async ({ keystone }) => {
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
           query {
             _CompaniesMeta {
@@ -54,9 +54,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(query.body).not.toHaveProperty('errors');
-          expect(query.body).toHaveProperty('data._CompaniesMeta.schema');
-          expect(query.body.data._CompaniesMeta.schema).toMatchObject({
+          expect(data).toHaveProperty('_CompaniesMeta.schema');
+          expect(data._CompaniesMeta.schema).toMatchObject({
             type: 'Company',
             queries: ['Company', 'allCompanies', '_allCompaniesMeta'],
             relatedFields: [
@@ -71,9 +70,9 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
       test(
         `'schema.relatedFields' returns empty array when none exist`,
-        runner(setupKeystone, async ({ server: { server } }) => {
-          const query = await graphqlRequest({
-            server,
+        runner(setupKeystone, async ({ keystone }) => {
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
           query {
             _PostsMeta {
@@ -90,9 +89,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(query.body).not.toHaveProperty('errors');
-          expect(query.body).toHaveProperty('data._PostsMeta.schema');
-          expect(query.body.data._PostsMeta.schema).toMatchObject({
+          expect(data).toHaveProperty('_PostsMeta.schema');
+          expect(data._PostsMeta.schema).toMatchObject({
             type: 'Post',
             queries: ['Post', 'allPosts', '_allPostsMeta'],
             relatedFields: [],
@@ -104,9 +102,9 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     describe('_ksListsMeta query for all lists meta data', () => {
       test(
         'returns results for all lists',
-        runner(setupKeystone, async ({ server: { server } }) => {
-          const query = await graphqlRequest({
-            server,
+        runner(setupKeystone, async ({ keystone }) => {
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
           query {
             _ksListsMeta {
@@ -124,9 +122,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(query.body).not.toHaveProperty('errors');
-          expect(query.body).toHaveProperty('data._ksListsMeta');
-          expect(query.body.data._ksListsMeta).toMatchObject([
+          expect(data).toHaveProperty('_ksListsMeta');
+          expect(data._ksListsMeta).toMatchObject([
             {
               name: 'User',
               schema: {

--- a/api-tests/queries/relationships.test.js
+++ b/api-tests/queries/relationships.test.js
@@ -33,7 +33,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       describe('to-single', () => {
         test(
           'with data',
-          runner(setupKeystone, async ({ server: { server }, create }) => {
+          runner(setupKeystone, async ({ keystone, create }) => {
             // Create an item to link against
             const users = await Promise.all([
               create('User', { name: 'Jess' }),
@@ -49,8 +49,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             ]);
 
             // Create an item that does the linking
-            const queryAllPosts = await graphqlRequest({
-              server,
+            const { data } = await graphqlRequest({
+              keystone,
               query: `
           query {
             allPosts(where: {
@@ -63,11 +63,10 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
             });
 
-            expect(queryAllPosts.body).not.toHaveProperty('errors');
-            expect(queryAllPosts.body.data).toHaveProperty('allPosts');
-            expect(queryAllPosts.body.data.allPosts).toHaveLength(3);
+            expect(data).toHaveProperty('allPosts');
+            expect(data.allPosts).toHaveLength(3);
 
-            const allPosts = queryAllPosts.body.data.allPosts;
+            const { allPosts } = data;
 
             // We don't know the order, so we have to check individually
             expect(allPosts).toContainEqual({ id: posts[0].id, title: posts[0].title });
@@ -78,7 +77,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
         test(
           'without data',
-          runner(setupKeystone, async ({ server: { server }, create }) => {
+          runner(setupKeystone, async ({ keystone, create }) => {
             // Create an item to link against
             const user = await create('User', { name: 'Jess' });
 
@@ -88,8 +87,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             ]);
 
             // Create an item that does the linking
-            const queryAllPosts = await graphqlRequest({
-              server,
+            const { data } = await graphqlRequest({
+              keystone,
               query: `
           query {
             allPosts(where: {
@@ -106,10 +105,9 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
             });
 
-            expect(queryAllPosts.body.data).toMatchObject({
+            expect(data).toMatchObject({
               allPosts: [{ id: posts[0].id, title: posts[0].title }],
             });
-            expect(queryAllPosts.body).not.toHaveProperty('errors');
           })
         );
       });
@@ -137,12 +135,12 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
         test(
           '_every condition',
-          runner(setupKeystone, async ({ server: { server }, create }) => {
+          runner(setupKeystone, async ({ keystone, create }) => {
             const { users } = await setup(create);
 
             // EVERY
-            const queryFeedEvery = await graphqlRequest({
-              server,
+            const { data } = await graphqlRequest({
+              keystone,
               query: `
           query {
             allUsers(where: {
@@ -159,21 +157,20 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
             });
 
-            expect(queryFeedEvery.body.data).toMatchObject({
+            expect(data).toMatchObject({
               allUsers: [{ id: users[2].id, feed: [{ title: 'I like Jelly' }] }],
             });
-            expect(queryFeedEvery.body).not.toHaveProperty('errors');
           })
         );
 
         test(
           '_some condition',
-          runner(setupKeystone, async ({ server: { server }, create }) => {
+          runner(setupKeystone, async ({ keystone, create }) => {
             const { users } = await setup(create);
 
             // SOME
-            const queryFeedSome = await graphqlRequest({
-              server,
+            const { data } = await graphqlRequest({
+              keystone,
               query: `
           query {
             allUsers(where: {
@@ -188,11 +185,10 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
             });
 
-            expect(queryFeedSome.body).not.toHaveProperty('errors');
-            expect(queryFeedSome.body.data).toHaveProperty('allUsers');
-            expect(queryFeedSome.body.data.allUsers).toHaveLength(2);
+            expect(data).toHaveProperty('allUsers');
+            expect(data.allUsers).toHaveLength(2);
 
-            const allUsers = queryFeedSome.body.data.allUsers;
+            const { allUsers } = data;
 
             // We don't know the order, so we have to check individually
             expect(allUsers).toContainEqual({
@@ -205,12 +201,12 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
         test(
           '_none condition',
-          runner(setupKeystone, async ({ server: { server }, create }) => {
+          runner(setupKeystone, async ({ keystone, create }) => {
             const { users } = await setup(create);
 
             // NONE
-            const queryFeedNone = await graphqlRequest({
-              server,
+            const { data } = await graphqlRequest({
+              keystone,
               query: `
           query {
             allUsers(where: {
@@ -227,10 +223,9 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
             });
 
-            expect(queryFeedNone.body.data).toMatchObject({
+            expect(data).toMatchObject({
               allUsers: [{ id: users[1].id, feed: [{ title: 'Bye' }] }],
             });
-            expect(queryFeedNone.body).not.toHaveProperty('errors');
           })
         );
       });
@@ -256,12 +251,12 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
         test(
           '_every condition',
-          runner(setupKeystone, async ({ server: { server }, create }) => {
+          runner(setupKeystone, async ({ keystone, create }) => {
             const { users } = await setup(create);
 
             // EVERY
-            const queryFeedEvery = await graphqlRequest({
-              server,
+            const { data } = await graphqlRequest({
+              keystone,
               query: `
           query {
             allUsers(where: {
@@ -278,21 +273,18 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
             });
 
-            expect(queryFeedEvery.body.data).toMatchObject({
-              allUsers: [{ id: users[2].id, feed: [] }],
-            });
-            expect(queryFeedEvery.body).not.toHaveProperty('errors');
+            expect(data).toMatchObject({ allUsers: [{ id: users[2].id, feed: [] }] });
           })
         );
 
         test(
           '_some condition',
-          runner(setupKeystone, async ({ server: { server }, create }) => {
+          runner(setupKeystone, async ({ keystone, create }) => {
             const { users } = await setup(create);
 
             // SOME
-            const queryFeedSome = await graphqlRequest({
-              server,
+            const { data } = await graphqlRequest({
+              keystone,
               query: `
           query {
             allUsers(where: {
@@ -309,24 +301,23 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
             });
 
-            expect(queryFeedSome.body.data).toMatchObject({
+            expect(data).toMatchObject({
               allUsers: [
                 { id: users[0].id, feed: [{ title: 'Hello' }, { title: 'I like Jelly' }] },
               ],
             });
-            expect(queryFeedSome.body.data.allUsers).toHaveLength(1);
-            expect(queryFeedSome.body).not.toHaveProperty('errors');
+            expect(data.allUsers).toHaveLength(1);
           })
         );
 
         test(
           '_none condition',
-          runner(setupKeystone, async ({ server: { server }, create }) => {
+          runner(setupKeystone, async ({ keystone, create }) => {
             const { users } = await setup(create);
 
             // NONE
-            const queryFeedNone = await graphqlRequest({
-              server,
+            const { data } = await graphqlRequest({
+              keystone,
               query: `
           query {
             allUsers(where: {
@@ -341,11 +332,10 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
             });
 
-            expect(queryFeedNone.body).not.toHaveProperty('errors');
-            expect(queryFeedNone.body.data).toHaveProperty('allUsers');
-            expect(queryFeedNone.body.data.allUsers).toHaveLength(2);
+            expect(data).toHaveProperty('allUsers');
+            expect(data.allUsers).toHaveLength(2);
 
-            const allUsers = queryFeedNone.body.data.allUsers;
+            const { allUsers } = data;
 
             // We don't know the order, so we have to check individually
             expect(allUsers).toContainEqual({ id: users[1].id, feed: [{ title: 'Hello' }] });

--- a/api-tests/queries/relationships.test.js
+++ b/api-tests/queries/relationships.test.js
@@ -49,7 +49,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             ]);
 
             // Create an item that does the linking
-            const { data } = await graphqlRequest({
+            const { data, errors } = await graphqlRequest({
               keystone,
               query: `
           query {
@@ -63,6 +63,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
             });
 
+            expect(errors).toBe(undefined);
             expect(data).toHaveProperty('allPosts');
             expect(data.allPosts).toHaveLength(3);
 
@@ -87,7 +88,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             ]);
 
             // Create an item that does the linking
-            const { data } = await graphqlRequest({
+            const { data, errors } = await graphqlRequest({
               keystone,
               query: `
           query {
@@ -108,6 +109,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(data).toMatchObject({
               allPosts: [{ id: posts[0].id, title: posts[0].title }],
             });
+            expect(errors).toBe(undefined);
           })
         );
       });
@@ -139,7 +141,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { users } = await setup(create);
 
             // EVERY
-            const { data } = await graphqlRequest({
+            const { data, errors } = await graphqlRequest({
               keystone,
               query: `
           query {
@@ -160,6 +162,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(data).toMatchObject({
               allUsers: [{ id: users[2].id, feed: [{ title: 'I like Jelly' }] }],
             });
+            expect(errors).toBe(undefined);
           })
         );
 
@@ -169,7 +172,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { users } = await setup(create);
 
             // SOME
-            const { data } = await graphqlRequest({
+            const { data, errors } = await graphqlRequest({
               keystone,
               query: `
           query {
@@ -185,6 +188,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
             });
 
+            expect(errors).toBe(undefined);
             expect(data).toHaveProperty('allUsers');
             expect(data.allUsers).toHaveLength(2);
 
@@ -205,7 +209,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { users } = await setup(create);
 
             // NONE
-            const { data } = await graphqlRequest({
+            const { data, errors } = await graphqlRequest({
               keystone,
               query: `
           query {
@@ -226,6 +230,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(data).toMatchObject({
               allUsers: [{ id: users[1].id, feed: [{ title: 'Bye' }] }],
             });
+            expect(errors).toBe(undefined);
           })
         );
       });
@@ -255,7 +260,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { users } = await setup(create);
 
             // EVERY
-            const { data } = await graphqlRequest({
+            const { data, errors } = await graphqlRequest({
               keystone,
               query: `
           query {
@@ -274,6 +279,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             });
 
             expect(data).toMatchObject({ allUsers: [{ id: users[2].id, feed: [] }] });
+            expect(errors).toBe(undefined);
           })
         );
 
@@ -283,7 +289,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { users } = await setup(create);
 
             // SOME
-            const { data } = await graphqlRequest({
+            const { data, errors } = await graphqlRequest({
               keystone,
               query: `
           query {
@@ -307,6 +313,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               ],
             });
             expect(data.allUsers).toHaveLength(1);
+            expect(errors).toBe(undefined);
           })
         );
 
@@ -316,7 +323,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { users } = await setup(create);
 
             // NONE
-            const { data } = await graphqlRequest({
+            const { data, errors } = await graphqlRequest({
               keystone,
               query: `
           query {
@@ -332,6 +339,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
             });
 
+            expect(errors).toBe(undefined);
             expect(data).toHaveProperty('allUsers');
             expect(data.allUsers).toHaveLength(2);
 

--- a/api-tests/relationships/filtering/access-control.test.js
+++ b/api-tests/relationships/filtering/access-control.test.js
@@ -55,7 +55,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           // Create an item that does the linking
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         query {
@@ -70,6 +70,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
+          expect(errors).toBe(undefined);
           expect(data).toMatchObject({
             UserToPostLimitedRead: {
               id: expect.any(String),
@@ -100,7 +101,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           // Create an item that does the linking
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         query {
@@ -117,6 +118,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
+          expect(errors).toBe(undefined);
           expect(data).toMatchObject({
             UserToPostLimitedRead: {
               id: expect.any(String),

--- a/api-tests/relationships/filtering/access-control.test.js
+++ b/api-tests/relationships/filtering/access-control.test.js
@@ -37,7 +37,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     describe('relationship filtering with access control', () => {
       test(
         'implicitly filters to only the IDs in the database by default',
-        runner(setupKeystone, async ({ server: { server }, create }) => {
+        runner(setupKeystone, async ({ keystone, create }) => {
           // Create all of the posts with the given IDs & random content
           const posts = await Promise.all(
             postNames.map(name => {
@@ -55,8 +55,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           // Create an item that does the linking
-          const queryUser = await graphqlRequest({
-            server,
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
         query {
           UserToPostLimitedRead(where: { id: "${user.id}" }) {
@@ -70,8 +70,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(queryUser.body).not.toHaveProperty('errors');
-          expect(queryUser.body.data).toMatchObject({
+          expect(data).toMatchObject({
             UserToPostLimitedRead: {
               id: expect.any(String),
               username,
@@ -83,7 +82,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
       test(
         'explicitly filters when given a `where` clause',
-        runner(setupKeystone, async ({ server: { server }, create }) => {
+        runner(setupKeystone, async ({ keystone, create }) => {
           // Create all of the posts with the given IDs & random content
           const posts = await Promise.all(
             postNames.map(name => {
@@ -101,8 +100,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           // Create an item that does the linking
-          const queryUser = await graphqlRequest({
-            server,
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
         query {
           UserToPostLimitedRead(where: { id: "${user.id}" }) {
@@ -118,8 +117,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(queryUser.body).not.toHaveProperty('errors');
-          expect(queryUser.body.data).toMatchObject({
+          expect(data).toMatchObject({
             UserToPostLimitedRead: {
               id: expect.any(String),
               username,

--- a/api-tests/relationships/filtering/filtering.test.js
+++ b/api-tests/relationships/filtering/filtering.test.js
@@ -40,7 +40,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const user = await create('User', { company: company.id });
           await create('User', { company: otherCompany.id });
 
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         query {
@@ -60,6 +60,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
+          expect(errors).toBe(undefined);
           expect(data.allUsers).toHaveLength(1);
           expect(data).toMatchObject({
             allUsers: [
@@ -84,7 +85,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const user = await create('User', { company: company.id });
           await create('User', { company: otherCompany.id });
 
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
           query {
@@ -104,6 +105,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         `,
           });
 
+          expect(errors).toBe(undefined);
           expect(data.allUsers).toHaveLength(1);
           expect(data).toMatchObject({
             allUsers: [
@@ -133,7 +135,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Create a dummy user to make sure we're actually filtering it out
           await create('User', { posts: [] });
 
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         query {
@@ -153,6 +155,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
+          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('allUsers.0.posts');
           expect(data.allUsers[0].posts).toHaveLength(3);
           expect(data).toMatchObject({
@@ -180,7 +183,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Create a dummy user to make sure we're actually filtering it out
           await create('User', { posts: [] });
 
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
           query {
@@ -200,6 +203,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         `,
           });
 
+          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('allUsers.0.posts');
           expect(data.allUsers[0].posts).toHaveLength(3);
           expect(data).toMatchObject({

--- a/api-tests/relationships/filtering/filtering.test.js
+++ b/api-tests/relationships/filtering/filtering.test.js
@@ -33,15 +33,15 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     describe('relationship filtering', () => {
       test(
         'nested to-single relationships can be filtered within AND clause',
-        runner(setupKeystone, async ({ server: { server }, create }) => {
+        runner(setupKeystone, async ({ keystone, create }) => {
           const company = await create('Company', { name: 'Thinkmill' });
           const otherCompany = await create('Company', { name: 'Cete' });
 
           const user = await create('User', { company: company.id });
           await create('User', { company: otherCompany.id });
 
-          const queryUser = await graphqlRequest({
-            server,
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
         query {
           allUsers(where: {
@@ -60,9 +60,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(queryUser.body).not.toHaveProperty('errors');
-          expect(queryUser.body.data.allUsers).toHaveLength(1);
-          expect(queryUser.body.data).toMatchObject({
+          expect(data.allUsers).toHaveLength(1);
+          expect(data).toMatchObject({
             allUsers: [
               {
                 id: user.id,
@@ -78,15 +77,15 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
       test(
         'nested to-single relationships can be filtered within OR clause',
-        runner(setupKeystone, async ({ server: { server }, create }) => {
+        runner(setupKeystone, async ({ keystone, create }) => {
           const company = await create('Company', { name: 'Thinkmill' });
           const otherCompany = await create('Company', { name: 'Cete' });
 
           const user = await create('User', { company: company.id });
           await create('User', { company: otherCompany.id });
 
-          const queryUser = await graphqlRequest({
-            server,
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
           query {
             allUsers(where: {
@@ -105,9 +104,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         `,
           });
 
-          expect(queryUser.body).not.toHaveProperty('errors');
-          expect(queryUser.body.data.allUsers).toHaveLength(1);
-          expect(queryUser.body.data).toMatchObject({
+          expect(data.allUsers).toHaveLength(1);
+          expect(data).toMatchObject({
             allUsers: [
               {
                 id: user.id,
@@ -123,7 +121,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
       test(
         'nested to-many relationships can be filtered within AND clause',
-        runner(setupKeystone, async ({ server: { server }, create }) => {
+        runner(setupKeystone, async ({ keystone, create }) => {
           const ids = [];
 
           ids.push((await create('Post', { content: 'Hello world' })).id);
@@ -135,8 +133,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Create a dummy user to make sure we're actually filtering it out
           await create('User', { posts: [] });
 
-          const queryUser = await graphqlRequest({
-            server,
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
         query {
           allUsers(where: {
@@ -155,10 +153,9 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(queryUser.body).not.toHaveProperty('errors');
-          expect(queryUser.body.data).toHaveProperty('allUsers.0.posts');
-          expect(queryUser.body.data.allUsers[0].posts).toHaveLength(3);
-          expect(queryUser.body.data).toMatchObject({
+          expect(data).toHaveProperty('allUsers.0.posts');
+          expect(data.allUsers[0].posts).toHaveLength(3);
+          expect(data).toMatchObject({
             allUsers: [
               {
                 id: user.id,
@@ -171,7 +168,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
       test(
         'nested to-many relationships can be filtered within OR clause',
-        runner(setupKeystone, async ({ server: { server }, create }) => {
+        runner(setupKeystone, async ({ keystone, create }) => {
           const ids = [];
 
           ids.push((await create('Post', { content: 'Hello world' })).id);
@@ -183,8 +180,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Create a dummy user to make sure we're actually filtering it out
           await create('User', { posts: [] });
 
-          const queryUser = await graphqlRequest({
-            server,
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
           query {
             allUsers(where: {
@@ -203,10 +200,9 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         `,
           });
 
-          expect(queryUser.body).not.toHaveProperty('errors');
-          expect(queryUser.body.data).toHaveProperty('allUsers.0.posts');
-          expect(queryUser.body.data.allUsers[0].posts).toHaveLength(3);
-          expect(queryUser.body.data).toMatchObject({
+          expect(data).toHaveProperty('allUsers.0.posts');
+          expect(data.allUsers[0].posts).toHaveLength(3);
+          expect(data).toMatchObject({
             allUsers: [
               {
                 id: user.id,

--- a/api-tests/relationships/filtering/nested.test.js
+++ b/api-tests/relationships/filtering/nested.test.js
@@ -33,7 +33,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     describe('relationship filtering', () => {
       test(
         'nested to-many relationships can be filtered',
-        runner(setupKeystone, async ({ server: { server }, create }) => {
+        runner(setupKeystone, async ({ keystone, create }) => {
           const ids = [];
 
           ids.push((await create('Post', { content: 'Hello world' })).id);
@@ -45,8 +45,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Create a dummy user to make sure we're actually filtering it out
           const user2 = await create('User', { posts: [ids[0]] });
 
-          const queryUser = await graphqlRequest({
-            server,
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
         query {
           allUsers {
@@ -62,10 +62,9 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(queryUser.body).not.toHaveProperty('errors');
-          expect(queryUser.body.data).toHaveProperty('allUsers.0.posts');
-          expect(queryUser.body.data.allUsers[0].posts).toHaveLength(2);
-          expect(queryUser.body.data).toMatchObject({
+          expect(data).toHaveProperty('allUsers.0.posts');
+          expect(data.allUsers[0].posts).toHaveLength(2);
+          expect(data).toMatchObject({
             allUsers: [
               {
                 id: user.id,
@@ -82,7 +81,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
       test(
         'nested to-many relationships can be limited',
-        runner(setupKeystone, async ({ server: { server }, create }) => {
+        runner(setupKeystone, async ({ keystone, create }) => {
           const ids = [];
 
           ids.push((await create('Post', { content: 'Hello world' })).id);
@@ -94,8 +93,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Create a dummy user to make sure we're actually filtering it out
           const user2 = await create('User', { posts: [ids[0]] });
 
-          const queryUser = await graphqlRequest({
-            server,
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
         query {
           allUsers {
@@ -109,10 +108,9 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(queryUser.body).not.toHaveProperty('errors');
-          expect(queryUser.body.data).toHaveProperty('allUsers.0.posts');
-          expect(queryUser.body.data.allUsers[0].posts).toHaveLength(1);
-          expect(queryUser.body.data).toMatchObject({
+          expect(data).toHaveProperty('allUsers.0.posts');
+          expect(data.allUsers[0].posts).toHaveLength(1);
+          expect(data).toMatchObject({
             allUsers: [
               {
                 id: user.id,
@@ -129,7 +127,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
       test(
         'nested to-many relationships can be filtered within AND clause',
-        runner(setupKeystone, async ({ server: { server }, create }) => {
+        runner(setupKeystone, async ({ keystone, create }) => {
           const ids = [];
 
           ids.push((await create('Post', { content: 'Hello world' })).id);
@@ -141,8 +139,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Create a dummy user to make sure we're actually filtering it out
           const user2 = await create('User', { posts: [ids[0]] });
 
-          const queryUser = await graphqlRequest({
-            server,
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
         query {
           allUsers {
@@ -161,10 +159,9 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(queryUser.body).not.toHaveProperty('errors');
-          expect(queryUser.body.data).toHaveProperty('allUsers.0.posts');
-          expect(queryUser.body.data.allUsers[0].posts).toHaveLength(1);
-          expect(queryUser.body.data).toMatchObject({
+          expect(data).toHaveProperty('allUsers.0.posts');
+          expect(data.allUsers[0].posts).toHaveLength(1);
+          expect(data).toMatchObject({
             allUsers: [
               {
                 id: user.id,
@@ -181,7 +178,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
       test(
         'nested to-many relationships can be filtered within OR clause',
-        runner(setupKeystone, async ({ server: { server }, create }) => {
+        runner(setupKeystone, async ({ keystone, create }) => {
           const ids = [];
 
           ids.push((await create('Post', { content: 'Hello world' })).id);
@@ -193,8 +190,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Create a dummy user to make sure we're actually filtering it out
           const user2 = await create('User', { posts: [ids[0]] });
 
-          const queryUser = await graphqlRequest({
-            server,
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
         query {
           allUsers {
@@ -213,9 +210,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(queryUser.body).not.toHaveProperty('errors');
-          expect(queryUser.body.data).toHaveProperty('allUsers.0.posts');
-          expect(queryUser.body.data).toMatchObject({
+          expect(data).toHaveProperty('allUsers.0.posts');
+          expect(data).toMatchObject({
             allUsers: [
               {
                 id: user.id,
@@ -232,7 +228,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
           // `expect.arrayContaining()` doesn't fail if there are _more_ results
           // than expected
-          expect(queryUser.body.data.allUsers[0].posts).toHaveLength(2);
+          expect(data.allUsers[0].posts).toHaveLength(2);
         })
       );
     });
@@ -240,7 +236,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     describe('relationship meta filtering', () => {
       test(
         'nested to-many relationships return meta info',
-        runner(setupKeystone, async ({ server: { server }, create }) => {
+        runner(setupKeystone, async ({ keystone, create }) => {
           const ids = [];
 
           ids.push((await create('Post', { content: 'Hello world' })).id);
@@ -252,8 +248,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Create a dummy user to make sure we're actually filtering it out
           const user2 = await create('User', { posts: [ids[0]] });
 
-          const queryUser = await graphqlRequest({
-            server,
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
         query {
           allUsers {
@@ -266,10 +262,9 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(queryUser.body).not.toHaveProperty('errors');
-          expect(queryUser.body.data.allUsers).toHaveLength(2);
-          expect(queryUser.body.data).toHaveProperty('allUsers.0._postsMeta');
-          expect(queryUser.body.data).toMatchObject({
+          expect(data.allUsers).toHaveLength(2);
+          expect(data).toHaveProperty('allUsers.0._postsMeta');
+          expect(data).toMatchObject({
             allUsers: [
               {
                 id: user.id,
@@ -286,7 +281,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
       test(
         'nested to-many relationship meta can be filtered',
-        runner(setupKeystone, async ({ server: { server }, create }) => {
+        runner(setupKeystone, async ({ keystone, create }) => {
           const ids = [];
 
           ids.push((await create('Post', { content: 'Hello world' })).id);
@@ -298,8 +293,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Create a dummy user to make sure we're actually filtering it out
           const user2 = await create('User', { posts: [ids[0]] });
 
-          const queryUser = await graphqlRequest({
-            server,
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
         query {
           allUsers {
@@ -314,10 +309,9 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(queryUser.body).not.toHaveProperty('errors');
-          expect(queryUser.body.data.allUsers).toHaveLength(2);
-          expect(queryUser.body.data).toHaveProperty('allUsers.0._postsMeta');
-          expect(queryUser.body.data).toMatchObject({
+          expect(data.allUsers).toHaveLength(2);
+          expect(data).toHaveProperty('allUsers.0._postsMeta');
+          expect(data).toMatchObject({
             allUsers: [
               {
                 id: user.id,
@@ -334,7 +328,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
       test(
         'nested to-many relationship meta can be limited',
-        runner(setupKeystone, async ({ server: { server }, create }) => {
+        runner(setupKeystone, async ({ keystone, create }) => {
           const ids = [];
 
           ids.push((await create('Post', { content: 'Hello world' })).id);
@@ -346,8 +340,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Create a dummy user to make sure we're actually filtering it out
           const user2 = await create('User', { posts: [ids[0]] });
 
-          const queryUser = await graphqlRequest({
-            server,
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
         query {
           allUsers {
@@ -360,10 +354,9 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(queryUser.body).not.toHaveProperty('errors');
-          expect(queryUser.body.data).toHaveProperty('allUsers.0._postsMeta');
-          expect(queryUser.body.data.allUsers).toHaveLength(2);
-          expect(queryUser.body.data).toMatchObject({
+          expect(data).toHaveProperty('allUsers.0._postsMeta');
+          expect(data.allUsers).toHaveLength(2);
+          expect(data).toMatchObject({
             allUsers: [
               {
                 id: user.id,
@@ -380,7 +373,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
       test(
         'nested to-many relationship meta can be filtered within AND clause',
-        runner(setupKeystone, async ({ server: { server }, create }) => {
+        runner(setupKeystone, async ({ keystone, create }) => {
           const ids = [];
 
           ids.push((await create('Post', { content: 'Hello world' })).id);
@@ -392,8 +385,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Create a dummy user to make sure we're actually filtering it out
           const user2 = await create('User', { posts: [ids[0]] });
 
-          const queryUser = await graphqlRequest({
-            server,
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
         query {
           allUsers {
@@ -411,10 +404,9 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(queryUser.body).not.toHaveProperty('errors');
-          expect(queryUser.body.data.allUsers).toHaveLength(2);
-          expect(queryUser.body.data).toHaveProperty('allUsers.0._postsMeta');
-          expect(queryUser.body.data).toMatchObject({
+          expect(data.allUsers).toHaveLength(2);
+          expect(data).toHaveProperty('allUsers.0._postsMeta');
+          expect(data).toMatchObject({
             allUsers: [
               {
                 id: user.id,
@@ -431,7 +423,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
       test(
         'nested to-many relationship meta can be filtered within OR clause',
-        runner(setupKeystone, async ({ server: { server }, create }) => {
+        runner(setupKeystone, async ({ keystone, create }) => {
           const ids = [];
 
           ids.push((await create('Post', { content: 'Hello world' })).id);
@@ -443,8 +435,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Create a dummy user to make sure we're actually filtering it out
           const user2 = await create('User', { posts: [ids[0]] });
 
-          const queryUser = await graphqlRequest({
-            server,
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
         query {
           allUsers {
@@ -462,10 +454,9 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(queryUser.body).not.toHaveProperty('errors');
-          expect(queryUser.body.data.allUsers).toHaveLength(2);
-          expect(queryUser.body.data).toHaveProperty('allUsers.0._postsMeta');
-          expect(queryUser.body.data).toMatchObject({
+          expect(data.allUsers).toHaveLength(2);
+          expect(data).toHaveProperty('allUsers.0._postsMeta');
+          expect(data).toMatchObject({
             allUsers: [
               {
                 id: user.id,

--- a/api-tests/relationships/filtering/nested.test.js
+++ b/api-tests/relationships/filtering/nested.test.js
@@ -45,7 +45,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Create a dummy user to make sure we're actually filtering it out
           const user2 = await create('User', { posts: [ids[0]] });
 
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         query {
@@ -62,6 +62,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
+          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('allUsers.0.posts');
           expect(data.allUsers[0].posts).toHaveLength(2);
           expect(data).toMatchObject({
@@ -93,7 +94,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Create a dummy user to make sure we're actually filtering it out
           const user2 = await create('User', { posts: [ids[0]] });
 
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         query {
@@ -108,6 +109,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
+          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('allUsers.0.posts');
           expect(data.allUsers[0].posts).toHaveLength(1);
           expect(data).toMatchObject({
@@ -139,7 +141,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Create a dummy user to make sure we're actually filtering it out
           const user2 = await create('User', { posts: [ids[0]] });
 
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         query {
@@ -159,6 +161,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
+          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('allUsers.0.posts');
           expect(data.allUsers[0].posts).toHaveLength(1);
           expect(data).toMatchObject({
@@ -190,7 +193,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Create a dummy user to make sure we're actually filtering it out
           const user2 = await create('User', { posts: [ids[0]] });
 
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         query {
@@ -210,6 +213,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
+          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('allUsers.0.posts');
           expect(data).toMatchObject({
             allUsers: [
@@ -248,7 +252,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Create a dummy user to make sure we're actually filtering it out
           const user2 = await create('User', { posts: [ids[0]] });
 
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         query {
@@ -262,6 +266,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
+          expect(errors).toBe(undefined);
           expect(data.allUsers).toHaveLength(2);
           expect(data).toHaveProperty('allUsers.0._postsMeta');
           expect(data).toMatchObject({
@@ -293,7 +298,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Create a dummy user to make sure we're actually filtering it out
           const user2 = await create('User', { posts: [ids[0]] });
 
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         query {
@@ -309,6 +314,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
+          expect(errors).toBe(undefined);
           expect(data.allUsers).toHaveLength(2);
           expect(data).toHaveProperty('allUsers.0._postsMeta');
           expect(data).toMatchObject({
@@ -340,7 +346,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Create a dummy user to make sure we're actually filtering it out
           const user2 = await create('User', { posts: [ids[0]] });
 
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         query {
@@ -354,6 +360,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
+          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('allUsers.0._postsMeta');
           expect(data.allUsers).toHaveLength(2);
           expect(data).toMatchObject({
@@ -385,7 +392,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Create a dummy user to make sure we're actually filtering it out
           const user2 = await create('User', { posts: [ids[0]] });
 
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         query {
@@ -404,6 +411,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
+          expect(errors).toBe(undefined);
           expect(data.allUsers).toHaveLength(2);
           expect(data).toHaveProperty('allUsers.0._postsMeta');
           expect(data).toMatchObject({
@@ -435,7 +443,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Create a dummy user to make sure we're actually filtering it out
           const user2 = await create('User', { posts: [ids[0]] });
 
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         query {
@@ -454,6 +462,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
+          expect(errors).toBe(undefined);
           expect(data.allUsers).toHaveLength(2);
           expect(data).toHaveProperty('allUsers.0._postsMeta');
           expect(data).toMatchObject({

--- a/api-tests/relationships/nested-mutations/connect-many.test.js
+++ b/api-tests/relationships/nested-mutations/connect-many.test.js
@@ -69,7 +69,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const createNote = await create('Note', { content: noteContent });
 
           // Create an item that does the linking
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -86,6 +86,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           expect(data).toMatchObject({
             createUser: { id: expect.any(String) },
           });
+          expect(errors).toBe(undefined);
 
           // Create an item that does the linking
           const {
@@ -121,7 +122,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const createNote2 = await create('Note', { content: noteContent2 });
 
           // Create an item that does the linking
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -138,6 +139,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           expect(data).toMatchObject({
             createUsers: [{ id: expect.any(String) }, { id: expect.any(String) }],
           });
+          expect(errors).toBe(undefined);
         })
       );
 
@@ -155,7 +157,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const createUser = await create('User', { username: 'A thing' });
 
           // Update the item and link the relationship field
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -187,6 +189,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               ],
             },
           });
+          expect(errors).toBe(undefined);
 
           // Update the item and link multiple relationship fields
           const {
@@ -244,7 +247,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const createUser = await create('User', { username: 'A thing', notes: [createNote.id] });
 
           // Update the item and link the relationship field
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -280,6 +283,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               ],
             },
           });
+          expect(errors).toBe(undefined);
         })
       );
 
@@ -300,7 +304,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
           const createUser2 = await create('User', { username: 'user2', notes: [] });
 
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -342,6 +346,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               },
             ],
           });
+          expect(errors).toBe(undefined);
         })
       );
     });

--- a/api-tests/relationships/nested-mutations/connect-many.test.js
+++ b/api-tests/relationships/nested-mutations/connect-many.test.js
@@ -62,15 +62,15 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     describe('no access control', () => {
       test(
         'connect nested from within create mutation',
-        runner(setupKeystone, async ({ server: { server }, create }) => {
+        runner(setupKeystone, async ({ keystone, create }) => {
           const noteContent = sampleOne(alphanumGenerator);
 
           // Create an item to link against
           const createNote = await create('Note', { content: noteContent });
 
           // Create an item that does the linking
-          const createUserOneNote = await graphqlRequest({
-            server,
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
         mutation {
           createUser(data: {
@@ -83,14 +83,15 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     `,
           });
 
-          expect(createUserOneNote.body.data).toMatchObject({
+          expect(data).toMatchObject({
             createUser: { id: expect.any(String) },
           });
-          expect(createUserOneNote.body).not.toHaveProperty('errors');
 
           // Create an item that does the linking
-          const createUserManyNotes = await graphqlRequest({
-            server,
+          const {
+            data: { createUser },
+          } = await graphqlRequest({
+            keystone,
             query: `
         mutation {
           createUser(data: {
@@ -103,16 +104,15 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     `,
           });
 
-          expect(createUserManyNotes.body.data).toMatchObject({
-            createUser: { id: expect.any(String) },
+          expect(createUser).toMatchObject({
+            id: expect.any(String),
           });
-          expect(createUserManyNotes.body).not.toHaveProperty('errors');
         })
       );
 
       test(
         'connect nested from within create many mutation',
-        runner(setupKeystone, async ({ server: { server }, create }) => {
+        runner(setupKeystone, async ({ keystone, create }) => {
           const noteContent = sampleOne(alphanumGenerator);
           const noteContent2 = sampleOne(alphanumGenerator);
 
@@ -121,8 +121,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const createNote2 = await create('Note', { content: noteContent2 });
 
           // Create an item that does the linking
-          const createUsersOneNote = await graphqlRequest({
-            server,
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
         mutation {
           createUsers(data: [
@@ -135,16 +135,15 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     `,
           });
 
-          expect(createUsersOneNote.body.data).toMatchObject({
+          expect(data).toMatchObject({
             createUsers: [{ id: expect.any(String) }, { id: expect.any(String) }],
           });
-          expect(createUsersOneNote.body).not.toHaveProperty('errors');
         })
       );
 
       test(
         'connect nested from within update mutation adds to an empty list',
-        runner(setupKeystone, async ({ server: { server }, create }) => {
+        runner(setupKeystone, async ({ keystone, create }) => {
           const noteContent = sampleOne(alphanumGenerator);
           const noteContent2 = sampleOne(alphanumGenerator);
 
@@ -156,8 +155,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const createUser = await create('User', { username: 'A thing' });
 
           // Update the item and link the relationship field
-          const updateUser = await graphqlRequest({
-            server,
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
         mutation {
           updateUser(
@@ -177,7 +176,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     `,
           });
 
-          expect(updateUser.body.data).toMatchObject({
+          expect(data).toMatchObject({
             updateUser: {
               id: expect.any(String),
               notes: [
@@ -188,11 +187,12 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               ],
             },
           });
-          expect(updateUser.body).not.toHaveProperty('errors');
 
           // Update the item and link multiple relationship fields
-          const { body } = await graphqlRequest({
-            server,
+          const {
+            data: { updateUser },
+          } = await graphqlRequest({
+            keystone,
             query: `
         mutation {
           updateUser(
@@ -214,28 +214,25 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     `,
           });
 
-          expect(body.data).toMatchObject({
-            updateUser: {
-              id: expect.any(String),
-              notes: [
-                {
-                  id: createNote.id,
-                  content: noteContent,
-                },
-                {
-                  id: createNote2.id,
-                  content: noteContent2,
-                },
-              ],
-            },
+          expect(updateUser).toMatchObject({
+            id: expect.any(String),
+            notes: [
+              {
+                id: createNote.id,
+                content: noteContent,
+              },
+              {
+                id: createNote2.id,
+                content: noteContent2,
+              },
+            ],
           });
-          expect(body).not.toHaveProperty('errors');
         })
       );
 
       test(
         'connect nested from within update mutation adds to an existing list',
-        runner(setupKeystone, async ({ server: { server }, create }) => {
+        runner(setupKeystone, async ({ keystone, create }) => {
           const noteContent = sampleOne(alphanumGenerator);
           const noteContent2 = sampleOne(alphanumGenerator);
 
@@ -247,8 +244,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const createUser = await create('User', { username: 'A thing', notes: [createNote.id] });
 
           // Update the item and link the relationship field
-          const updateUser = await graphqlRequest({
-            server,
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
         mutation {
           updateUser(
@@ -268,7 +265,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     `,
           });
 
-          expect(updateUser.body.data).toMatchObject({
+          expect(data).toMatchObject({
             updateUser: {
               id: expect.any(String),
               notes: [
@@ -283,13 +280,12 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               ],
             },
           });
-          expect(updateUser.body).not.toHaveProperty('errors');
         })
       );
 
       test(
         'connect nested from within update many mutation adds to an existing list',
-        runner(setupKeystone, async ({ server: { server }, create }) => {
+        runner(setupKeystone, async ({ keystone, create }) => {
           const noteContent = sampleOne(alphanumGenerator);
           const noteContent2 = sampleOne(alphanumGenerator);
 
@@ -304,8 +300,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
           const createUser2 = await create('User', { username: 'user2', notes: [] });
 
-          const updateUsers = await graphqlRequest({
-            server,
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
         mutation {
           updateUsers(data: [
@@ -324,7 +320,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         }
       }`,
           });
-          expect(updateUsers.body.data).toMatchObject({
+          expect(data).toMatchObject({
             updateUsers: [
               {
                 id: expect.any(String),
@@ -346,7 +342,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               },
             ],
           });
-          expect(updateUsers.body).not.toHaveProperty('errors');
         })
       );
     });
@@ -354,12 +349,12 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     describe('non-matching filter', () => {
       test(
         'errors if connecting items which cannot be found during creating',
-        runner(setupKeystone, async ({ server: { server } }) => {
+        runner(setupKeystone, async ({ keystone }) => {
           const FAKE_ID = adapterName === 'mongoose' ? '5b84f38256d3c2df59a0d9bf' : 100;
 
           // Create an item that does the linking
-          const createUser = await graphqlRequest({
-            server,
+          const { errors } = await graphqlRequest({
+            keystone,
             query: `
         mutation {
           createUser(data: {
@@ -373,23 +368,9 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     `,
           });
 
-          expect(createUser.body).toHaveProperty('data.createUser', null);
-          expect(createUser.body.errors).toMatchObject([
+          expect(errors).toMatchObject([
             {
-              name: 'NestedError',
-              data: {
-                errors: [
-                  {
-                    message: 'Unable to create and/or connect 1 User.notes<Note>',
-                    path: ['createUser', 'notes'],
-                    name: 'Error',
-                  },
-                  {
-                    name: 'AccessDeniedError',
-                    path: ['createUser', 'notes', 'connect', 0],
-                  },
-                ],
-              },
+              message: 'Unable to create and/or connect 1 User.notes<Note>',
             },
           ]);
         })
@@ -397,15 +378,15 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
       test(
         'errors if connecting items which cannot be found during update',
-        runner(setupKeystone, async ({ server: { server }, create }) => {
+        runner(setupKeystone, async ({ keystone, create }) => {
           const FAKE_ID = adapterName === 'mongoose' ? '5b84f38256d3c2df59a0d9bf' : 100;
 
           // Create an item to link against
           const createUser = await create('User', {});
 
           // Create an item that does the linking
-          const updateUser = await graphqlRequest({
-            server,
+          const { errors } = await graphqlRequest({
+            keystone,
             query: `
         mutation {
           updateUser(
@@ -422,23 +403,9 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     `,
           });
 
-          expect(updateUser.body).toHaveProperty('data.updateUser', null);
-          expect(updateUser.body.errors).toMatchObject([
+          expect(errors).toMatchObject([
             {
-              name: 'NestedError',
-              data: {
-                errors: [
-                  {
-                    message: 'Unable to create and/or connect 1 User.notes<Note>',
-                    path: ['updateUser', 'notes'],
-                    name: 'Error',
-                  },
-                  {
-                    name: 'AccessDeniedError',
-                    path: ['updateUser', 'notes', 'connect', 0],
-                  },
-                ],
-              },
+              message: 'Unable to create and/or connect 1 User.notes<Note>',
             },
           ]);
         })
@@ -449,7 +416,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       describe('read: false on related list', () => {
         test(
           'throws when link nested from within create mutation',
-          runner(setupKeystone, async ({ server: { server }, create }) => {
+          runner(setupKeystone, async ({ keystone, create }) => {
             const noteContent = sampleOne(alphanumGenerator);
 
             // Create an item to link against
@@ -458,8 +425,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             });
 
             // Create an item that does the linking
-            const createUserOneNote = await graphqlRequest({
-              server,
+            const { errors } = await graphqlRequest({
+              keystone,
               query: `
           mutation {
             createUserToNotesNoRead(data: {
@@ -472,24 +439,9 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
             });
 
-            expect(createUserOneNote.body).toHaveProperty('data.createUserToNotesNoRead', null);
-            expect(createUserOneNote.body.errors).toMatchObject([
+            expect(errors).toMatchObject([
               {
-                name: 'NestedError',
-                data: {
-                  errors: [
-                    {
-                      message:
-                        'Unable to create and/or connect 1 UserToNotesNoRead.notes<NoteNoRead>',
-                      path: ['createUserToNotesNoRead', 'notes'],
-                      name: 'Error',
-                    },
-                    {
-                      name: 'AccessDeniedError',
-                      path: ['createUserToNotesNoRead', 'notes', 'connect', 0],
-                    },
-                  ],
-                },
+                message: 'Unable to create and/or connect 1 UserToNotesNoRead.notes<NoteNoRead>',
               },
             ]);
           })
@@ -497,7 +449,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
         test(
           'throws when link nested from within update mutation',
-          runner(setupKeystone, async ({ server: { server }, create }) => {
+          runner(setupKeystone, async ({ keystone, create }) => {
             const noteContent = sampleOne(alphanumGenerator);
 
             // Create an item to link against
@@ -509,8 +461,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             });
 
             // Update the item and link the relationship field
-            const { body } = await graphqlRequest({
-              server,
+            const { errors } = await graphqlRequest({
+              keystone,
               query: `
           mutation {
             updateUserToNotesNoRead(
@@ -526,24 +478,9 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
             });
 
-            expect(body).toHaveProperty('data.updateUserToNotesNoRead', null);
-            expect(body.errors).toMatchObject([
+            expect(errors).toMatchObject([
               {
-                name: 'NestedError',
-                data: {
-                  errors: [
-                    {
-                      message:
-                        'Unable to create and/or connect 1 UserToNotesNoRead.notes<NoteNoRead>',
-                      path: ['updateUserToNotesNoRead', 'notes'],
-                      name: 'Error',
-                    },
-                    {
-                      name: 'AccessDeniedError',
-                      path: ['updateUserToNotesNoRead', 'notes', 'connect', 0],
-                    },
-                  ],
-                },
+                message: 'Unable to create and/or connect 1 UserToNotesNoRead.notes<NoteNoRead>',
               },
             ]);
           })
@@ -553,7 +490,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       describe('create: false on related list', () => {
         test(
           'does not throw when link nested from within create mutation',
-          runner(setupKeystone, async ({ server: { server }, create }) => {
+          runner(setupKeystone, async ({ keystone, create }) => {
             const noteContent = sampleOne(alphanumGenerator);
 
             // Create an item to link against
@@ -562,8 +499,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             });
 
             // Create an item that does the linking
-            const createUserOneNote = await graphqlRequest({
-              server,
+            const { errors } = await graphqlRequest({
+              keystone,
               query: `
           mutation {
             createUserToNotesNoCreate(data: {
@@ -576,13 +513,13 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
             });
 
-            expect(createUserOneNote.body).not.toHaveProperty('errors');
+            expect(errors).toBe(undefined);
           })
         );
 
         test(
           'does not throw when link nested from within update mutation',
-          runner(setupKeystone, async ({ server: { server }, create }) => {
+          runner(setupKeystone, async ({ keystone, create }) => {
             const noteContent = sampleOne(alphanumGenerator);
 
             // Create an item to link against
@@ -594,8 +531,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             });
 
             // Update the item and link the relationship field
-            const { body } = await graphqlRequest({
-              server,
+            const { errors } = await graphqlRequest({
+              keystone,
               query: `
           mutation {
             updateUserToNotesNoCreate(
@@ -613,7 +550,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
             });
 
-            expect(body).not.toHaveProperty('errors');
+            expect(errors).toBe(undefined);
           })
         );
       });

--- a/api-tests/relationships/nested-mutations/connect-singular.test.js
+++ b/api-tests/relationships/nested-mutations/connect-singular.test.js
@@ -67,7 +67,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const createGroup = await create('Group', { name: groupName });
 
           // Create an item that does the linking
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
           mutation {
@@ -82,6 +82,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           expect(data).toMatchObject({ createEvent: { id: expect.any(String) } });
+          expect(errors).toBe(undefined);
         })
       );
 
@@ -102,7 +103,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           // Update the item and link the relationship field
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -132,6 +133,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               },
             },
           });
+          expect(errors).toBe(undefined);
         })
       );
     });
@@ -297,7 +299,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { id } = await create('GroupNoCreate', { name: groupName });
 
             // Create an item that does the linking
-            const { data } = await graphqlRequest({
+            const { data, errors } = await graphqlRequest({
               keystone,
               query: `
           mutation {
@@ -317,6 +319,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(data).toMatchObject({
               createEventToGroupNoCreate: { id: expect.any(String), group: { id } },
             });
+            expect(errors).toBe(undefined);
           })
         );
 
@@ -337,7 +340,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             });
 
             // Update the item and link the relationship field
-            const { data } = await graphqlRequest({
+            const { data, errors } = await graphqlRequest({
               keystone,
               query: `
           mutation {
@@ -367,6 +370,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                 },
               },
             });
+            expect(errors).toBe(undefined);
 
             // See that it actually stored the group ID on the Event record
             const event = await findOne('EventToGroupNoCreate', { title: 'A thing' });

--- a/api-tests/relationships/nested-mutations/create-and-connect-many.test.js
+++ b/api-tests/relationships/nested-mutations/create-and-connect-many.test.js
@@ -70,7 +70,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const createNote = await create('Note', { content: noteContent });
 
           // Create an item that does the linking
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -100,6 +100,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               ],
             },
           });
+          expect(errors).toBe(undefined);
 
           // Sanity check that the items are actually created
           const {
@@ -135,7 +136,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const createUser = await create('User', { username: 'A thing' });
 
           // Update the item and link the relationship field
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -174,6 +175,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               ],
             },
           });
+          expect(errors).toBe(undefined);
 
           // Sanity check that the items are actually created
           const {

--- a/api-tests/relationships/nested-mutations/create-and-connect-many.test.js
+++ b/api-tests/relationships/nested-mutations/create-and-connect-many.test.js
@@ -62,7 +62,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     describe('no access control', () => {
       test(
         'link AND create nested from within create mutation',
-        runner(setupKeystone, async ({ server: { server }, create }) => {
+        runner(setupKeystone, async ({ keystone, create }) => {
           const noteContent = sampleOne(alphanumGenerator);
           const noteContent2 = sampleOne(alphanumGenerator);
 
@@ -70,8 +70,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const createNote = await create('Note', { content: noteContent });
 
           // Create an item that does the linking
-          const createUser = await graphqlRequest({
-            server,
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
         mutation {
           createUser(data: {
@@ -91,7 +91,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     `,
           });
 
-          expect(createUser.body.data).toMatchObject({
+          expect(data).toMatchObject({
             createUser: {
               id: expect.any(String),
               notes: [
@@ -100,18 +100,15 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               ],
             },
           });
-          expect(createUser.body).not.toHaveProperty('errors');
 
           // Sanity check that the items are actually created
           const {
-            body: {
-              data: { allNotes },
-            },
+            data: { allNotes },
           } = await graphqlRequest({
-            server,
+            keystone,
             query: `
         query {
-          allNotes(where: { id_in: [${createUser.body.data.createUser.notes
+          allNotes(where: { id_in: [${data.createUser.notes
             .map(({ id }) => `"${id}"`)
             .join(',')}] }) {
             id
@@ -121,13 +118,13 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     `,
           });
 
-          expect(allNotes).toHaveLength(createUser.body.data.createUser.notes.length);
+          expect(allNotes).toHaveLength(data.createUser.notes.length);
         })
       );
 
       test(
         'link & create nested from within update mutation',
-        runner(setupKeystone, async ({ server: { server }, create }) => {
+        runner(setupKeystone, async ({ keystone, create }) => {
           const noteContent = sampleOne(alphanumGenerator);
           const noteContent2 = sampleOne(alphanumGenerator);
 
@@ -138,8 +135,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const createUser = await create('User', { username: 'A thing' });
 
           // Update the item and link the relationship field
-          const { body } = await graphqlRequest({
-            server,
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
         mutation {
           updateUser(
@@ -162,7 +159,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     `,
           });
 
-          expect(body.data).toMatchObject({
+          expect(data).toMatchObject({
             updateUser: {
               id: expect.any(String),
               notes: [
@@ -177,18 +174,15 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               ],
             },
           });
-          expect(body).not.toHaveProperty('errors');
 
           // Sanity check that the items are actually created
           const {
-            body: {
-              data: { allNotes },
-            },
+            data: { allNotes },
           } = await graphqlRequest({
-            server,
+            keystone,
             query: `
         query {
-          allNotes(where: { id_in: [${body.data.updateUser.notes
+          allNotes(where: { id_in: [${data.updateUser.notes
             .map(({ id }) => `"${id}"`)
             .join(',')}] }) {
             id
@@ -198,7 +192,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     `,
           });
 
-          expect(allNotes).toHaveLength(body.data.updateUser.notes.length);
+          expect(allNotes).toHaveLength(data.updateUser.notes.length);
         })
       );
     });
@@ -206,10 +200,10 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     describe('errors on incomplete data', () => {
       test(
         'when neither id or create data passed',
-        runner(setupKeystone, async ({ server: { server } }) => {
+        runner(setupKeystone, async ({ keystone }) => {
           // Create an item that does the linking
-          const createUser = await graphqlRequest({
-            server,
+          const { errors } = await graphqlRequest({
+            keystone,
             query: `
         mutation {
           createUser(data: { notes: {} }) {
@@ -219,24 +213,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     `,
           });
 
-          expect(createUser.body).toHaveProperty('data.createUser', null);
-          expect(createUser.body.errors).toMatchObject([
-            {
-              name: 'NestedError',
-              data: {
-                errors: [
-                  {
-                    message: 'Nested mutation operation invalid for User.notes<Note>',
-                    path: ['createUser', 'notes'],
-                    name: 'Error',
-                  },
-                  {
-                    name: 'ParameterError',
-                    path: ['createUser', 'notes', '<validate>'],
-                  },
-                ],
-              },
-            },
+          expect(errors).toMatchObject([
+            { message: 'Nested mutation operation invalid for User.notes<Note>' },
           ]);
         })
       );
@@ -246,7 +224,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       describe('read: false on related list', () => {
         test(
           'throws when link AND create nested from within create mutation',
-          runner(setupKeystone, async ({ server: { server }, create }) => {
+          runner(setupKeystone, async ({ keystone, create }) => {
             const noteContent = sampleOne(alphanumGenerator);
             const noteContent2 = sampleOne(alphanumGenerator);
 
@@ -256,8 +234,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             });
 
             // Create an item that does the linking
-            const createUser = await graphqlRequest({
-              server,
+            const { errors } = await graphqlRequest({
+              keystone,
               query: `
           mutation {
             createUserToNotesNoRead(data: {
@@ -273,32 +251,15 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
             });
 
-            expect(createUser.body).toHaveProperty('data.createUserToNotesNoRead', null);
-            expect(createUser.body.errors).toMatchObject([
-              {
-                name: 'NestedError',
-                data: {
-                  errors: [
-                    {
-                      message:
-                        'Unable to create and/or connect 1 UserToNotesNoRead.notes<NoteNoRead>',
-                      path: ['createUserToNotesNoRead', 'notes'],
-                      name: 'Error',
-                    },
-                    {
-                      name: 'AccessDeniedError',
-                      path: ['createUserToNotesNoRead', 'notes', 'connect', 0],
-                    },
-                  ],
-                },
-              },
+            expect(errors).toMatchObject([
+              { message: 'Unable to create and/or connect 1 UserToNotesNoRead.notes<NoteNoRead>' },
             ]);
           })
         );
 
         test(
           'throws when link & create nested from within update mutation',
-          runner(setupKeystone, async ({ server: { server }, create }) => {
+          runner(setupKeystone, async ({ keystone, create }) => {
             const noteContent = sampleOne(alphanumGenerator);
             const noteContent2 = sampleOne(alphanumGenerator);
 
@@ -311,8 +272,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             });
 
             // Update the item and link the relationship field
-            const { body } = await graphqlRequest({
-              server,
+            const { errors } = await graphqlRequest({
+              keystone,
               query: `
           mutation {
             updateUserToNotesNoRead(
@@ -331,25 +292,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
             });
 
-            expect(body).toHaveProperty('data.updateUserToNotesNoRead', null);
-            expect(body.errors).toMatchObject([
-              {
-                name: 'NestedError',
-                data: {
-                  errors: [
-                    {
-                      message:
-                        'Unable to create and/or connect 1 UserToNotesNoRead.notes<NoteNoRead>',
-                      path: ['updateUserToNotesNoRead', 'notes'],
-                      name: 'Error',
-                    },
-                    {
-                      name: 'AccessDeniedError',
-                      path: ['updateUserToNotesNoRead', 'notes', 'connect', 0],
-                    },
-                  ],
-                },
-              },
+            expect(errors).toMatchObject([
+              { message: 'Unable to create and/or connect 1 UserToNotesNoRead.notes<NoteNoRead>' },
             ]);
           })
         );

--- a/api-tests/relationships/nested-mutations/create-and-connect-singular.test.js
+++ b/api-tests/relationships/nested-mutations/create-and-connect-singular.test.js
@@ -59,10 +59,10 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     describe('errors on incomplete data', () => {
       test(
         'when neither id or create data passed',
-        runner(setupKeystone, async ({ server: { server } }) => {
+        runner(setupKeystone, async ({ keystone }) => {
           // Create an item that does the linking
-          const createEvent = await graphqlRequest({
-            server,
+          const { errors } = await graphqlRequest({
+            keystone,
             query: `
         mutation {
           createEvent(data: { group: {} }) {
@@ -72,34 +72,18 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     `,
           });
 
-          expect(createEvent.body).toHaveProperty('data.createEvent', null);
-          expect(createEvent.body.errors).toMatchObject([
-            {
-              name: 'NestedError',
-              data: {
-                errors: [
-                  {
-                    message: 'Nested mutation operation invalid for Event.group<Group>',
-                    path: ['createEvent', 'group'],
-                    name: 'Error',
-                  },
-                  {
-                    name: 'ParameterError',
-                    path: ['createEvent', 'group', '<validate>'],
-                  },
-                ],
-              },
-            },
+          expect(errors).toMatchObject([
+            { message: 'Nested mutation operation invalid for Event.group<Group>' },
           ]);
         })
       );
 
       test(
         'when both id and create data passed',
-        runner(setupKeystone, async ({ server: { server } }) => {
+        runner(setupKeystone, async ({ keystone }) => {
           // Create an item that does the linking
-          const createEvent = await graphqlRequest({
-            server,
+          const { data, errors } = await graphqlRequest({
+            keystone,
             query: `
         mutation {
           createEvent(data: { group: {
@@ -112,24 +96,9 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     `,
           });
 
-          expect(createEvent.body).toHaveProperty('data.createEvent', null);
-          expect(createEvent.body.errors).toMatchObject([
-            {
-              name: 'NestedError',
-              data: {
-                errors: [
-                  {
-                    message: 'Nested mutation operation invalid for Event.group<Group>',
-                    path: ['createEvent', 'group'],
-                    name: 'Error',
-                  },
-                  {
-                    name: 'ParameterError',
-                    path: ['createEvent', 'group', '<validate>'],
-                  },
-                ],
-              },
-            },
+          expect(data.createEvent).toBe(null);
+          expect(errors).toMatchObject([
+            { message: 'Nested mutation operation invalid for Event.group<Group>' },
           ]);
         })
       );

--- a/api-tests/relationships/nested-mutations/create-many.test.js
+++ b/api-tests/relationships/nested-mutations/create-many.test.js
@@ -68,7 +68,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const noteContent3 = sampleOne(alphanumGenerator);
 
           // Create an item that does the nested create
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -86,6 +86,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     `,
           });
 
+          expect(errors).toBe(undefined);
           expect(data).toMatchObject({
             createUser: {
               id: expect.any(String),
@@ -200,6 +201,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
           const {
             data: { updateUser },
+            errors,
           } = await graphqlRequest({
             keystone,
             query: `
@@ -226,6 +228,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     `,
           });
 
+          expect(errors).toBe(undefined);
           expect(updateUser).toMatchObject({
             id: expect.any(String),
             notes: [

--- a/api-tests/relationships/nested-mutations/create-singular.test.js
+++ b/api-tests/relationships/nested-mutations/create-singular.test.js
@@ -64,7 +64,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const groupName = sampleOne(gen.alphaNumString.notEmpty());
 
           // Create an item that does the nested create
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -82,6 +82,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     `,
           });
 
+          expect(errors).toBe(undefined);
           expect(data).toMatchObject({
             createEvent: {
               id: expect.any(String),
@@ -122,7 +123,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const createEvent = await create('Event', { title: 'A thing' });
 
           // Update an item that does the nested create
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -143,6 +144,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     `,
           });
 
+          expect(errors).toBe(undefined);
           expect(data).toMatchObject({
             updateEvent: {
               id: expect.any(String),
@@ -183,7 +185,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const groupName = sampleOne(gen.alphaNumString.notEmpty());
 
             // Create an item that does the nested create
-            const { data } = await graphqlRequest({
+            const { data, errors } = await graphqlRequest({
               keystone,
               query: `
           mutation {
@@ -197,6 +199,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
             });
 
+            expect(errors).toBe(undefined);
             expect(data).toMatchObject({
               createEventToGroupNoRead: { id: expect.any(String) },
             });
@@ -223,7 +226,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             });
 
             // Update an item that does the nested create
-            const { data } = await graphqlRequest({
+            const { data, errors } = await graphqlRequest({
               keystone,
               query: `
           mutation {
@@ -240,6 +243,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
             });
 
+            expect(errors).toBe(undefined);
             expect(data).toMatchObject({ updateEventToGroupNoRead: { id: expect.any(String) } });
 
             // See that it actually stored the group ID on the Event record

--- a/api-tests/relationships/nested-mutations/disconnect-all-many.test.js
+++ b/api-tests/relationships/nested-mutations/disconnect-all-many.test.js
@@ -63,7 +63,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     describe('no access control', () => {
       test(
         'removes all items from list',
-        runner(setupKeystone, async ({ server: { server }, create }) => {
+        runner(setupKeystone, async ({ keystone, create }) => {
           const noteContent = `foo${sampleOne(alphanumGenerator)}`;
           const noteContent2 = `foo${sampleOne(alphanumGenerator)}`;
 
@@ -78,8 +78,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           // Update the item and link the relationship field
-          const updateUser = await graphqlRequest({
-            server,
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
           mutation {
             updateUser(
@@ -99,24 +99,21 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(updateUser.body.data).toMatchObject({
+          expect(data).toMatchObject({
             updateUser: {
               id: expect.any(String),
               notes: [],
             },
           });
-          expect(updateUser.body).not.toHaveProperty('errors');
         })
       );
 
       test(
         'silently succeeds if used during create',
-        runner(setupKeystone, async ({ server: { server } }) => {
+        runner(setupKeystone, async ({ keystone }) => {
           // Create an item that does the linking
-          const {
-            body: { data },
-          } = await graphqlRequest({
-            server,
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
           mutation {
             createUser(data: {
@@ -133,7 +130,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(data.createUser).not.toHaveProperty('errors');
           expect(data.createUser).toMatchObject({
             id: expect.any(String),
             notes: [],
@@ -146,7 +142,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       describe('read: false on related list', () => {
         test(
           'has no effect when specifying disconnectAll',
-          runner(setupKeystone, async ({ server: { server }, create, findById }) => {
+          runner(setupKeystone, async ({ keystone, create, findById }) => {
             const noteContent = sampleOne(alphanumGenerator);
 
             // Create an item to link against
@@ -159,8 +155,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             });
 
             // Update the item and link the relationship field
-            const { body } = await graphqlRequest({
-              server,
+            await graphqlRequest({
+              keystone,
               query: `
             mutation {
               updateUserToNotesNoRead(
@@ -175,8 +171,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             }
         `,
             });
-
-            expect(body).not.toHaveProperty('data.updateUserToNotesNoRead.errors');
 
             const userData = await findById('UserToNotesNoRead', createUser.id);
 

--- a/api-tests/relationships/nested-mutations/disconnect-all-many.test.js
+++ b/api-tests/relationships/nested-mutations/disconnect-all-many.test.js
@@ -78,7 +78,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           // Update the item and link the relationship field
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
           mutation {
@@ -105,6 +105,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               notes: [],
             },
           });
+          expect(errors).toBe(undefined);
         })
       );
 
@@ -112,7 +113,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         'silently succeeds if used during create',
         runner(setupKeystone, async ({ keystone }) => {
           // Create an item that does the linking
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
           mutation {
@@ -130,6 +131,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
+          expect(errors).toBe(undefined);
           expect(data.createUser).toMatchObject({
             id: expect.any(String),
             notes: [],
@@ -155,7 +157,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             });
 
             // Update the item and link the relationship field
-            await graphqlRequest({
+            const { errors } = await graphqlRequest({
               keystone,
               query: `
             mutation {
@@ -172,6 +174,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         `,
             });
 
+            expect(errors).toBe(undefined);
             const userData = await findById('UserToNotesNoRead', createUser.id);
 
             expect(userData.notes).toHaveLength(0);

--- a/api-tests/relationships/nested-mutations/disconnect-all-singular.test.js
+++ b/api-tests/relationships/nested-mutations/disconnect-all-singular.test.js
@@ -62,7 +62,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           expect(createEvent.group.toString()).toBe(createGroup.id);
 
           // Update the item and link the relationship field
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -87,6 +87,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               group: null,
             },
           });
+          expect(errors).toBe(undefined);
 
           // Avoid false-positives by checking the database directly
           const eventData = await findById('Event', createEvent.id);
@@ -182,7 +183,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(createEvent.group.toString()).toBe(createGroup.id);
 
             // Update the item and link the relationship field
-            await graphqlRequest({
+            const { errors } = await graphqlRequest({
               keystone,
               query: `
           mutation {
@@ -197,6 +198,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           }
       `,
             });
+
+            expect(errors).toBe(undefined);
 
             // Avoid false-positives by checking the database directly
             const eventData = await findById('EventToGroupNoRead', createEvent.id);

--- a/api-tests/relationships/nested-mutations/disconnect-many.test.js
+++ b/api-tests/relationships/nested-mutations/disconnect-many.test.js
@@ -78,7 +78,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           // Update the item and link the relationship field
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -110,6 +110,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               ],
             },
           });
+          expect(errors).toBe(undefined);
         })
       );
 
@@ -203,7 +204,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           // Update the item and link the relationship field
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -234,6 +235,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               ],
             },
           });
+          expect(errors).toBe(undefined);
         })
       );
     });
@@ -255,7 +257,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             });
 
             // Update the item and link the relationship field
-            await graphqlRequest({
+            const { errors } = await graphqlRequest({
               keystone,
               query: `
           mutation {
@@ -272,7 +274,9 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
             });
 
+            expect(errors).toBe(undefined);
             const userData = await findById('UserToNotesNoRead', createUser.id);
+
             expect(userData.notes).toHaveLength(0);
           })
         );

--- a/api-tests/relationships/nested-mutations/disconnect-singular.test.js
+++ b/api-tests/relationships/nested-mutations/disconnect-singular.test.js
@@ -62,7 +62,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           expect(createEvent.group.toString()).toBe(createGroup.id);
 
           // Update the item and link the relationship field
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -87,6 +87,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               group: null,
             },
           });
+          expect(errors).toBe(undefined);
 
           // Avoid false-positives by checking the database directly
           const eventData = await findById('Event', createEvent.id);
@@ -226,7 +227,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(createEvent.group.toString()).toBe(createGroup.id);
 
             // Update the item and link the relationship field
-            await graphqlRequest({
+            const { errors } = await graphqlRequest({
               keystone,
               query: `
           mutation {
@@ -241,6 +242,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           }
       `,
             });
+            expect(errors).toBe(undefined);
 
             // Avoid false-positives by checking the database directly
             const eventData = await findById('EventToGroupNoRead', createEvent.id);

--- a/api-tests/relationships/nested-mutations/two-way-backreference/to-many.test.js
+++ b/api-tests/relationships/nested-mutations/two-way-backreference/to-many.test.js
@@ -38,9 +38,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       describe('nested connect', () => {
         test(
           'during create mutation',
-          runner(setupKeystone, async ({ server: { server }, create, findById }) => {
-            console.log('connected');
-
+          runner(setupKeystone, async ({ keystone, create, findById }) => {
             // Manually setup a connected Student <-> Teacher
             let teacher1 = await create('Teacher', {});
             await new Promise(resolve => process.nextTick(resolve));
@@ -61,8 +59,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(toStr(teacher2.students)).toHaveLength(0);
 
             // Run the query to disconnect the teacher from student
-            const queryResult = await graphqlRequest({
-              server,
+            const { data } = await graphqlRequest({
+              keystone,
               query: `
           mutation {
             createStudent(
@@ -79,9 +77,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         `,
             });
 
-            expect(queryResult.body).not.toHaveProperty('errors');
-
-            let newStudent = queryResult.body.data.createStudent;
+            let newStudent = data.createStudent;
 
             // Check the link has been broken
             teacher1 = await findById('Teacher', teacher1.id);
@@ -101,7 +97,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
         test(
           'during update mutation',
-          runner(setupKeystone, async ({ server: { server }, create, findById }) => {
+          runner(setupKeystone, async ({ keystone, create, findById }) => {
             // Manually setup a connected Student <-> Teacher
             let teacher1 = await create('Teacher', {});
             let teacher2 = await create('Teacher', {});
@@ -122,8 +118,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(toStr(teacher2.students)).toHaveLength(0);
 
             // Run the query to disconnect the teacher from student
-            const queryResult = await graphqlRequest({
-              server,
+            await graphqlRequest({
+              keystone,
               query: `
           mutation {
             updateStudent(
@@ -140,8 +136,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           }
       `,
             });
-
-            expect(queryResult.body).not.toHaveProperty('errors');
 
             // Check the link has been broken
             teacher1 = await findById('Teacher', teacher1.id);
@@ -164,13 +158,13 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       describe('nested create', () => {
         test(
           'during create mutation',
-          runner(setupKeystone, async ({ server: { server }, findById }) => {
+          runner(setupKeystone, async ({ keystone, findById }) => {
             const teacherName1 = sampleOne(alphanumGenerator);
             const teacherName2 = sampleOne(alphanumGenerator);
 
             // Run the query to disconnect the teacher from student
-            const queryResult = await graphqlRequest({
-              server,
+            const { data } = await graphqlRequest({
+              keystone,
               query: `
           mutation {
             createStudent(
@@ -187,10 +181,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
             });
 
-            expect(queryResult.body).not.toHaveProperty('errors');
-
-            let newStudent = queryResult.body.data.createStudent;
-            let newTeachers = queryResult.body.data.createStudent.teachers;
+            let newStudent = data.createStudent;
+            let newTeachers = data.createStudent.teachers;
 
             // Check the link has been broken
             const teacher1 = await findById('Teacher', newTeachers[0].id);
@@ -208,14 +200,14 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
         test(
           'during update mutation',
-          runner(setupKeystone, async ({ server: { server }, create, findById }) => {
+          runner(setupKeystone, async ({ keystone, create, findById }) => {
             let student = await create('Student', {});
             const teacherName1 = sampleOne(alphanumGenerator);
             const teacherName2 = sampleOne(alphanumGenerator);
 
             // Run the query to disconnect the teacher from student
-            const queryResult = await graphqlRequest({
-              server,
+            const { data } = await graphqlRequest({
+              keystone,
               query: `
           mutation {
             updateStudent(
@@ -233,9 +225,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
             });
 
-            expect(queryResult.body).not.toHaveProperty('errors');
-
-            let newTeachers = queryResult.body.data.updateStudent.teachers;
+            let newTeachers = data.updateStudent.teachers;
 
             // Check the link has been broken
             const teacher1 = await findById('Teacher', newTeachers[0].id);
@@ -254,7 +244,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
       test(
         'nested disconnect during update mutation',
-        runner(setupKeystone, async ({ server: { server }, create, update, findById }) => {
+        runner(setupKeystone, async ({ keystone, create, update, findById }) => {
           // Manually setup a connected Student <-> Teacher
           let teacher1 = await create('Teacher', {});
           let teacher2 = await create('Teacher', {});
@@ -288,8 +278,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           ]);
 
           // Run the query to disconnect the teacher from student
-          const queryResult = await graphqlRequest({
-            server,
+          await graphqlRequest({
+            keystone,
             query: `
         mutation {
           updateStudent(
@@ -306,8 +296,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         }
     `,
           });
-
-          expect(queryResult.body).not.toHaveProperty('errors');
 
           // Check the link has been broken
           teacher1 = await findById('Teacher', teacher1.id);
@@ -331,7 +319,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
       test(
         'nested disconnectAll during update mutation',
-        runner(setupKeystone, async ({ server: { server }, create, update, findById }) => {
+        runner(setupKeystone, async ({ keystone, create, update, findById }) => {
           // Manually setup a connected Student <-> Teacher
           let teacher1 = await create('Teacher', {});
           let teacher2 = await create('Teacher', {});
@@ -365,8 +353,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           ]);
 
           // Run the query to disconnect the teacher from student
-          const queryResult = await graphqlRequest({
-            server,
+          await graphqlRequest({
+            keystone,
             query: `
         mutation {
           updateStudent(
@@ -383,8 +371,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         }
     `,
           });
-
-          expect(queryResult.body).not.toHaveProperty('errors');
 
           // Check the link has been broken
           teacher1 = await findById('Teacher', teacher1.id);
@@ -406,7 +392,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
     test(
       'delete mutation updates back references in to-many relationship',
-      runner(setupKeystone, async ({ server: { server }, create, update, findById }) => {
+      runner(setupKeystone, async ({ keystone, create, update, findById }) => {
         // Manually setup a connected Student <-> Teacher
         let teacher1 = await create('Teacher', {});
         let teacher2 = await create('Teacher', {});
@@ -440,8 +426,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         ]);
 
         // Run the query to delete the student
-        const queryResult = await graphqlRequest({
-          server,
+        await graphqlRequest({
+          keystone,
           query: `
       mutation {
         deleteStudent(id: "${student1.id}") {
@@ -450,8 +436,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       }
   `,
         });
-
-        expect(queryResult.body).not.toHaveProperty('errors');
 
         teacher1 = await findById('Teacher', teacher1.id);
         teacher2 = await findById('Teacher', teacher2.id);

--- a/api-tests/relationships/nested-mutations/two-way-backreference/to-many.test.js
+++ b/api-tests/relationships/nested-mutations/two-way-backreference/to-many.test.js
@@ -59,7 +59,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(toStr(teacher2.students)).toHaveLength(0);
 
             // Run the query to disconnect the teacher from student
-            const { data } = await graphqlRequest({
+            const { data, errors } = await graphqlRequest({
               keystone,
               query: `
           mutation {
@@ -76,6 +76,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           }
         `,
             });
+
+            expect(errors).toBe(undefined);
 
             let newStudent = data.createStudent;
 
@@ -118,7 +120,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(toStr(teacher2.students)).toHaveLength(0);
 
             // Run the query to disconnect the teacher from student
-            await graphqlRequest({
+            const { errors } = await graphqlRequest({
               keystone,
               query: `
           mutation {
@@ -136,6 +138,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           }
       `,
             });
+
+            expect(errors).toBe(undefined);
 
             // Check the link has been broken
             teacher1 = await findById('Teacher', teacher1.id);
@@ -163,7 +167,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const teacherName2 = sampleOne(alphanumGenerator);
 
             // Run the query to disconnect the teacher from student
-            const { data } = await graphqlRequest({
+            const { data, errors } = await graphqlRequest({
               keystone,
               query: `
           mutation {
@@ -180,6 +184,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           }
       `,
             });
+
+            expect(errors).toBe(undefined);
 
             let newStudent = data.createStudent;
             let newTeachers = data.createStudent.teachers;
@@ -206,7 +212,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const teacherName2 = sampleOne(alphanumGenerator);
 
             // Run the query to disconnect the teacher from student
-            const { data } = await graphqlRequest({
+            const { data, errors } = await graphqlRequest({
               keystone,
               query: `
           mutation {
@@ -224,6 +230,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           }
       `,
             });
+
+            expect(errors).toBe(undefined);
 
             let newTeachers = data.updateStudent.teachers;
 
@@ -278,7 +286,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           ]);
 
           // Run the query to disconnect the teacher from student
-          await graphqlRequest({
+          const { errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -296,6 +304,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         }
     `,
           });
+
+          expect(errors).toBe(undefined);
 
           // Check the link has been broken
           teacher1 = await findById('Teacher', teacher1.id);
@@ -353,7 +363,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           ]);
 
           // Run the query to disconnect the teacher from student
-          await graphqlRequest({
+          const { errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -371,6 +381,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         }
     `,
           });
+
+          expect(errors).toBe(undefined);
 
           // Check the link has been broken
           teacher1 = await findById('Teacher', teacher1.id);
@@ -426,7 +438,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         ]);
 
         // Run the query to delete the student
-        await graphqlRequest({
+        const { errors } = await graphqlRequest({
           keystone,
           query: `
       mutation {
@@ -436,6 +448,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       }
   `,
         });
+
+        expect(errors).toBe(undefined);
 
         teacher1 = await findById('Teacher', teacher1.id);
         teacher2 = await findById('Teacher', teacher2.id);

--- a/api-tests/relationships/nested-mutations/two-way-backreference/to-one-required.test.js
+++ b/api-tests/relationships/nested-mutations/two-way-backreference/to-one-required.test.js
@@ -33,10 +33,10 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     describe('update one to one relationship back reference', () => {
       test(
         'nested create',
-        runner(setupKeystone, async ({ server: { server }, findById }) => {
+        runner(setupKeystone, async ({ keystone, findById }) => {
           const locationName = sampleOne(alphanumGenerator);
-          const queryResult = await graphqlRequest({
-            server,
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
         mutation {
           createCompany(data: {
@@ -51,10 +51,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     `,
           });
 
-          expect(queryResult.body).not.toHaveProperty('errors');
-
-          const companyId = queryResult.body.data.createCompany.id;
-          const locationId = queryResult.body.data.createCompany.location.id;
+          const companyId = data.createCompany.id;
+          const locationId = data.createCompany.location.id;
 
           const location = await findById('Location', locationId);
           const company = await findById('Company', companyId);

--- a/api-tests/relationships/nested-mutations/two-way-backreference/to-one-required.test.js
+++ b/api-tests/relationships/nested-mutations/two-way-backreference/to-one-required.test.js
@@ -35,7 +35,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         'nested create',
         runner(setupKeystone, async ({ keystone, findById }) => {
           const locationName = sampleOne(alphanumGenerator);
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -50,6 +50,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         }
     `,
           });
+
+          expect(errors).toBe(undefined);
 
           const companyId = data.createCompany.id;
           const locationId = data.createCompany.location.id;

--- a/api-tests/relationships/nested-mutations/two-way-backreference/to-one.test.js
+++ b/api-tests/relationships/nested-mutations/two-way-backreference/to-one.test.js
@@ -36,7 +36,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           'during create mutation',
           runner(setupKeystone, async ({ keystone, create, findById }) => {
             let location = await create('Location', {});
-            const { data } = await graphqlRequest({
+            const { data, errors } = await graphqlRequest({
               keystone,
               query: `
           mutation {
@@ -51,6 +51,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           }
       `,
             });
+
+            expect(errors).toBe(undefined);
 
             const companyId = data.createCompany.id;
 
@@ -74,7 +76,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(company.location).toBe(undefined);
             expect(location.company).toBe(undefined);
 
-            await graphqlRequest({
+            const { errors } = await graphqlRequest({
               keystone,
               query: `
           mutation {
@@ -93,6 +95,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
             });
 
+            expect(errors).toBe(undefined);
+
             location = await findById('Location', location.id);
             company = await findById('Company', company.id);
 
@@ -108,7 +112,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           'during create mutation',
           runner(setupKeystone, async ({ keystone, findById }) => {
             const locationName = sampleOne(alphanumGenerator);
-            const { data } = await graphqlRequest({
+            const { data, errors } = await graphqlRequest({
               keystone,
               query: `
           mutation {
@@ -123,6 +127,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           }
       `,
             });
+
+            expect(errors).toBe(undefined);
 
             const companyId = data.createCompany.id;
             const locationId = data.createCompany.location.id;
@@ -141,7 +147,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           runner(setupKeystone, async ({ keystone, create, findById }) => {
             const locationName = sampleOne(alphanumGenerator);
             let company = await create('Company', {});
-            const { data } = await graphqlRequest({
+            const { data, errors } = await graphqlRequest({
               keystone,
               query: `
           mutation {
@@ -160,6 +166,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           }
       `,
             });
+
+            expect(errors).toBe(undefined);
 
             const locationId = data.updateCompany.location.id;
 
@@ -189,7 +197,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           expect(location.company.toString()).toBe(company.id.toString());
 
           // Run the query to disconnect the location from company
-          await graphqlRequest({
+          const { errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -208,6 +216,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         }
     `,
           });
+
+          expect(errors).toBe(undefined);
 
           // Check the link has been broken
           location = await findById('Location', location.id);
@@ -234,7 +244,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           expect(location.company.toString()).toBe(company.id.toString());
 
           // Run the query to disconnect the location from company
-          await graphqlRequest({
+          const { errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -253,6 +263,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         }
     `,
           });
+
+          expect(errors).toBe(undefined);
 
           // Check the link has been broken
           location = await findById('Location', location.id);
@@ -280,7 +292,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         expect(location.company.toString()).toBe(company.id.toString());
 
         // Run the query to disconnect the location from company
-        await graphqlRequest({
+        const { errors } = await graphqlRequest({
           keystone,
           query: `
       mutation {
@@ -290,6 +302,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       }
   `,
         });
+
+        expect(errors).toBe(undefined);
 
         // Check the link has been broken
         location = await findById('Location', location.id);

--- a/api-tests/relationships/nested-mutations/two-way-backreference/to-one.test.js
+++ b/api-tests/relationships/nested-mutations/two-way-backreference/to-one.test.js
@@ -34,10 +34,10 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       describe('nested connect', () => {
         test(
           'during create mutation',
-          runner(setupKeystone, async ({ server: { server }, create, findById }) => {
+          runner(setupKeystone, async ({ keystone, create, findById }) => {
             let location = await create('Location', {});
-            const queryResult = await graphqlRequest({
-              server,
+            const { data } = await graphqlRequest({
+              keystone,
               query: `
           mutation {
             createCompany(data: {
@@ -52,9 +52,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
             });
 
-            expect(queryResult.body).not.toHaveProperty('errors');
-
-            const companyId = queryResult.body.data.createCompany.id;
+            const companyId = data.createCompany.id;
 
             location = await findById('Location', location.id);
             const company = await findById('Company', companyId);
@@ -67,7 +65,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
         test(
           'during update mutation',
-          runner(setupKeystone, async ({ server: { server }, create, findById }) => {
+          runner(setupKeystone, async ({ keystone, create, findById }) => {
             // Manually setup a connected Company <-> Location
             let location = await create('Location', {});
             let company = await create('Company', {});
@@ -76,8 +74,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(company.location).toBe(undefined);
             expect(location.company).toBe(undefined);
 
-            const queryResult = await graphqlRequest({
-              server,
+            await graphqlRequest({
+              keystone,
               query: `
           mutation {
             updateCompany(
@@ -95,8 +93,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
             });
 
-            expect(queryResult.body).not.toHaveProperty('errors');
-
             location = await findById('Location', location.id);
             company = await findById('Company', company.id);
 
@@ -110,10 +106,10 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       describe('nested create', () => {
         test(
           'during create mutation',
-          runner(setupKeystone, async ({ server: { server }, findById }) => {
+          runner(setupKeystone, async ({ keystone, findById }) => {
             const locationName = sampleOne(alphanumGenerator);
-            const queryResult = await graphqlRequest({
-              server,
+            const { data } = await graphqlRequest({
+              keystone,
               query: `
           mutation {
             createCompany(data: {
@@ -128,10 +124,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
             });
 
-            expect(queryResult.body).not.toHaveProperty('errors');
-
-            const companyId = queryResult.body.data.createCompany.id;
-            const locationId = queryResult.body.data.createCompany.location.id;
+            const companyId = data.createCompany.id;
+            const locationId = data.createCompany.location.id;
 
             const location = await findById('Location', locationId);
             const company = await findById('Company', companyId);
@@ -144,11 +138,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
         test(
           'during update mutation',
-          runner(setupKeystone, async ({ server: { server }, create, findById }) => {
+          runner(setupKeystone, async ({ keystone, create, findById }) => {
             const locationName = sampleOne(alphanumGenerator);
             let company = await create('Company', {});
-            const queryResult = await graphqlRequest({
-              server,
+            const { data } = await graphqlRequest({
+              keystone,
               query: `
           mutation {
             updateCompany(
@@ -167,9 +161,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
             });
 
-            expect(queryResult.body).not.toHaveProperty('errors');
-
-            const locationId = queryResult.body.data.updateCompany.location.id;
+            const locationId = data.updateCompany.location.id;
 
             const location = await findById('Location', locationId);
             company = await findById('Company', company.id);
@@ -183,7 +175,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
       test(
         'nested disconnect during update mutation',
-        runner(setupKeystone, async ({ server: { server }, create, update, findById }) => {
+        runner(setupKeystone, async ({ keystone, create, update, findById }) => {
           // Manually setup a connected Company <-> Location
           let location = await create('Location', {});
           let company = await create('Company', { location: location.id });
@@ -197,8 +189,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           expect(location.company.toString()).toBe(company.id.toString());
 
           // Run the query to disconnect the location from company
-          const queryResult = await graphqlRequest({
-            server,
+          await graphqlRequest({
+            keystone,
             query: `
         mutation {
           updateCompany(
@@ -217,8 +209,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     `,
           });
 
-          expect(queryResult.body).not.toHaveProperty('errors');
-
           // Check the link has been broken
           location = await findById('Location', location.id);
           company = await findById('Company', company.id);
@@ -230,7 +220,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
       test(
         'nested disconnectAll during update mutation',
-        runner(setupKeystone, async ({ server: { server }, create, update, findById }) => {
+        runner(setupKeystone, async ({ keystone, create, update, findById }) => {
           // Manually setup a connected Company <-> Location
           let location = await create('Location', {});
           let company = await create('Company', { location: location.id });
@@ -244,8 +234,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           expect(location.company.toString()).toBe(company.id.toString());
 
           // Run the query to disconnect the location from company
-          const queryResult = await graphqlRequest({
-            server,
+          await graphqlRequest({
+            keystone,
             query: `
         mutation {
           updateCompany(
@@ -264,8 +254,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     `,
           });
 
-          expect(queryResult.body).not.toHaveProperty('errors');
-
           // Check the link has been broken
           location = await findById('Location', location.id);
           company = await findById('Company', company.id);
@@ -278,7 +266,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
     test(
       'one to one relationship back reference on deletes',
-      runner(setupKeystone, async ({ server: { server }, create, update, findById }) => {
+      runner(setupKeystone, async ({ keystone, create, update, findById }) => {
         // Manually setup a connected Company <-> Location
         let location = await create('Location', {});
         let company = await create('Company', { location: location.id });
@@ -292,8 +280,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         expect(location.company.toString()).toBe(company.id.toString());
 
         // Run the query to disconnect the location from company
-        const queryResult = await graphqlRequest({
-          server,
+        await graphqlRequest({
+          keystone,
           query: `
       mutation {
         deleteCompany(id: "${company.id}") {
@@ -302,8 +290,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       }
   `,
         });
-
-        expect(queryResult.body).not.toHaveProperty('errors');
 
         // Check the link has been broken
         location = await findById('Location', location.id);

--- a/api-tests/uniqueness/unique.test.js
+++ b/api-tests/uniqueness/unique.test.js
@@ -66,7 +66,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         'Configuring uniqueness on one field does not affect others',
         runner(setupKeystone, async ({ keystone }) => {
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -76,6 +76,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
+          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('foo.id');
           expect(data).toHaveProperty('bar.id');
         })

--- a/api-tests/uniqueness/unique.test.js
+++ b/api-tests/uniqueness/unique.test.js
@@ -21,9 +21,9 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     describe('uniqueness', () => {
       test(
         'uniqueness is enforced over multiple mutations',
-        runner(setupKeystone, async ({ server: { server } }) => {
-          const queryUser = await graphqlRequest({
-            server,
+        runner(setupKeystone, async ({ keystone }) => {
+          await graphqlRequest({
+            keystone,
             query: `
         mutation {
           createUser(data: { email: "hi@test.com" }) { id }
@@ -31,10 +31,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(queryUser.body).not.toHaveProperty('errors');
-
-          const queryUser2 = await graphqlRequest({
-            server,
+          const { errors } = await graphqlRequest({
+            keystone,
             query: `
         mutation {
           createUser(data: { email: "hi@test.com" }) { id }
@@ -42,16 +40,16 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(queryUser2.body).toHaveProperty('errors.0.message');
-          expect(queryUser2.body.errors[0].message).toEqual(expect.stringMatching(/duplicate key/));
+          expect(errors).toHaveProperty('0.message');
+          expect(errors[0].message).toEqual(expect.stringMatching(/duplicate key/));
         })
       );
 
       test(
         'uniqueness is enforced over single mutation',
-        runner(setupKeystone, async ({ server: { server } }) => {
-          const queryUser = await graphqlRequest({
-            server,
+        runner(setupKeystone, async ({ keystone }) => {
+          const { errors } = await graphqlRequest({
+            keystone,
             query: `
         mutation {
           foo: createUser(data: { email: "hi@test.com" }) { id }
@@ -60,16 +58,16 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(queryUser.body).toHaveProperty('errors.0.message');
-          expect(queryUser.body.errors[0].message).toEqual(expect.stringMatching(/duplicate key/));
+          expect(errors).toHaveProperty('0.message');
+          expect(errors[0].message).toEqual(expect.stringMatching(/duplicate key/));
         })
       );
 
       test(
         'Configuring uniqueness on one field does not affect others',
-        runner(setupKeystone, async ({ server: { server } }) => {
-          const queryUser = await graphqlRequest({
-            server,
+        runner(setupKeystone, async ({ keystone }) => {
+          const { data } = await graphqlRequest({
+            keystone,
             query: `
         mutation {
           foo: createUser(data: { email: "1", username: "jess" }) { id }
@@ -78,18 +76,9 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(queryUser.body).not.toHaveProperty('errors');
-          expect(queryUser.body).toHaveProperty('data.foo.id');
-          expect(queryUser.body).toHaveProperty('data.bar.id');
+          expect(data).toHaveProperty('foo.id');
+          expect(data).toHaveProperty('bar.id');
         })
-      );
-
-      test.failing(
-        'adding uniqueness to a field containing non-unique data will fail connection',
-        async () => {
-          // I have no idea how to test this :/
-          expect(false).toBe(true);
-        }
       );
     });
   })

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "express-pino-logger": "^4.0.0",
     "express-react-views": "^0.11.0",
     "express-session": "^1.15.6",
-    "extract-stack": "^1.0.0",
     "facepaint": "^1.2.1",
     "falsey": "^1.0.0",
     "fast-memoize": "^2.4.0",

--- a/packages/fields/tests/idFilterTests.js
+++ b/packages/fields/tests/idFilterTests.js
@@ -25,15 +25,15 @@ const getIDs = async keystone => {
 };
 
 export const filterTests = withKeystone => {
-  const match = (server, filter, targets) => {
-    return matchFilter(server, filter, '{ id name }', targets, 'name');
+  const match = (keystone, filter, targets) => {
+    return matchFilter(keystone, filter, '{ id name }', targets, 'name');
   };
 
   test(
     'No filter',
-    withKeystone(async ({ server: { server, keystone } }) => {
+    withKeystone(async ({ keystone }) => {
       const IDs = await getIDs(keystone);
-      return match(server, undefined, [
+      return match(keystone, undefined, [
         { id: IDs['person1'], name: 'person1' },
         { id: IDs['person2'], name: 'person2' },
         { id: IDs['person3'], name: 'person3' },
@@ -44,9 +44,9 @@ export const filterTests = withKeystone => {
 
   test(
     'Empty filter',
-    withKeystone(async ({ server: { server, keystone } }) => {
+    withKeystone(async ({ keystone }) => {
       const IDs = await getIDs(keystone);
-      return match(server, 'where: { }', [
+      return match(keystone, 'where: { }', [
         { id: IDs['person1'], name: 'person1' },
         { id: IDs['person2'], name: 'person2' },
         { id: IDs['person3'], name: 'person3' },
@@ -57,19 +57,19 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: id',
-    withKeystone(async ({ server: { server, keystone } }) => {
+    withKeystone(async ({ keystone }) => {
       const IDs = await getIDs(keystone);
       const id = IDs['person2'];
-      return match(server, `where: { id: "${id}" }`, [{ id: IDs['person2'], name: 'person2' }]);
+      return match(keystone, `where: { id: "${id}" }`, [{ id: IDs['person2'], name: 'person2' }]);
     })
   );
 
   test(
     'Filter: id_not',
-    withKeystone(async ({ server: { server, keystone } }) => {
+    withKeystone(async ({ keystone }) => {
       const IDs = await getIDs(keystone);
       const id = IDs['person2'];
-      return match(server, `where: { id_not: "${id}" }`, [
+      return match(keystone, `where: { id_not: "${id}" }`, [
         { id: IDs['person1'], name: 'person1' },
         { id: IDs['person3'], name: 'person3' },
         { id: IDs['person4'], name: 'person4' },
@@ -79,11 +79,11 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: id_in',
-    withKeystone(async ({ server: { server, keystone } }) => {
+    withKeystone(async ({ keystone }) => {
       const IDs = await getIDs(keystone);
       const id2 = IDs['person2'];
       const id3 = IDs['person3'];
-      return match(server, `where: { id_in: ["${id2}", "${id3}"] }`, [
+      return match(keystone, `where: { id_in: ["${id2}", "${id3}"] }`, [
         { id: IDs['person2'], name: 'person2' },
         { id: IDs['person3'], name: 'person3' },
       ]);
@@ -92,25 +92,25 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: id_in - empty list',
-    withKeystone(({ server: { server } }) => {
-      return match(server, 'where: { id_in: [] }', []);
+    withKeystone(({ keystone }) => {
+      return match(keystone, 'where: { id_in: [] }', []);
     })
   );
 
   test(
     'Filter: id_in - missing id',
-    withKeystone(({ server: { server } }) => {
-      return match(server, 'where: { id_in: ["0123456789abcdef01234567"] }', []);
+    withKeystone(({ keystone }) => {
+      return match(keystone, 'where: { id_in: ["0123456789abcdef01234567"] }', []);
     })
   );
 
   test(
     'Filter: id_not_in',
-    withKeystone(async ({ server: { server, keystone } }) => {
+    withKeystone(async ({ keystone }) => {
       const IDs = await getIDs(keystone);
       const id2 = IDs['person2'];
       const id3 = IDs['person3'];
-      return match(server, `where: { id_not_in: ["${id2}", "${id3}"] }`, [
+      return match(keystone, `where: { id_not_in: ["${id2}", "${id3}"] }`, [
         { id: IDs['person1'], name: 'person1' },
         { id: IDs['person4'], name: 'person4' },
       ]);
@@ -119,9 +119,9 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: id_not_in - empty list',
-    withKeystone(async ({ server: { server, keystone } }) => {
+    withKeystone(async ({ keystone }) => {
       const IDs = await getIDs(keystone);
-      return match(server, 'where: { id_not_in: [] }', [
+      return match(keystone, 'where: { id_not_in: [] }', [
         { id: IDs['person1'], name: 'person1' },
         { id: IDs['person2'], name: 'person2' },
         { id: IDs['person3'], name: 'person3' },
@@ -132,10 +132,10 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: id_not_in - missing id',
-    withKeystone(async ({ server: { server, keystone }, adapterName }) => {
+    withKeystone(async ({ keystone, adapterName }) => {
       const IDs = await getIDs(keystone);
       const fakeID = adapterName === 'mongoose' ? '"0123456789abcdef01234567"' : 1000;
-      return match(server, `where: { id_not_in: [${fakeID}] }`, [
+      return match(keystone, `where: { id_not_in: [${fakeID}] }`, [
         { id: IDs['person1'], name: 'person1' },
         { id: IDs['person2'], name: 'person2' },
         { id: IDs['person3'], name: 'person3' },

--- a/packages/fields/types/CalendarDay/filterTests.js
+++ b/packages/fields/types/CalendarDay/filterTests.js
@@ -22,13 +22,13 @@ export const initItems = () => {
 };
 
 export const filterTests = withKeystone => {
-  const match = (server, filter, targets) =>
-    matchFilter(server, filter, '{ name, birthday }', targets, 'name');
+  const match = (keystone, filter, targets) =>
+    matchFilter(keystone, filter, '{ name, birthday }', targets, 'name');
 
   test(
     'No filter',
-    withKeystone(({ server: { server } }) =>
-      match(server, undefined, [
+    withKeystone(({ keystone }) =>
+      match(keystone, undefined, [
         { name: 'person1', birthday: '1990-12-31' },
         { name: 'person2', birthday: '2000-01-20' },
         { name: 'person3', birthday: '1950-10-01' },
@@ -40,8 +40,8 @@ export const filterTests = withKeystone => {
 
   test(
     'Empty filter',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { }', [
         { name: 'person1', birthday: '1990-12-31' },
         { name: 'person2', birthday: '2000-01-20' },
         { name: 'person3', birthday: '1950-10-01' },
@@ -53,8 +53,8 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: birthday',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { birthday: "2000-01-20" }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { birthday: "2000-01-20" }', [
         { name: 'person2', birthday: '2000-01-20' },
       ])
     )
@@ -62,8 +62,8 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: birthday_not',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { birthday_not: "2000-01-20" }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { birthday_not: "2000-01-20" }', [
         { name: 'person1', birthday: '1990-12-31' },
         { name: 'person3', birthday: '1950-10-01' },
         { name: 'person4', birthday: '1666-04-12' },
@@ -74,8 +74,8 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: birthday_not null',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { birthday_not: null }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { birthday_not: null }', [
         { name: 'person1', birthday: '1990-12-31' },
         { name: 'person2', birthday: '2000-01-20' },
         { name: 'person3', birthday: '1950-10-01' },
@@ -86,8 +86,8 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: birthday_lt',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { birthday_lt: "1950-10-01" }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { birthday_lt: "1950-10-01" }', [
         { name: 'person4', birthday: '1666-04-12' },
       ])
     )
@@ -95,8 +95,8 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: birthday_lte',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { birthday_lte: "1950-10-01" }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { birthday_lte: "1950-10-01" }', [
         { name: 'person3', birthday: '1950-10-01' },
         { name: 'person4', birthday: '1666-04-12' },
       ])
@@ -105,8 +105,8 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: birthday_gt',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { birthday_gt: "1950-10-01" }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { birthday_gt: "1950-10-01" }', [
         { name: 'person1', birthday: '1990-12-31' },
         { name: 'person2', birthday: '2000-01-20' },
       ])
@@ -115,8 +115,8 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: birthday_gte',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { birthday_gte: "1950-10-01" }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { birthday_gte: "1950-10-01" }', [
         { name: 'person1', birthday: '1990-12-31' },
         { name: 'person2', birthday: '2000-01-20' },
         { name: 'person3', birthday: '1950-10-01' },
@@ -126,13 +126,13 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: birthday_in (empty list)',
-    withKeystone(({ server: { server } }) => match(server, 'where: { birthday_in: [] }', []))
+    withKeystone(({ keystone }) => match(keystone, 'where: { birthday_in: [] }', []))
   );
 
   test(
     'Filter: birthday_not_in (empty list)',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { birthday_not_in: [] }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { birthday_not_in: [] }', [
         { name: 'person1', birthday: '1990-12-31' },
         { name: 'person2', birthday: '2000-01-20' },
         { name: 'person3', birthday: '1950-10-01' },
@@ -144,8 +144,8 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: birthday_in',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { birthday_in: ["1990-12-31", "2000-01-20", "1950-10-01"] }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { birthday_in: ["1990-12-31", "2000-01-20", "1950-10-01"] }', [
         { name: 'person1', birthday: '1990-12-31' },
         { name: 'person2', birthday: '2000-01-20' },
         { name: 'person3', birthday: '1950-10-01' },
@@ -155,8 +155,8 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: birthday_not_in',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { birthday_not_in: ["1990-12-31", "2000-01-20", "1950-10-01"] }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { birthday_not_in: ["1990-12-31", "2000-01-20", "1950-10-01"] }', [
         { name: 'person4', birthday: '1666-04-12' },
         { name: 'person5', birthday: null },
       ])
@@ -165,15 +165,15 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: birthday_in null',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { birthday_in: [null] }', [{ name: 'person5', birthday: null }])
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { birthday_in: [null] }', [{ name: 'person5', birthday: null }])
     )
   );
 
   test(
     'Filter: birthday_not_in null',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { birthday_not_in: [null] }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { birthday_not_in: [null] }', [
         { name: 'person1', birthday: '1990-12-31' },
         { name: 'person2', birthday: '2000-01-20' },
         { name: 'person3', birthday: '1950-10-01' },

--- a/packages/fields/types/Checkbox/filterTests.js
+++ b/packages/fields/types/Checkbox/filterTests.js
@@ -21,13 +21,13 @@ export const initItems = () => {
 };
 
 export const filterTests = withKeystone => {
-  const match = (server, filter, targets) =>
-    matchFilter(server, filter, '{ name enabled }', targets, 'name');
+  const match = (keystone, filter, targets) =>
+    matchFilter(keystone, filter, '{ name enabled }', targets, 'name');
 
   test(
     'No filter',
-    withKeystone(({ server: { server } }) =>
-      match(server, undefined, [
+    withKeystone(({ keystone }) =>
+      match(keystone, undefined, [
         { name: 'person1', enabled: true },
         { name: 'person2', enabled: false },
         { name: 'person3', enabled: null },
@@ -38,8 +38,8 @@ export const filterTests = withKeystone => {
 
   test(
     'Empty filter',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { }', [
         { name: 'person1', enabled: true },
         { name: 'person2', enabled: false },
         { name: 'person3', enabled: null },
@@ -50,8 +50,8 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: enabled true',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { enabled: true }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { enabled: true }', [
         { name: 'person1', enabled: true },
         { name: 'person4', enabled: true },
       ])
@@ -60,15 +60,15 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: enabled false',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { enabled: false }', [{ name: 'person2', enabled: false }])
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { enabled: false }', [{ name: 'person2', enabled: false }])
     )
   );
 
   test(
     'Filter: enabled_not true',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { enabled_not: true }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { enabled_not: true }', [
         { name: 'person2', enabled: false },
         { name: 'person3', enabled: null },
       ])
@@ -77,8 +77,8 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: enabled_not false',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { enabled_not: false }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { enabled_not: false }', [
         { name: 'person1', enabled: true },
         { name: 'person3', enabled: null },
         { name: 'person4', enabled: true },

--- a/packages/fields/types/DateTime/filterTests.js
+++ b/packages/fields/types/DateTime/filterTests.js
@@ -22,13 +22,13 @@ export const initItems = () => {
 };
 
 export const filterTests = withKeystone => {
-  const match = (server, filter, targets, forceSortBy = 'name') =>
-    matchFilter(server, filter, '{ name, lastOnline }', targets, forceSortBy);
+  const match = (keystone, filter, targets, forceSortBy = 'name') =>
+    matchFilter(keystone, filter, '{ name, lastOnline }', targets, forceSortBy);
 
   test(
     'No filter',
-    withKeystone(({ server: { server } }) =>
-      match(server, undefined, [
+    withKeystone(({ keystone }) =>
+      match(keystone, undefined, [
         { name: 'person1', lastOnline: '1990-12-31T12:34:56.789+01:23' },
         { name: 'person2', lastOnline: '2000-01-20T00:08:00.000+10:00' },
         { name: 'person3', lastOnline: '1950-10-01T23:59:59.999-10:00' },
@@ -40,8 +40,8 @@ export const filterTests = withKeystone => {
 
   test(
     'Empty filter',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { }', [
         { name: 'person1', lastOnline: '1990-12-31T12:34:56.789+01:23' },
         { name: 'person2', lastOnline: '2000-01-20T00:08:00.000+10:00' },
         { name: 'person3', lastOnline: '1950-10-01T23:59:59.999-10:00' },
@@ -53,8 +53,8 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: lastOnline',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { lastOnline: "2000-01-20T00:08:00.000+10:00" }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { lastOnline: "2000-01-20T00:08:00.000+10:00" }', [
         { name: 'person2', lastOnline: '2000-01-20T00:08:00.000+10:00' },
       ])
     )
@@ -62,8 +62,8 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: lastOnline_not',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { lastOnline_not: "2000-01-20T00:08:00.000+10:00" }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { lastOnline_not: "2000-01-20T00:08:00.000+10:00" }', [
         { name: 'person1', lastOnline: '1990-12-31T12:34:56.789+01:23' },
         { name: 'person3', lastOnline: '1950-10-01T23:59:59.999-10:00' },
         { name: 'person4', lastOnline: '1666-04-12T00:08:00.000+10:00' },
@@ -74,8 +74,8 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: lastOnline_not null',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { lastOnline_not: null }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { lastOnline_not: null }', [
         { name: 'person1', lastOnline: '1990-12-31T12:34:56.789+01:23' },
         { name: 'person2', lastOnline: '2000-01-20T00:08:00.000+10:00' },
         { name: 'person3', lastOnline: '1950-10-01T23:59:59.999-10:00' },
@@ -86,8 +86,8 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: lastOnline_lt',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { lastOnline_lt: "1950-10-01T23:59:59.999-10:00" }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { lastOnline_lt: "1950-10-01T23:59:59.999-10:00" }', [
         { name: 'person4', lastOnline: '1666-04-12T00:08:00.000+10:00' },
       ])
     )
@@ -95,8 +95,8 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: lastOnline_lte',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { lastOnline_lte: "1950-10-01T23:59:59.999-10:00" }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { lastOnline_lte: "1950-10-01T23:59:59.999-10:00" }', [
         { name: 'person3', lastOnline: '1950-10-01T23:59:59.999-10:00' },
         { name: 'person4', lastOnline: '1666-04-12T00:08:00.000+10:00' },
       ])
@@ -105,8 +105,8 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: lastOnline_gt',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { lastOnline_gt: "1950-10-01T23:59:59.999-10:00" }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { lastOnline_gt: "1950-10-01T23:59:59.999-10:00" }', [
         { name: 'person1', lastOnline: '1990-12-31T12:34:56.789+01:23' },
         { name: 'person2', lastOnline: '2000-01-20T00:08:00.000+10:00' },
       ])
@@ -115,8 +115,8 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: lastOnline_gte',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { lastOnline_gte: "1950-10-01T23:59:59.999-10:00" }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { lastOnline_gte: "1950-10-01T23:59:59.999-10:00" }', [
         { name: 'person1', lastOnline: '1990-12-31T12:34:56.789+01:23' },
         { name: 'person2', lastOnline: '2000-01-20T00:08:00.000+10:00' },
         { name: 'person3', lastOnline: '1950-10-01T23:59:59.999-10:00' },
@@ -126,13 +126,13 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: lastOnline_in (empty list)',
-    withKeystone(({ server: { server } }) => match(server, 'where: { lastOnline_in: [] }', []))
+    withKeystone(({ keystone }) => match(keystone, 'where: { lastOnline_in: [] }', []))
   );
 
   test(
     'Filter: lastOnline_not_in (empty list)',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { lastOnline_not_in: [] }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { lastOnline_not_in: [] }', [
         { name: 'person1', lastOnline: '1990-12-31T12:34:56.789+01:23' },
         { name: 'person2', lastOnline: '2000-01-20T00:08:00.000+10:00' },
         { name: 'person3', lastOnline: '1950-10-01T23:59:59.999-10:00' },
@@ -144,9 +144,9 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: lastOnline_in',
-    withKeystone(({ server: { server } }) =>
+    withKeystone(({ keystone }) =>
       match(
-        server,
+        keystone,
         'where: { lastOnline_in: ["1990-12-31T12:34:56.789+01:23", "2000-01-20T00:08:00.000+10:00", "1950-10-01T23:59:59.999-10:00"] }',
         [
           { name: 'person1', lastOnline: '1990-12-31T12:34:56.789+01:23' },
@@ -159,9 +159,9 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: lastOnline_not_in',
-    withKeystone(({ server: { server } }) =>
+    withKeystone(({ keystone }) =>
       match(
-        server,
+        keystone,
         'where: { lastOnline_not_in: ["1990-12-31T12:34:56.789+01:23", "2000-01-20T00:08:00.000+10:00", "1950-10-01T23:59:59.999-10:00"] }',
         [
           { name: 'person4', lastOnline: '1666-04-12T00:08:00.000+10:00' },
@@ -173,15 +173,15 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: lastOnline_in null',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { lastOnline_in: [null] }', [{ name: 'person5', lastOnline: null }])
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { lastOnline_in: [null] }', [{ name: 'person5', lastOnline: null }])
     )
   );
 
   test(
     'Filter: lastOnline_not_in null',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { lastOnline_not_in: [null] }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { lastOnline_not_in: [null] }', [
         { name: 'person1', lastOnline: '1990-12-31T12:34:56.789+01:23' },
         { name: 'person2', lastOnline: '2000-01-20T00:08:00.000+10:00' },
         { name: 'person3', lastOnline: '1950-10-01T23:59:59.999-10:00' },
@@ -192,9 +192,9 @@ export const filterTests = withKeystone => {
 
   test(
     'Sorting: orderBy: lastOnline_ASC',
-    withKeystone(({ server: { server }, adapterName }) =>
+    withKeystone(({ keystone, adapterName }) =>
       match(
-        server,
+        keystone,
         'orderBy: "lastOnline_ASC"',
         adapterName === 'mongoose'
           ? [
@@ -218,9 +218,9 @@ export const filterTests = withKeystone => {
 
   test(
     'Sorting: orderBy: lastOnline_DESC',
-    withKeystone(({ server: { server }, adapterName }) =>
+    withKeystone(({ keystone, adapterName }) =>
       match(
-        server,
+        keystone,
         'orderBy: "lastOnline_DESC"',
         adapterName === 'mongoose'
           ? [

--- a/packages/fields/types/Decimal/filterTests.js
+++ b/packages/fields/types/Decimal/filterTests.js
@@ -22,13 +22,13 @@ export const initItems = () => {
 };
 
 export const filterTests = withKeystone => {
-  const match = (server, filter, targets) =>
-    matchFilter(server, filter, '{ name, price }', targets, 'name');
+  const match = (keystone, filter, targets) =>
+    matchFilter(keystone, filter, '{ name, price }', targets, 'name');
 
   test(
     'No filter',
-    withKeystone(({ server: { server } }) =>
-      match(server, undefined, [
+    withKeystone(({ keystone }) =>
+      match(keystone, undefined, [
         { name: 'price1', price: '50.00' },
         { name: 'price2', price: '0.01' },
         { name: 'price3', price: '2000.00' },
@@ -40,8 +40,8 @@ export const filterTests = withKeystone => {
 
   test(
     'Empty filter',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { }', [
         { name: 'price1', price: '50.00' },
         { name: 'price2', price: '0.01' },
         { name: 'price3', price: '2000.00' },
@@ -53,15 +53,15 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: price',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { price: "50.00" }', [{ name: 'price1', price: '50.00' }])
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { price: "50.00" }', [{ name: 'price1', price: '50.00' }])
     )
   );
 
   test(
     'Filter: price_not',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { price_not: "50.00" }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { price_not: "50.00" }', [
         { name: 'price2', price: '0.01' },
         { name: 'price3', price: '2000.00' },
         { name: 'price4', price: '40000.00' },
@@ -72,15 +72,15 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: price_lt',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { price_lt: "50.00" }', [{ name: 'price2', price: '0.01' }])
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { price_lt: "50.00" }', [{ name: 'price2', price: '0.01' }])
     )
   );
 
   test(
     'Filter: price_lte',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { price_lte: "2000.00" }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { price_lte: "2000.00" }', [
         { name: 'price1', price: '50.00' },
         { name: 'price2', price: '0.01' },
         { name: 'price3', price: '2000.00' },
@@ -90,15 +90,15 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: price_gt',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { price_gt: "2000.00" }', [{ name: 'price4', price: '40000.00' }])
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { price_gt: "2000.00" }', [{ name: 'price4', price: '40000.00' }])
     )
   );
 
   test(
     'Filter: price_gte',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { price_gte: "2000.00" }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { price_gte: "2000.00" }', [
         { name: 'price3', price: '2000.00' },
         { name: 'price4', price: '40000.00' },
       ])

--- a/packages/fields/types/Float/filterTests.js
+++ b/packages/fields/types/Float/filterTests.js
@@ -17,314 +17,167 @@ export const getTestFields = () => {
 
 export const initItems = () => {
   return [
-    {
-      name: 'post1',
-      stars: 0,
-    },
-    {
-      name: 'post2',
-      stars: 1.2,
-    },
-    {
-      name: 'post3',
-      stars: 2.3,
-    },
-    {
-      name: 'post4',
-      stars: 3,
-    },
-    {
-      name: 'post5',
-      stars: null,
-    },
+    { name: 'post1', stars: 0 },
+    { name: 'post2', stars: 1.2 },
+    { name: 'post3', stars: 2.3 },
+    { name: 'post4', stars: 3 },
+    { name: 'post5', stars: null },
   ];
 };
 
 export const filterTests = withKeystone => {
-  const match = (server, filter, targets) =>
-    matchFilter(server, filter, '{ name, stars }', targets, 'name');
+  const match = (keystone, filter, targets) =>
+    matchFilter(keystone, filter, '{ name, stars }', targets, 'name');
 
   test(
     'No filter',
-    withKeystone(({ server: { server } }) =>
-      match(server, undefined, [
-        {
-          name: 'post1',
-          stars: 0,
-        },
-        {
-          name: 'post2',
-          stars: 1.2,
-        },
-        {
-          name: 'post3',
-          stars: 2.3,
-        },
-        {
-          name: 'post4',
-          stars: 3,
-        },
-        {
-          name: 'post5',
-          stars: null,
-        },
+    withKeystone(({ keystone }) =>
+      match(keystone, undefined, [
+        { name: 'post1', stars: 0 },
+        { name: 'post2', stars: 1.2 },
+        { name: 'post3', stars: 2.3 },
+        { name: 'post4', stars: 3 },
+        { name: 'post5', stars: null },
       ])
     )
   );
 
   test(
     'Empty filter',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { }', [
-        {
-          name: 'post1',
-          stars: 0,
-        },
-        {
-          name: 'post2',
-          stars: 1.2,
-        },
-        {
-          name: 'post3',
-          stars: 2.3,
-        },
-        {
-          name: 'post4',
-          stars: 3,
-        },
-        {
-          name: 'post5',
-          stars: null,
-        },
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { }', [
+        { name: 'post1', stars: 0 },
+        { name: 'post2', stars: 1.2 },
+        { name: 'post3', stars: 2.3 },
+        { name: 'post4', stars: 3 },
+        { name: 'post5', stars: null },
       ])
     )
   );
 
   test(
     'Filter: stars',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { stars: 1.2 }', [
-        {
-          name: 'post2',
-          stars: 1.2,
-        },
-      ])
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { stars: 1.2 }', [{ name: 'post2', stars: 1.2 }])
     )
   );
 
   test(
     'Filter: stars_not',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { stars_not: 1.2 }', [
-        {
-          name: 'post1',
-          stars: 0,
-        },
-        {
-          name: 'post3',
-          stars: 2.3,
-        },
-        {
-          name: 'post4',
-          stars: 3,
-        },
-        {
-          name: 'post5',
-          stars: null,
-        },
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { stars_not: 1.2 }', [
+        { name: 'post1', stars: 0 },
+        { name: 'post3', stars: 2.3 },
+        { name: 'post4', stars: 3 },
+        { name: 'post5', stars: null },
       ])
     )
   );
 
   test(
     'Filter: stars_not null',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { stars_not: null }', [
-        {
-          name: 'post1',
-          stars: 0,
-        },
-        {
-          name: 'post2',
-          stars: 1.2,
-        },
-        {
-          name: 'post3',
-          stars: 2.3,
-        },
-        {
-          name: 'post4',
-          stars: 3,
-        },
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { stars_not: null }', [
+        { name: 'post1', stars: 0 },
+        { name: 'post2', stars: 1.2 },
+        { name: 'post3', stars: 2.3 },
+        { name: 'post4', stars: 3 },
       ])
     )
   );
 
   test(
     'Filter: stars_lt',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { stars_lt: 2.30 }', [
-        {
-          name: 'post1',
-          stars: 0,
-        },
-        {
-          name: 'post2',
-          stars: 1.2,
-        },
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { stars_lt: 2.30 }', [
+        { name: 'post1', stars: 0 },
+        { name: 'post2', stars: 1.2 },
       ])
     )
   );
 
   test(
     'Filter: stars_lte',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { stars_lte: 2.30 }', [
-        {
-          name: 'post1',
-          stars: 0,
-        },
-        {
-          name: 'post2',
-          stars: 1.2,
-        },
-        {
-          name: 'post3',
-          stars: 2.3,
-        },
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { stars_lte: 2.30 }', [
+        { name: 'post1', stars: 0 },
+        { name: 'post2', stars: 1.2 },
+        { name: 'post3', stars: 2.3 },
       ])
     )
   );
 
   test(
     'Filter: stars_gt',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { stars_gt: 2.30 }', [
-        {
-          name: 'post4',
-          stars: 3,
-        },
-      ])
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { stars_gt: 2.30 }', [{ name: 'post4', stars: 3 }])
     )
   );
 
   test(
     'Filter: stars_gte',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { stars_gte: 2.30 }', [
-        {
-          name: 'post3',
-          stars: 2.3,
-        },
-        {
-          name: 'post4',
-          stars: 3,
-        },
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { stars_gte: 2.30 }', [
+        { name: 'post3', stars: 2.3 },
+        { name: 'post4', stars: 3 },
       ])
     )
   );
 
   test(
     'Filter: stars_in (empty list)',
-    withKeystone(({ server: { server } }) => match(server, 'where: { stars_in: [] }', []))
+    withKeystone(({ keystone }) => match(keystone, 'where: { stars_in: [] }', []))
   );
 
   test(
     'Filter: stars_not_in (empty list)',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { stars_not_in: [] }', [
-        {
-          name: 'post1',
-          stars: 0,
-        },
-        {
-          name: 'post2',
-          stars: 1.2,
-        },
-        {
-          name: 'post3',
-          stars: 2.3,
-        },
-        {
-          name: 'post4',
-          stars: 3,
-        },
-        {
-          name: 'post5',
-          stars: null,
-        },
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { stars_not_in: [] }', [
+        { name: 'post1', stars: 0 },
+        { name: 'post2', stars: 1.2 },
+        { name: 'post3', stars: 2.3 },
+        { name: 'post4', stars: 3 },
+        { name: 'post5', stars: null },
       ])
     )
   );
 
   test(
     'Filter: stars_in',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { stars_in: [0, 1.2, 2.30] }', [
-        {
-          name: 'post1',
-          stars: 0,
-        },
-        {
-          name: 'post2',
-          stars: 1.2,
-        },
-        {
-          name: 'post3',
-          stars: 2.3,
-        },
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { stars_in: [0, 1.2, 2.30] }', [
+        { name: 'post1', stars: 0 },
+        { name: 'post2', stars: 1.2 },
+        { name: 'post3', stars: 2.3 },
       ])
     )
   );
 
   test(
     'Filter: stars_not_in',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { stars_not_in: [0, 1.2, 2.30] }', [
-        {
-          name: 'post4',
-          stars: 3,
-        },
-        {
-          name: 'post5',
-          stars: null,
-        },
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { stars_not_in: [0, 1.2, 2.30] }', [
+        { name: 'post4', stars: 3 },
+        { name: 'post5', stars: null },
       ])
     )
   );
 
   test(
     'Filter: stars_in null',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { stars_in: [null] }', [
-        {
-          name: 'post5',
-          stars: null,
-        },
-      ])
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { stars_in: [null] }', [{ name: 'post5', stars: null }])
     )
   );
 
   test(
     'Filter: stars_not_in null',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { stars_not_in: [null] }', [
-        {
-          name: 'post1',
-          stars: 0,
-        },
-        {
-          name: 'post2',
-          stars: 1.2,
-        },
-        {
-          name: 'post3',
-          stars: 2.3,
-        },
-        {
-          name: 'post4',
-          stars: 3,
-        },
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { stars_not_in: [null] }', [
+        { name: 'post1', stars: 0 },
+        { name: 'post2', stars: 1.2 },
+        { name: 'post3', stars: 2.3 },
+        { name: 'post4', stars: 3 },
       ])
     )
   );

--- a/packages/fields/types/Integer/filterTests.js
+++ b/packages/fields/types/Integer/filterTests.js
@@ -22,13 +22,13 @@ export const initItems = () => {
 };
 
 export const filterTests = withKeystone => {
-  const match = (server, filter, targets) =>
-    matchFilter(server, filter, '{ name, count }', targets, 'name');
+  const match = (keystone, filter, targets) =>
+    matchFilter(keystone, filter, '{ name, count }', targets, 'name');
 
   test(
     'No filter',
-    withKeystone(({ server: { server } }) =>
-      match(server, undefined, [
+    withKeystone(({ keystone }) =>
+      match(keystone, undefined, [
         { name: 'person1', count: 0 },
         { name: 'person2', count: 1 },
         { name: 'person3', count: 2 },
@@ -40,8 +40,8 @@ export const filterTests = withKeystone => {
 
   test(
     'Empty filter',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { }', [
         { name: 'person1', count: 0 },
         { name: 'person2', count: 1 },
         { name: 'person3', count: 2 },
@@ -53,15 +53,15 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: count',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { count: 1 }', [{ name: 'person2', count: 1 }])
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { count: 1 }', [{ name: 'person2', count: 1 }])
     )
   );
 
   test(
     'Filter: count_not',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { count_not: 1 }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { count_not: 1 }', [
         { name: 'person1', count: 0 },
         { name: 'person3', count: 2 },
         { name: 'person4', count: 3 },
@@ -72,8 +72,8 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: count_not null',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { count_not: null }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { count_not: null }', [
         { name: 'person1', count: 0 },
         { name: 'person2', count: 1 },
         { name: 'person3', count: 2 },
@@ -84,8 +84,8 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: count_lt',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { count_lt: 2 }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { count_lt: 2 }', [
         { name: 'person1', count: 0 },
         { name: 'person2', count: 1 },
       ])
@@ -94,8 +94,8 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: count_lte',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { count_lte: 2 }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { count_lte: 2 }', [
         { name: 'person1', count: 0 },
         { name: 'person2', count: 1 },
         { name: 'person3', count: 2 },
@@ -105,15 +105,15 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: count_gt',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { count_gt: 2 }', [{ name: 'person4', count: 3 }])
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { count_gt: 2 }', [{ name: 'person4', count: 3 }])
     )
   );
 
   test(
     'Filter: count_gte',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { count_gte: 2 }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { count_gte: 2 }', [
         { name: 'person3', count: 2 },
         { name: 'person4', count: 3 },
       ])
@@ -122,13 +122,13 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: count_in (empty list)',
-    withKeystone(({ server: { server } }) => match(server, 'where: { count_in: [] }', []))
+    withKeystone(({ keystone }) => match(keystone, 'where: { count_in: [] }', []))
   );
 
   test(
     'Filter: count_not_in (empty list)',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { count_not_in: [] }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { count_not_in: [] }', [
         { name: 'person1', count: 0 },
         { name: 'person2', count: 1 },
         { name: 'person3', count: 2 },
@@ -140,8 +140,8 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: count_in',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { count_in: [0, 1, 2] }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { count_in: [0, 1, 2] }', [
         { name: 'person1', count: 0 },
         { name: 'person2', count: 1 },
         { name: 'person3', count: 2 },
@@ -151,8 +151,8 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: count_not_in',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { count_not_in: [0, 1, 2] }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { count_not_in: [0, 1, 2] }', [
         { name: 'person4', count: 3 },
         { name: 'person5', count: null },
       ])
@@ -161,15 +161,15 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: count_in null',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { count_in: [null] }', [{ name: 'person5', count: null }])
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { count_in: [null] }', [{ name: 'person5', count: null }])
     )
   );
 
   test(
     'Filter: count_not_in null',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { count_not_in: [null] }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { count_not_in: [null] }', [
         { name: 'person1', count: 0 },
         { name: 'person2', count: 1 },
         { name: 'person3', count: 2 },

--- a/packages/fields/types/Password/filterTests.js
+++ b/packages/fields/types/Password/filterTests.js
@@ -20,9 +20,9 @@ export const initItems = () => {
 };
 
 export const filterTests = withKeystone => {
-  const match = (server, filter, targets) =>
+  const match = (keystone, filter, targets) =>
     matchFilter(
-      server,
+      keystone,
       filter,
       '{ name password_is_set }',
       targets,
@@ -31,8 +31,8 @@ export const filterTests = withKeystone => {
 
   test(
     'No filter',
-    withKeystone(({ server: { server } }) =>
-      match(server, undefined, [
+    withKeystone(({ keystone }) =>
+      match(keystone, undefined, [
         { name: 'person1', password_is_set: true },
         { name: 'person2', password_is_set: false },
         { name: 'person3', password_is_set: true },
@@ -42,8 +42,8 @@ export const filterTests = withKeystone => {
 
   test(
     'Empty filter',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { }', [
         { name: 'person1', password_is_set: true },
         { name: 'person2', password_is_set: false },
         { name: 'person3', password_is_set: true },
@@ -53,8 +53,8 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: is_set - true',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { password_is_set: true }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { password_is_set: true }', [
         { name: 'person1', password_is_set: true },
         { name: 'person3', password_is_set: true },
       ])
@@ -63,8 +63,8 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: is_set - false',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { password_is_set: false }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { password_is_set: false }', [
         { name: 'person2', password_is_set: false },
       ])
     )

--- a/packages/fields/types/Select/filterTests.js
+++ b/packages/fields/types/Select/filterTests.js
@@ -29,9 +29,9 @@ export const initItems = () => {
 };
 
 export const filterTests = withKeystone => {
-  const match = (server, filter, targets) =>
+  const match = (keystone, filter, targets) =>
     matchFilter(
-      server,
+      keystone,
       filter,
       '{ company name }',
       targets,
@@ -40,8 +40,8 @@ export const filterTests = withKeystone => {
 
   test(
     'No filter',
-    withKeystone(({ server: { server } }) =>
-      match(server, undefined, [
+    withKeystone(({ keystone }) =>
+      match(keystone, undefined, [
         { company: 'thinkmill', name: 'a' },
         { company: 'atlassian', name: 'b' },
         { company: 'gelato', name: 'c' },
@@ -52,15 +52,15 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: company',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { company: thinkmill }', [{ company: 'thinkmill', name: 'a' }])
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { company: thinkmill }', [{ company: 'thinkmill', name: 'a' }])
     )
   );
 
   test(
     'Filter: company_not',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { company_not: thinkmill }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { company_not: thinkmill }', [
         { company: 'atlassian', name: 'b' },
         { company: 'gelato', name: 'c' },
         { company: 'cete', name: 'd' },
@@ -70,8 +70,8 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: company_in',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { company_in: [ atlassian, gelato ] }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { company_in: [ atlassian, gelato ] }', [
         { company: 'atlassian', name: 'b' },
         { company: 'gelato', name: 'c' },
       ])
@@ -80,8 +80,8 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: company_not_in',
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { company_not_in: [ atlassian, gelato ] }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { company_not_in: [ atlassian, gelato ] }', [
         { company: 'thinkmill', name: 'a' },
         { company: 'cete', name: 'd' },
       ])

--- a/packages/fields/types/Text/filterTests.js
+++ b/packages/fields/types/Text/filterTests.js
@@ -27,14 +27,14 @@ export const initItems = () => {
 // See https://github.com/keystonejs/keystone-5/issues/391
 
 export const filterTests = withKeystone => {
-  const match = (server, gqlArgs, targets) => {
-    return matchFilter(server, gqlArgs, '{ name order }', targets, 'order');
+  const match = (keystone, gqlArgs, targets) => {
+    return matchFilter(keystone, gqlArgs, '{ name order }', targets, 'order');
   };
 
   test(
     `No 'where' argument`,
-    withKeystone(({ server: { server } }) =>
-      match(server, '', [
+    withKeystone(({ keystone }) =>
+      match(keystone, '', [
         { order: 'a', name: '' },
         { order: 'b', name: 'other' },
         { order: 'c', name: 'FOOBAR' },
@@ -47,8 +47,8 @@ export const filterTests = withKeystone => {
   );
   test(
     `Empty 'where' argument'`,
-    withKeystone(({ server: { server } }) =>
-      match(server, '', [
+    withKeystone(({ keystone }) =>
+      match(keystone, '', [
         { order: 'a', name: '' },
         { order: 'b', name: 'other' },
         { order: 'c', name: 'FOOBAR' },
@@ -62,14 +62,14 @@ export const filterTests = withKeystone => {
 
   test(
     `Filter: {key} (case-sensitive)`,
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { name: "fooBAR" }', [{ order: 'd', name: 'fooBAR' }])
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { name: "fooBAR" }', [{ order: 'd', name: 'fooBAR' }])
     )
   );
   test(
     `Filter: {key}_i (case-insensitive)`,
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { name_i: "fooBAR" }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { name_i: "fooBAR" }', [
         { order: 'c', name: 'FOOBAR' },
         { order: 'd', name: 'fooBAR' },
         { order: 'e', name: 'foobar' },
@@ -79,8 +79,8 @@ export const filterTests = withKeystone => {
 
   test(
     `Filter: {key}_not (case-sensitive)`,
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { name_not: "fooBAR" }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { name_not: "fooBAR" }', [
         { order: 'a', name: '' },
         { order: 'b', name: 'other' },
         { order: 'c', name: 'FOOBAR' },
@@ -92,8 +92,8 @@ export const filterTests = withKeystone => {
   );
   test(
     `Filter: {key}_not_i (case-insensitive)`,
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { name_not_i: "fooBAR" }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { name_not_i: "fooBAR" }', [
         { order: 'a', name: '' },
         { order: 'b', name: 'other' },
         { order: 'f', name: null },
@@ -104,8 +104,8 @@ export const filterTests = withKeystone => {
 
   test(
     `Filter: {key}_contains (case-sensitive)`,
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { name_contains: "oo" }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { name_contains: "oo" }', [
         { order: 'd', name: 'fooBAR' },
         { order: 'e', name: 'foobar' },
       ])
@@ -113,8 +113,8 @@ export const filterTests = withKeystone => {
   );
   test(
     `Filter: {key}_contains_i (case-insensitive)`,
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { name_contains_i: "oo" }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { name_contains_i: "oo" }', [
         { order: 'c', name: 'FOOBAR' },
         { order: 'd', name: 'fooBAR' },
         { order: 'e', name: 'foobar' },
@@ -124,8 +124,8 @@ export const filterTests = withKeystone => {
 
   test(
     `Filter: {key}_not_contains (case-sensitive)`,
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { name_not_contains: "oo" }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { name_not_contains: "oo" }', [
         { order: 'a', name: '' },
         { order: 'b', name: 'other' },
         { order: 'c', name: 'FOOBAR' },
@@ -136,8 +136,8 @@ export const filterTests = withKeystone => {
   );
   test(
     `Filter: {key}_not_contains_i (case-insensitive)`,
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { name_not_contains_i: "oo" }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { name_not_contains_i: "oo" }', [
         { order: 'a', name: '' },
         { order: 'b', name: 'other' },
         { order: 'f', name: null },
@@ -148,8 +148,8 @@ export const filterTests = withKeystone => {
 
   test(
     `Filter: {key}_starts_with (case-sensitive)`,
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { name_starts_with: "foo" }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { name_starts_with: "foo" }', [
         { order: 'd', name: 'fooBAR' },
         { order: 'e', name: 'foobar' },
       ])
@@ -157,8 +157,8 @@ export const filterTests = withKeystone => {
   );
   test(
     `Filter: {key}_starts_with_i (case-insensitive)`,
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { name_starts_with_i: "foo" }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { name_starts_with_i: "foo" }', [
         { order: 'c', name: 'FOOBAR' },
         { order: 'd', name: 'fooBAR' },
         { order: 'e', name: 'foobar' },
@@ -168,8 +168,8 @@ export const filterTests = withKeystone => {
 
   test(
     `Filter: {key}_not_starts_with (case-sensitive)`,
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { name_not_starts_with: "foo" }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { name_not_starts_with: "foo" }', [
         { order: 'a', name: '' },
         { order: 'b', name: 'other' },
         { order: 'c', name: 'FOOBAR' },
@@ -180,8 +180,8 @@ export const filterTests = withKeystone => {
   );
   test(
     `Filter: {key}_not_starts_with_i (case-insensitive)`,
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { name_not_starts_with_i: "foo" }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { name_not_starts_with_i: "foo" }', [
         { order: 'a', name: '' },
         { order: 'b', name: 'other' },
         { order: 'f', name: null },
@@ -192,8 +192,8 @@ export const filterTests = withKeystone => {
 
   test(
     `Filter: {key}_ends_with (case-sensitive)`,
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { name_ends_with: "BAR" }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { name_ends_with: "BAR" }', [
         { order: 'c', name: 'FOOBAR' },
         { order: 'd', name: 'fooBAR' },
       ])
@@ -201,8 +201,8 @@ export const filterTests = withKeystone => {
   );
   test(
     `Filter: {key}_ends_with_i (case-insensitive)`,
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { name_ends_with_i: "BAR" }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { name_ends_with_i: "BAR" }', [
         { order: 'c', name: 'FOOBAR' },
         { order: 'd', name: 'fooBAR' },
         { order: 'e', name: 'foobar' },
@@ -212,8 +212,8 @@ export const filterTests = withKeystone => {
 
   test(
     `Filter: {key}_not_ends_with (case-sensitive)`,
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { name_not_ends_with: "BAR" }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { name_not_ends_with: "BAR" }', [
         { order: 'a', name: '' },
         { order: 'b', name: 'other' },
         { order: 'e', name: 'foobar' },
@@ -224,8 +224,8 @@ export const filterTests = withKeystone => {
   );
   test(
     `Filter: {key}_not_ends_with_i (case-insensitive)`,
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { name_not_ends_with_i: "BAR" }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { name_not_ends_with_i: "BAR" }', [
         { order: 'a', name: '' },
         { order: 'b', name: 'other' },
         { order: 'f', name: null },
@@ -236,12 +236,12 @@ export const filterTests = withKeystone => {
 
   test(
     `Filter: {key}_in (case-sensitive, empty list)`,
-    withKeystone(({ server: { server } }) => match(server, 'where: { name_in: [] }', []))
+    withKeystone(({ keystone }) => match(keystone, 'where: { name_in: [] }', []))
   );
   test(
     `Filter: {key}_in (case-sensitive)`,
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { name_in: ["", "FOOBAR"] }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { name_in: ["", "FOOBAR"] }', [
         { order: 'a', name: '' },
         { order: 'c', name: 'FOOBAR' },
       ])
@@ -250,8 +250,8 @@ export const filterTests = withKeystone => {
 
   test(
     `Filter: {key}_not_in (case-sensitive, empty list)`,
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { name_not_in: [] }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { name_not_in: [] }', [
         { order: 'a', name: '' },
         { order: 'b', name: 'other' },
         { order: 'c', name: 'FOOBAR' },
@@ -264,8 +264,8 @@ export const filterTests = withKeystone => {
   );
   test(
     `Filter: {key}_not_in (case-sensitive)`,
-    withKeystone(({ server: { server } }) =>
-      match(server, 'where: { name_not_in: ["", "FOOBAR"] }', [
+    withKeystone(({ keystone }) =>
+      match(keystone, 'where: { name_not_in: ["", "FOOBAR"] }', [
         { order: 'b', name: 'other' },
         { order: 'd', name: 'fooBAR' },
         { order: 'e', name: 'foobar' },

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -1,5 +1,7 @@
 const WebServer = require('./lib/index');
+const { createApolloServer } = require('./lib/apolloServer');
 
 module.exports = {
   WebServer,
+  createApolloServer,
 };

--- a/packages/test-utils/index.js
+++ b/packages/test-utils/index.js
@@ -3,7 +3,6 @@ const {
   multiAdapterRunners,
   graphqlRequest,
   matchFilter,
-  runQuery,
 } = require('./lib/test-utils');
 
-module.exports = { setupServer, multiAdapterRunners, graphqlRequest, matchFilter, runQuery };
+module.exports = { setupServer, multiAdapterRunners, graphqlRequest, matchFilter };

--- a/packages/test-utils/lib/test-utils.js
+++ b/packages/test-utils/lib/test-utils.js
@@ -1,11 +1,11 @@
 const pFinally = require('p-finally');
-const supertest = require('supertest-light');
-const extractStack = require('extract-stack');
 const { Keystone } = require('@keystone-alpha/keystone');
-const { WebServer } = require('@keystone-alpha/server');
+const { createApolloServer } = require('@keystone-alpha/server');
 const { MongooseAdapter } = require('@keystone-alpha/adapter-mongoose');
 const { KnexAdapter } = require('@keystone-alpha/adapter-knex');
 const MongoDBMemoryServer = require('mongodb-memory-server').default;
+
+const SCHEMA_NAME = 'testing';
 
 function setupServer({ name, adapterName, createLists = () => {} }) {
   const Adapter = { mongoose: MongooseAdapter, knex: KnexAdapter }[adapterName];
@@ -17,56 +17,13 @@ function setupServer({ name, adapterName, createLists = () => {} }) {
 
   createLists(keystone);
 
-  const server = new WebServer(keystone, {
-    apiPath: '/admin/api',
-    graphiqlPath: '/admin/graphiql',
-  });
+  createApolloServer(keystone, {}, SCHEMA_NAME);
 
-  return { keystone, server };
+  return { keystone };
 }
 
-function graphqlRequest({ server, query }) {
-  try {
-    const cleanedStack = extractStack(new Error())
-      .split('\n')
-      // Slice out the stackframe pointing to this function
-      .slice(1)
-      // Stick the stacktrace back together
-      .join('\n');
-
-    if (!server.app) {
-      const params = `{ server: { ${Object.keys(server).join(', ')} } }`;
-      const error = new Error(`Must provide { server: { app: <express> } }, got: ${params}`);
-      error.stack = error.stack.replace(extractStack(error), cleanedStack);
-      return Promise.reject(error);
-    }
-
-    return supertest(server.app)
-      .set('Accept', 'application/json')
-      .set('Content-Type', 'application/json')
-      .post('/admin/api', { query })
-      .then(res => {
-        res.body = JSON.parse(res.text);
-        return res;
-      })
-      .then(res => {
-        if (res.statusCode && (res.statusCode < 200 || res.statusCode >= 300)) {
-          const error = new Error(
-            `Expected status "2XX", got ${res.statusCode} with body:` +
-              `\n${require('util').inspect(res.body || {}, { depth: null })}`
-          );
-
-          // Replace the stacktrace with the clean one we gathered and cleaned
-          // before this async process
-          error.stack = error.stack.replace(extractStack(error), cleanedStack);
-
-          throw error;
-        }
-        return res;
-      });
-  } catch (error) {
-    return Promise.reject(error);
-  }
+function graphqlRequest({ keystone, query }) {
+  return keystone._graphQLQuery[SCHEMA_NAME](query, keystone.getAccessContext(SCHEMA_NAME, {}));
 }
 
 // One instance per node.js thread which cleans itself up when the main process
@@ -103,57 +60,60 @@ function teardownMongoMemoryServer() {
   return stopping;
 }
 
-function getCreate(server) {
-  return (list, item) => server.keystone.getListByKey(list).adapter.create(item);
+function getCreate(keystone) {
+  return (list, item) => keystone.getListByKey(list).adapter.create(item);
 }
 
-function getFindById(server) {
-  return (list, item) => server.keystone.getListByKey(list).adapter.findById(item);
+function getFindById(keystone) {
+  return (list, item) => keystone.getListByKey(list).adapter.findById(item);
 }
 
-function getFindOne(server) {
-  return (list, item) => server.keystone.getListByKey(list).adapter.findOne(item);
+function getFindOne(keystone) {
+  return (list, item) => keystone.getListByKey(list).adapter.findOne(item);
 }
 
-function getUpdate(server) {
-  return (list, id, data) => server.keystone.getListByKey(list).adapter.update(id, data);
+function getUpdate(keystone) {
+  return (list, id, data) => keystone.getListByKey(list).adapter.update(id, data);
 }
 
 function keystoneMongoTest(setupKeystoneFn, testFn) {
   return async function() {
-    const server = setupKeystoneFn('mongoose');
+    const setup = setupKeystoneFn('mongoose');
+    const { keystone } = setup;
+
     const { mongoUri, dbName } = await getMongoMemoryServerConfig();
 
-    await server.keystone.connect(mongoUri, { dbName });
+    await keystone.connect(mongoUri, { dbName });
 
     return pFinally(
       testFn({
-        server,
-        create: getCreate(server),
-        findById: getFindById(server),
-        findOne: getFindOne(server),
-        update: getUpdate(server),
+        ...setup,
+        create: getCreate(keystone),
+        findById: getFindById(keystone),
+        findOne: getFindOne(keystone),
+        update: getUpdate(keystone),
       }),
-      () => server.keystone.disconnect().then(teardownMongoMemoryServer)
+      () => keystone.disconnect().then(teardownMongoMemoryServer)
     );
   };
 }
 
 function keystoneKnexTest(setupKeystoneFn, testFn) {
   return async function() {
-    const server = setupKeystoneFn('knex');
+    const setup = setupKeystoneFn('knex');
+    const { keystone } = setup;
 
-    await server.keystone.connect();
+    await keystone.connect();
 
     return pFinally(
       testFn({
-        server,
-        create: getCreate(server),
-        findById: getFindById(server),
-        findOne: getFindOne(server),
-        update: getUpdate(server),
+        ...setup,
+        create: getCreate(keystone),
+        findById: getFindById(keystone),
+        findOne: getFindOne(keystone),
+        update: getUpdate(keystone),
       }),
-      () => server.keystone.disconnect()
+      () => keystone.disconnect()
     );
   };
 }
@@ -181,17 +141,10 @@ const sorted = (arr, keyFn) => {
   return arr;
 };
 
-const runQuery = (server, snippet) => {
-  return graphqlRequest({
-    server,
-    query: `query { ${snippet} }`,
-  }).then(res => res.body.data);
-};
-
-const matchFilter = (server, gqlArgs, fields, target, sortkey) => {
+const matchFilter = (keystone, gqlArgs, fields, target, sortkey) => {
   gqlArgs = gqlArgs ? `(${gqlArgs})` : '';
   const snippet = `allTests ${gqlArgs} ${fields}`;
-  return runQuery(server, snippet).then(data => {
+  return graphqlRequest({ keystone, query: `query { ${snippet} }` }).then(({ data }) => {
     const value = sortkey ? sorted(data.allTests || [], i => i[sortkey]) : data.allTests;
     expect(value).toEqual(target);
   });
@@ -202,5 +155,4 @@ module.exports = {
   multiAdapterRunners,
   graphqlRequest,
   matchFilter,
-  runQuery,
 };

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -12,9 +12,7 @@
     "@keystone-alpha/adapter-mongoose": "^1.0.4",
     "@keystone-alpha/keystone": "^2.0.0",
     "@keystone-alpha/server": "^3.0.0",
-    "extract-stack": "^1.0.0",
     "mongodb-memory-server": "^3.1.2",
-    "p-finally": "^1.0.0",
-    "supertest-light": "^1.0.2"
+    "p-finally": "^1.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8368,11 +8368,6 @@ extract-react-types@^0.16.0:
     babylon-options "^2.0.1"
     strip-indent "^2.0.0"
 
-extract-stack@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/extract-stack/-/extract-stack-1.0.0.tgz#b97acaf9441eea2332529624b732fc5a1c8165fa"
-  integrity sha1-uXrK+UQe6iMyUpYktzL8WhyBZfo=
-
 extract-zip@1.6.7:
   version "1.6.7"
   resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.6.7.tgz#a840b4b8af6403264c8db57f4f1a74333ef81fe9"


### PR DESCRIPTION
The `test-utils` package provides a bunch of helper code to support the `api-tests` tests. These tests exist to ensure that our graphQL resolvers are behaving correctly. The current system exercises the resolvers via an HTTP query an established `WebServer`. Recent changes have made it so that we can set up an `ApolloServer` object without actually starting a webserver. We can use this object to exercise graphQL queries locally without needing to go via HTTP.

This PR makes the changes required to remove the HTTP layer from our test framework. This involves editing an awful lot of files, but the meaty changes are confined to `test-utils/index.js`.