### PR TITLE
Pass GraphQL context to hooks so they can do fun things for much joy

### DIFF
--- a/.changeset/8e4d8a0b/changes.json
+++ b/.changeset/8e4d8a0b/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/keystone", "type": "minor" }], "dependents": [] }

--- a/.changeset/8e4d8a0b/changes.md
+++ b/.changeset/8e4d8a0b/changes.md
@@ -1,0 +1,1 @@
+- Expose GraphQL `context` object to hooks for advanced use cases.

--- a/packages/keystone/lib/List/index.js
+++ b/packages/keystone/lib/List/index.js
@@ -938,6 +938,7 @@ module.exports = class List {
     const args = {
       resolvedData,
       existingItem,
+      context,
       originalInput,
       actions: mapKeys(this.hooksActions, hook => hook(context)),
     };
@@ -964,6 +965,7 @@ module.exports = class List {
     const args = {
       resolvedData,
       existingItem,
+      context,
       originalInput,
       actions: mapKeys(this.hooksActions, hook => hook(context)),
     };
@@ -974,6 +976,7 @@ module.exports = class List {
   async _validateDelete(existingItem, context, operation) {
     const args = {
       existingItem,
+      context,
       actions: mapKeys(this.hooksActions, hook => hook(context)),
     };
     const fields = this.fields;
@@ -1011,6 +1014,7 @@ module.exports = class List {
     const args = {
       resolvedData,
       existingItem,
+      context,
       originalInput,
       actions: mapKeys(this.hooksActions, hook => hook(context)),
     };
@@ -1020,6 +1024,7 @@ module.exports = class List {
   async _beforeDelete(existingItem, context) {
     const args = {
       existingItem,
+      context,
       actions: mapKeys(this.hooksActions, hook => hook(context)),
     };
     await this._runHook(args, existingItem, 'beforeDelete');
@@ -1030,6 +1035,7 @@ module.exports = class List {
       updatedItem,
       originalInput,
       existingItem,
+      context,
       actions: mapKeys(this.hooksActions, hook => hook(context)),
     };
     await this._runHook(args, updatedItem, 'afterChange');
@@ -1038,6 +1044,7 @@ module.exports = class List {
   async _afterDelete(existingItem, context) {
     const args = {
       existingItem,
+      context,
       actions: mapKeys(this.hooksActions, hook => hook(context)),
     };
     await this._runHook(args, existingItem, 'afterDelete');
@@ -1075,7 +1082,7 @@ module.exports = class List {
     const { afterChangeStack } = mutationState;
     afterChangeStack.push(afterHook);
     if (isRootMutation) {
-      // TODO: Close transation
+      // TODO: Close transaction
 
       // Execute post-hook stack
       while (afterChangeStack.length) {


### PR DESCRIPTION
In particular; the Content Editor will be executing Relationship queries which expect the GraphQL `context` to be passed within the `resolveInput()` hook.

_Update_: Spoke offline with @timleslie:

In the end, this is necessary because we have a relationship which needs to check Access Control. Access Control is currently checked at the `context` level (ie; for the entire current GraphQL query). 

The execution goes:

```
Update/Create Content field
-> <Content field>.resolveInput()
-> <CloudinaryImage Relationship>.resolveRelationship()
-> <context>.checkAccessControl()
```

Before this PR, the `context` is not available on the file step, now it's exposed to the `.resolveInput()` hook, so can be passed down.

Alternatives to the underlying motivation (which would not require passing `context`) are:

1. Have a global `context` object per query, and let the `Relationship` type access that internally. This has the benefit of hiding the API away from public access and enabling easier refactors in the future. Downside is now we've got global state which _anything_ could access and mess with.

2. Grab the logic from within the Relationship code that deals with adding the relationship and paste it into the `.resolveInput()` handler. This would mean we can tailor it to skip access control (we only need a very simplified check really), but means duplicate code which can quickly fork and not benefit from other advancements in the upstream `Relationship` field.

We're going to go ahead with this PR for now, and see if the API shakes out differently than expected or another way of handling this turns up. If not, we'll run with it and leave `context` undocumented and deal with any issues it implies in the future.