### PR TITLE
Don't throw when no relationship ID set

### DIFF
--- a/.changeset/99566b3d/changes.json
+++ b/.changeset/99566b3d/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/fields", "type": "patch" }], "dependents": [] }

--- a/.changeset/99566b3d/changes.md
+++ b/.changeset/99566b3d/changes.md
@@ -1,0 +1,1 @@
+- Correctly return null to the Admin UI for to-single relationship fields which don't have any ID set

--- a/packages/fields/types/Relationship/Implementation.js
+++ b/packages/fields/types/Relationship/Implementation.js
@@ -115,9 +115,8 @@ class Relationship extends Implementation {
     if (!many) {
       return {
         [this.path]: (item, _, context) => {
-          // The field may have already been filled in during an early DB lookup
-          // (ie; joining when doing a filter)
-          if (item[this.path] === null) {
+          // No ID set, so we return null for the value
+          if (!item[this.path]) {
             return null;
           }
           const filteredQueryArgs = { where: { id: item[this.path].toString() } };


### PR DESCRIPTION
Was throwing:

```
10:47:19 🚨 GraphQLError Cannot read property 'toString' of undefined
```