### PR TITLE
Content Field shouldn't throw when no blocks specified or server data is corrupt

### DIFF
--- a/.changeset/0f6a966d/changes.json
+++ b/.changeset/0f6a966d/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/fields", "type": "patch" }], "dependents": [] }

--- a/.changeset/0f6a966d/changes.md
+++ b/.changeset/0f6a966d/changes.md
@@ -1,0 +1,1 @@
+- Content Field no longer throws when no blocks specified or server data is corrupt

--- a/packages/fields/types/Content/Implementation.js
+++ b/packages/fields/types/Content/Implementation.js
@@ -25,7 +25,9 @@ class Content extends Text {
       output: type,
     };
 
-    this.complexBlocks = this.config.blocks
+    this.blocks = Array.isArray(this.blocks) || [];
+
+    this.complexBlocks = this.blocks
       .map(blockConfig => {
         let Impl = blockConfig;
         let fieldConfig = {};
@@ -64,7 +66,7 @@ class Content extends Text {
     return {
       ...meta,
       // NOTE: We rely on order, which is why we end up with a sparse array
-      blockOptions: this.config.blocks.map(block => (Array.isArray(block) ? block[1] : undefined)),
+      blockOptions: this.blocks.map(block => (Array.isArray(block) ? block[1] : undefined)),
     };
   }
   // Add the blocks config to the views object for usage in the admin UI
@@ -72,7 +74,7 @@ class Content extends Text {
   extendViews(views) {
     return {
       ...views,
-      blocks: this.config.blocks.map(block => (Array.isArray(block) ? block[0] : block).viewPath),
+      blocks: this.blocks.map(block => (Array.isArray(block) ? block[0] : block).viewPath),
     };
   }
   get gqlUpdateInputFields() {

--- a/packages/fields/types/Content/Implementation.js
+++ b/packages/fields/types/Content/Implementation.js
@@ -25,7 +25,7 @@ class Content extends Text {
       output: type,
     };
 
-    this.blocks = Array.isArray(this.blocks) || [];
+    this.blocks = Array.isArray(this.config.blocks) ? this.config.blocks : [];
 
     this.complexBlocks = this.blocks
       .map(blockConfig => {

--- a/packages/fields/types/Content/views/src/Field.js
+++ b/packages/fields/types/Content/views/src/Field.js
@@ -54,7 +54,13 @@ let ContentField = ({ field, value: serverValue, onChange, autoFocus }) => {
 
   let parsedValue;
   if (serverValue && serverValue.structure) {
-    parsedValue = JSON.parse(serverValue.structure);
+    try {
+      parsedValue = JSON.parse(serverValue.structure);
+    } catch (error) {
+      console.error('Unable to parse Content field structure: ', error);
+      console.error('Received: ' + serverValue.toString().slice(0, 100));
+      parsedValue = initialValue;
+    }
   } else {
     parsedValue = initialValue;
   }


### PR DESCRIPTION
I ran into both situations when attempting to add a `Content` field to an existing database. This PR should stop those errors from occurring.