### PR TITLE
Update collectCoverageFrom to provide more meaningful coverage reports

### DIFF
--- a/package.json
+++ b/package.json
@@ -240,7 +240,16 @@
       "<rootDir>/website/.cache"
     ],
     "collectCoverageFrom": [
-      "<rootDir>/packages/**/*.js"
+      "packages/**/*.js",
+      "!packages/**/dist/**",
+      "!packages/admin-ui/client/**",
+      "!packages/arch/**",
+      "!packages/create-keystone-app/templates/**",
+      "!packages/core/tests/default-entry/index.js",
+      "!packages/fields/**/views/**",
+      "!packages/fields/**/filterTests.js",
+      "!packages/fields/types.js",
+      "!packages/mongo-join-builder/examples/**"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
There are certain packages and areas of our code base which we are not currently targetting with out unit tests. Including these bits of code in the coverage distorts the reporting, which makes it less useful as a tool. `bolt coverage` now only reports on files which we can reasonably expect to have test coverage.