### PR TITLE
Don't create graphiql shortlinks for multipart forms

### DIFF
--- a/packages/server/lib/devQuery.js
+++ b/packages/server/lib/devQuery.js
@@ -21,8 +21,12 @@ const graphiqlDevQueryMiddleware = (graphiqlPath, devQueryPath, devQueryLog) => 
   res,
   next
 ) => {
-  // Skip requests from graphiql itself
-  if (req.headers.referer && req.headers.referer.includes(graphiqlPath)) {
+  if (
+    // Skip requests from graphiql itself
+    (req.headers.referer && req.headers.referer.includes(graphiqlPath)) ||
+    // Skip multipart form requests (ie; when using the Upload type)
+    !req.body.query
+  ) {
     return next();
   }
 


### PR DESCRIPTION
Trying to do a query with an upload (the `Upload` type) uses a multi-part form, but our logic expects a JSON POST.

Before this fix, it would throw this error:

```
TypeError: Cannot read property '0' of undefined
    at gql (/Users/jess/dev/keystone-5/node_modules/graphql-tag/lib/graphql-tag.umd.js:164:69)
    at /Users/jess/dev/keystone-5/packages/server/lib/devQuery.js:37:15
```