### PR TITLE
Fix Wysiwyg field type usage outside the monorepo

### DIFF
--- a/.changeset/cb84db13/changes.json
+++ b/.changeset/cb84db13/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "@keystone-alpha/fields-wysiwyg-tinymce", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/cb84db13/changes.md
+++ b/.changeset/cb84db13/changes.md
@@ -1,0 +1,1 @@
+- Use compiled Field component to fix webpack compilation error when building Admin UI

--- a/packages/fields-wysiwyg-tinymce/index.js
+++ b/packages/fields-wysiwyg-tinymce/index.js
@@ -12,7 +12,7 @@ module.exports = {
   implementation: Text.implementation,
   views: {
     Controller: '@keystone-alpha/fields/types/Text/views/Controller',
-    Field: path.join(__dirname, './views/Field/Field'),
+    Field: path.join(__dirname, './views/Field'),
     Filter: '@keystone-alpha/fields/types/Text/views/Filter',
   },
   adapters: Text.adapters,


### PR DESCRIPTION
The Field view path was pointing to the source file rather than the preconstruct entrypoint so when the field type was used outside the monorepo, the compiled version wasn't being used.