### PR TITLE
Aux lists shouldn't have CRUD operations in the public GraphQL API

### DIFF
--- a/.changeset/8c80b209/changes.json
+++ b/.changeset/8c80b209/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/keystone", "type": "patch" }], "dependents": [] }

--- a/.changeset/8c80b209/changes.md
+++ b/.changeset/8c80b209/changes.md
@@ -1,0 +1,1 @@
+- Remove erroneous addition of CRUD operations for Auxiliary Lists from GraphQL API

--- a/packages/keystone/lib/Keystone/index.js
+++ b/packages/keystone/lib/Keystone/index.js
@@ -141,6 +141,10 @@ module.exports = class Keystone {
   }
 
   getTypeDefs({ skipAccessControl = false } = {}) {
+    // Aux lists are only there for typing and internal operations, they should
+    // not have any GraphQL operations performed on them
+    const firstClassLists = this.listsArray.filter(list => !list.isAuxList);
+
     // Fields can be represented multiple times within and between lists.
     // If a field defines a `getGqlAuxTypes()` method, it will be
     // duplicated.
@@ -207,14 +211,14 @@ module.exports = class Keystone {
        }`,
       `type Query {
           ${unique(
-            flatten(this.listsArray.map(list => list.getGqlQueries({ skipAccessControl })))
+            flatten(firstClassLists.map(list => list.getGqlQueries({ skipAccessControl })))
           ).join('\n')}
           """ Retrieve the meta-data for all lists. """
           _ksListsMeta: [_ListMeta]
        }`,
       `type Mutation {
           ${unique(
-            flatten(this.listsArray.map(list => list.getGqlMutations({ skipAccessControl })))
+            flatten(firstClassLists.map(list => list.getGqlMutations({ skipAccessControl })))
           ).join('\n')}
        }`,
     ].map(s => print(gql(s)));


### PR DESCRIPTION
Remove erroneous addition of CRUD operations for Auxiliary Lists from GraphQL API