### PR TITLE
Ensure Content Block views are always loaded

### DIFF
--- a/packages/fields/types/Content/blocks/blockquote.js
+++ b/packages/fields/types/Content/blocks/blockquote.js
@@ -1,0 +1,6 @@
+const path = require('path');
+
+module.exports = {
+  type: 'blockquote',
+  viewPath: path.join(__dirname, '../views/blocks/blockquote'),
+};

--- a/packages/fields/types/Content/blocks/caption.js
+++ b/packages/fields/types/Content/blocks/caption.js
@@ -1,0 +1,6 @@
+const path = require('path');
+
+module.exports = {
+  type: 'caption',
+  viewPath: path.join(__dirname, '../views/blocks/caption'),
+};

--- a/packages/fields/types/Content/blocks/embed.js
+++ b/packages/fields/types/Content/blocks/embed.js
@@ -1,0 +1,6 @@
+const path = require('path');
+
+module.exports = {
+  type: 'embed',
+  viewPath: path.join(__dirname, '../views/blocks/embed'),
+};

--- a/packages/fields/types/Content/blocks/heading.js
+++ b/packages/fields/types/Content/blocks/heading.js
@@ -1,0 +1,8 @@
+const path = require('path');
+const paragraph = require('./paragraph');
+
+module.exports = {
+  type: 'heading',
+  viewPath: path.join(__dirname, '../views/blocks/heading'),
+  dependencies: [paragraph],
+};

--- a/packages/fields/types/Content/blocks/image-container.js
+++ b/packages/fields/types/Content/blocks/image-container.js
@@ -1,0 +1,9 @@
+const path = require('path');
+const image = require('./image');
+const caption = require('./caption');
+
+module.exports = {
+  type: 'image-container',
+  viewPath: path.join(__dirname, '../views/blocks/image-container'),
+  dependencies: [image, caption],
+};

--- a/packages/fields/types/Content/blocks/image.js
+++ b/packages/fields/types/Content/blocks/image.js
@@ -1,0 +1,6 @@
+const path = require('path');
+
+module.exports = {
+  type: 'image',
+  viewPath: path.join(__dirname, '../views/blocks/image'),
+};

--- a/packages/fields/types/Content/blocks/link.js
+++ b/packages/fields/types/Content/blocks/link.js
@@ -1,0 +1,6 @@
+const path = require('path');
+
+module.exports = {
+  type: 'link',
+  viewPath: path.join(__dirname, '../views/blocks/link'),
+};

--- a/packages/fields/types/Content/blocks/list-item.js
+++ b/packages/fields/types/Content/blocks/list-item.js
@@ -1,0 +1,6 @@
+const path = require('path');
+
+module.exports = {
+  type: 'list-item',
+  viewPath: path.join(__dirname, '../views/blocks/list-item'),
+};

--- a/packages/fields/types/Content/blocks/ordered-list.js
+++ b/packages/fields/types/Content/blocks/ordered-list.js
@@ -1,0 +1,8 @@
+const path = require('path');
+const listItem = require('./list-item');
+
+module.exports = {
+  type: 'ordered-list',
+  viewPath: path.join(__dirname, '../views/blocks/ordered-list'),
+  dependencies: [listItem],
+};

--- a/packages/fields/types/Content/blocks/paragraph.js
+++ b/packages/fields/types/Content/blocks/paragraph.js
@@ -1,0 +1,6 @@
+const path = require('path');
+
+module.exports = {
+  type: 'paragraph',
+  viewPath: path.join(__dirname, '../views/blocks/paragraph'),
+};

--- a/packages/fields/types/Content/blocks/unordered-list.js
+++ b/packages/fields/types/Content/blocks/unordered-list.js
@@ -1,0 +1,8 @@
+const path = require('path');
+const listItem = require('./list-item');
+
+module.exports = {
+  type: 'unordered-list',
+  viewPath: path.join(__dirname, '../views/blocks/unordered-list'),
+  dependencies: [listItem],
+};

--- a/packages/fields/types/Content/index.js
+++ b/packages/fields/types/Content/index.js
@@ -1,5 +1,13 @@
-const { Content, MongoContentInterface, KnexContentInterface } = require('./Implementation');
 const path = require('path');
