### PR TITLE
Initialise Block Constructors inside Field Controller

### DIFF
--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -49,6 +49,7 @@
     "lodash.groupby": "^4.6.0",
     "lodash.omitby": "^4.6.0",
     "luxon": "^1.11.4",
+    "memoize-one": "^4.0.2",
     "mongoose": "^5.4.19",
     "p-settle": "^2.1.0",
     "pluralize": "^7.0.0",

--- a/packages/fields/types/Content/views/src/Controller.js
+++ b/packages/fields/types/Content/views/src/Controller.js
@@ -2,9 +2,63 @@
 // out into its own package. But the build process doesn't understand
 // how to traverse preconstruct's src pointers yet, when it does this
 // should import from '@keystone-alpha/fields/types/Text/views/Controller'
+import memoizeOne from 'memoize-one';
 import TextController from '../../../Text/views/Controller/Controller';
+import * as paragraph from './editor/blocks/paragraph';
+
+const DEFAULT_BLOCKS = [paragraph];
+
+const flattenBlocks = (inputBlocks, outputObj = {}) =>
+  inputBlocks.reduce((outputBlocks, block) => {
+    if (outputBlocks[block.type]) {
+      // check the referential equality of a blocks Node since it has to be
+      // defined and if they're equal we know it's the same block
+      if (outputBlocks[block.type].Node !== block.Node) {
+        throw new Error(`There are two different Content blocks with the type '${block.type}'`);
+      } else {
+        // This block (and its dependencies) have already been added
+        return outputBlocks;
+      }
+    }
+
+    if (block.Node === undefined) {
+      throw new Error(`Unable to load Content block '${block.type}' - no Node component defined`);
+    }
+
+    const { dependencies, ...blockToInsert } = block;
+
+    outputBlocks[block.type] = blockToInsert;
+
+    if (dependencies !== undefined) {
+      // Recurse on the dependencies
+      flattenBlocks(dependencies, outputBlocks);
+    }
+
+    return outputBlocks;
+  }, outputObj);
 
 export default class ContentController extends TextController {
+  constructor(...args) {
+    super(...args);
+
+    // Attach this as a memoized member function to avoid two pitfalls;
+    // 1. Don't load all the block views up front. Instead, lazily load them
+    //    only when requested.
+    // 2. Avoid recalculating everything on each request for the Blocks.
+    //    Instead, when requested multiple times, use the previously cached
+    //    results.
+    this.getBlocks = memoizeOne(() => {
+      const blocksModules = this.adminMeta.readViews(this.views.blocks);
+
+      let customBlocks = blocksModules.map((block, i) => ({
+        ...block,
+        options: this.config.blockOptions[i],
+      }));
+
+      return flattenBlocks([...DEFAULT_BLOCKS, ...customBlocks]);
+    });
+  }
+
   getValue = data => {
     const { path } = this.config;
     if (!data || !data[path] || !data[path].document) {

--- a/packages/fields/types/Content/views/src/Field.js
+++ b/packages/fields/types/Content/views/src/Field.js
@@ -1,57 +1,13 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
-import { useState, useMemo } from 'react';
+import { useState } from 'react';
 import Editor from './editor';
 import { Value } from 'slate';
 import { initialValue } from './editor/constants';
-import * as paragraph from './editor/blocks/paragraph';
 import { FieldContainer, FieldLabel, FieldInput } from '@arch-ui/fields';
 import { inputStyles } from '@arch-ui/input';
 
 let ContentField = ({ field, value: serverValue, onChange, autoFocus }) => {
-  const blocksModules = field.adminMeta.readViews(field.views.blocks);
-  let blocks = useMemo(() => {
-    let defaultBlocks = [paragraph];
-
-    let customBlocks = blocksModules.map((block, i) => ({
-      ...block,
-      options: field.config.blockOptions[i],
-    }));
-
-    let combinedBlocks = [...defaultBlocks, ...customBlocks];
-
-    let flatBlocks = [];
-
-    function pushBlocks(blocksToPush) {
-      blocksToPush.forEach(block => {
-        let existingItem = flatBlocks.find(({ type }) => type === block.type);
-        if (existingItem === undefined) {
-          let { dependencies, ...blockToInsert } = block;
-          flatBlocks.push(blockToInsert);
-          if (dependencies !== undefined) {
-            pushBlocks(dependencies);
-          }
-        } else if (existingItem.Node === undefined) {
-          throw new Error(
-            `Unable to load Content block '${existingItem.type}' - no Node component defined`
-          );
-        }
-        // check the referential equality of a blocks Node since it has to be defined
-        // and if they're equal we know it's the same block
-        else if (existingItem.Node !== block.Node) {
-          throw new Error(`There are two different Content blocks with the type '${block.type}'`);
-        }
-      });
-    }
-
-    pushBlocks(combinedBlocks);
-
-    return flatBlocks.reduce((obj, block) => {
-      obj[block.type] = block;
-      return obj;
-    }, {});
-  }, [blocksModules]);
-
   let parsedValue;
   if (serverValue && serverValue.document) {
     try {
@@ -80,14 +36,14 @@ let ContentField = ({ field, value: serverValue, onChange, autoFocus }) => {
     >
       <FieldLabel htmlFor={htmlID}>{field.label}</FieldLabel>
       <FieldInput>
-        {Object.values(blocks)
+        {Object.values(field.getBlocks())
           .filter(({ Provider, options }) => Provider && options)
           .reduce(
             (children, { Provider, options }) => (
               <Provider value={options}>{children}</Provider>
             ),
             <Editor
-              blocks={blocks}
+              blocks={field.getBlocks()}
               value={value}
               onChange={setValue}
               autoFocus={autoFocus}


### PR DESCRIPTION
This is mostly a move-and-refactor, no functionality is changed (except for one minor improvement noted inline below).

This enables access to the block config during Controller actions (eg; inside `Controller#getValue()`), which I'll be implementing in a future PR.