+
+const { Content, MongoContentInterface, KnexContentInterface } = require('./Implementation');
+const blockquote = require('./blocks/blockquote');
+const embed = require('./blocks/embed');
+const heading = require('./blocks/heading');
+const image = require('./blocks/image-container');
+const link = require('./blocks/link');
+const orderedList = require('./blocks/ordered-list');
+const unorderedList = require('./blocks/unordered-list');
 
 module.exports = {
   type: 'Content',
@@ -14,13 +22,13 @@ module.exports = {
     knex: KnexContentInterface,
   },
   blocks: {
-    blockquote: { viewPath: path.join(__dirname, './views/blocks/blockquote') },
-    embed: { viewPath: path.join(__dirname, './views/blocks/embed') },
-    heading: { viewPath: path.join(__dirname, './views/blocks/heading') },
-    image: { viewPath: path.join(__dirname, './views/blocks/image-container') },
-    link: { viewPath: path.join(__dirname, './views/blocks/link') },
-    orderedList: { viewPath: path.join(__dirname, './views/blocks/ordered-list') },
-    unorderedList: { viewPath: path.join(__dirname, './views/blocks/unordered-list') },
+    blockquote,
+    embed,
+    heading,
+    image,
+    link,
+    orderedList,
+    unorderedList,
     // not exposing list-item since it's only used internally by the other blocks
     // not exposing paragraph since it's included by default
   },

--- a/packages/fields/types/Content/views/blocks/caption/package.json
+++ b/packages/fields/types/Content/views/blocks/caption/package.json
@@ -1,0 +1,7 @@
+{
+  "main": "dist/fields.cjs.js",
+  "module": "dist/fields.esm.js",
+  "preconstruct": {
+    "source": "../../src/editor/blocks/caption"
+  }
+}

--- a/packages/fields/types/Content/views/blocks/image/package.json
+++ b/packages/fields/types/Content/views/blocks/image/package.json
@@ -1,0 +1,7 @@
+{
+  "main": "dist/fields.cjs.js",
+  "module": "dist/fields.esm.js",
+  "preconstruct": {
+    "source": "../../src/editor/blocks/image"
+  }
+}

--- a/packages/fields/types/Content/views/blocks/list-item/package.json
+++ b/packages/fields/types/Content/views/blocks/list-item/package.json
@@ -1,0 +1,7 @@
+{
+  "main": "dist/fields.cjs.js",
+  "module": "dist/fields.esm.js",
+  "preconstruct": {
+    "source": "../../src/editor/blocks/list-item"
+  }
+}

--- a/packages/fields/types/Content/views/blocks/paragraph/package.json
+++ b/packages/fields/types/Content/views/blocks/paragraph/package.json
@@ -1,0 +1,7 @@
+{
+  "main": "dist/fields.cjs.js",
+  "module": "dist/fields.esm.js",
+  "preconstruct": {
+    "source": "../../src/editor/blocks/paragraph"
+  }
+}

--- a/packages/fields/types/Content/views/src/editor/AddBlock.js
+++ b/packages/fields/types/Content/views/src/editor/AddBlock.js
@@ -77,7 +77,7 @@ let AddBlock = ({ editorState, editor, blocks }) => {
           <div>
             {Object.keys(blocks).map(key => {
               let { Sidebar } = blocks[key];
-              if (Sidebar === undefined) {
+              if (!blocks[key].withChrome || Sidebar === undefined) {
                 return null;
               }
               return <Sidebar key={key} editor={editor} />;

--- a/packages/fields/types/Content/views/src/editor/blocks/image-container.js
+++ b/packages/fields/types/Content/views/src/editor/blocks/image-container.js
@@ -173,5 +173,3 @@ export let plugins = [
     },
   },
 ];
-
-export let dependencies = [image, caption];

--- a/packages/fields/types/Content/views/src/editor/blocks/ordered-list.js
+++ b/packages/fields/types/Content/views/src/editor/blocks/ordered-list.js
@@ -77,5 +77,3 @@ export const schema = {
     }
   },
 };
-
-export let dependencies = [listItem];

--- a/packages/fields/types/Content/views/src/editor/blocks/unordered-list.js
+++ b/packages/fields/types/Content/views/src/editor/blocks/unordered-list.js
@@ -77,5 +77,3 @@ export const schema = {
     }
   },
 };
-
-export let dependencies = [listItem];

--- a/packages/fields/types/Content/views/src/editor/toolbar.js
+++ b/packages/fields/types/Content/views/src/editor/toolbar.js
@@ -19,7 +19,7 @@ function InnerToolbar({ blocks, editor, editorState }) {
   return (
     <div css={{ display: 'flex' }}>
       {Object.keys(blocks)
-        .map(x => blocks[x].Toolbar)
+        .map(x => blocks[x].withChrome && blocks[x].Toolbar)
         .filter(x => x)
         .reduce(
           (children, Toolbar) => {
@@ -58,7 +58,7 @@ function InnerToolbar({ blocks, editor, editorState }) {
 
             {Object.keys(blocks).map(type => {
               let ToolbarElement = blocks[type].ToolbarElement;
-              if (ToolbarElement === undefined) {
+              if (!blocks[type].withChrome || ToolbarElement === undefined) {
                 return null;
               }
               return <ToolbarElement key={type} editor={editor} editorState={editorState} />;

--- a/test-projects/basic/index.js
+++ b/test-projects/basic/index.js
@@ -124,6 +124,7 @@ keystone.createList('Post', {
       blocks: [
         [CloudinaryImage.block, { adapter: cloudinaryAdapter }],
         Content.blocks.blockquote,
+        Content.blocks.image,
         Content.blocks.orderedList,
         Content.blocks.unorderedList,
         [Content.blocks.embed, { apiKey: process.env.EMBEDLY_API_KEY }],


### PR DESCRIPTION
Previous behaviour was to rely on manually importing a block for it to
be included (eg; `unordered-list` imports the `list-item` block). While
this is currently always the case, it doesn't necessarily have to be.

One example might be a 3rd party block which wants to create
heading+subheading pair, and set a dependency on the `heading` block
without ever importing it (instead; referencing it by its type name from
within the 3rd party block).

By surfacing the type on the server / during webpack build we're able to
do a couple more checks such as for duplicates and also replace the
sparse config array with a keyed object.

Finally, we can pull up the default `paragraph` block into the pre-build
step and remove that logic from the client code, making it a bit
cleaner.