### PR TITLE
Expose result of running relationship operations (create/connect/disconnect)

### DIFF
--- a/.changeset/60916452/changes.json
+++ b/.changeset/60916452/changes.json
@@ -1,0 +1,87 @@
+{
+  "releases": [
+    { "name": "@keystone-alpha/api-tests", "type": "patch" },
+    { "name": "@keystone-alpha/fields", "type": "major" }
+  ],
+  "dependents": [
+    {
+      "name": "@keystone-alpha/admin-ui",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields"]
+    },
+    {
+      "name": "@keystone-alpha/fields-wysiwyg-tinymce",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields"]
+    },
+    {
+      "name": "@keystone-alpha/keystone",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields"]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-blog",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/fields-wysiwyg-tinymce",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-todo",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-access-control",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-basic",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-facebook-login",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-login",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-twitter-login",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/fields"
+      ]
+    }
+  ]
+}

--- a/.changeset/60916452/changes.md
+++ b/.changeset/60916452/changes.md
@@ -1,0 +1,1 @@
+- Expose result of running relationship operations (create/connect/disconnect)

--- a/api-tests/relationships/filtering/nested.test.js
+++ b/api-tests/relationships/filtering/nested.test.js
@@ -235,6 +235,28 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           expect(data.allUsers[0].posts).toHaveLength(2);
         })
       );
+
+      test(
+        'Filtering out all items by nested field should return []',
+        runner(setupKeystone, async ({ keystone, create }) => {
+          await create('User', {});
+
+          const result = await graphqlRequest({
+            keystone,
+            query: `
+              query {
+                allUsers(where: { posts_some: { content_contains: "foo" } }) {
+                  posts { id }
+                }
+              }
+            `,
+          });
+          expect(result.errors).toBe(undefined);
+
+          expect(Array.isArray(result.data.allUsers)).toBeTruthy();
+          expect(result.data.allUsers).toHaveLength(0);
+        })
+      );
     });
 
     describe('relationship meta filtering', () => {

--- a/api-tests/relationships/mongo/data-storage.test.js
+++ b/api-tests/relationships/mongo/data-storage.test.js
@@ -1,0 +1,105 @@
+const { Text, Relationship } = require('@keystone-alpha/fields');
+const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystone-alpha/test-utils');
+const cuid = require('cuid');
+
+function setupKeystone(adapterName) {
+  return setupServer({
+    adapterName,
+    name: `ks5-testdb-${cuid()}`,
+    createLists: keystone => {
+      keystone.createList('User', {
+        fields: {
+          posts: { type: Relationship, ref: 'Post', many: true },
+        },
+      });
+
+      keystone.createList('Post', {
+        fields: {
+          content: { type: Text },
+        },
+      });
+    },
+  });
+}
+
+let adapterRunners = multiAdapterRunners().filter(({ adapterName }) => adapterName === 'mongoose');
+
+// Sanity check that our tests are running against mongoose
+test('Mongoose adapter exists', () => {
+  expect(adapterRunners).toMatchObject([{ adapterName: 'mongoose' }]);
+});
+
+adapterRunners.forEach(({ runner, adapterName }) =>
+  describe(`${adapterName} Data Storage`, () => {
+    test(
+      'to-many relationship must be stored as empty array',
+      runner(setupKeystone, async ({ keystone, findById }) => {
+        const { data, errors } = await graphqlRequest({
+          keystone,
+          query: `
+            mutation {
+              createUser(data: {}) {
+                id
+              }
+            }
+          `,
+        });
+
+        expect(errors).toBe(undefined);
+
+        const {
+          createUser: { id },
+        } = data;
+
+        const storedData = await findById('User', id);
+
+        expect(Array.isArray(storedData.posts)).toBeTruthy();
+        expect(storedData.posts).toHaveLength(0);
+      })
+    );
+
+    test(
+      'disconnecting all items in to-many relationship should store empty array',
+      runner(setupKeystone, async ({ keystone, findById }) => {
+        const createResult = await graphqlRequest({
+          keystone,
+          query: `
+            mutation {
+              createUser(data: { posts: { create: [{ content: "hi" }] } }) {
+                id
+              }
+            }
+          `,
+        });
+
+        expect(createResult.errors).toBe(undefined);
+
+        const storedCreateData = await findById('User', createResult.data.createUser.id);
+        expect(Array.isArray(storedCreateData.posts)).toBeTruthy();
+        expect(storedCreateData.posts).toHaveLength(1);
+
+        const updateResult = await graphqlRequest({
+          keystone,
+          query: `
+            mutation {
+              updateUser(
+                id: "${createResult.data.createUser.id}"
+                data: {
+                  posts: { disconnectAll: true }
+                }
+              ) {
+                id
+              }
+            }
+          `,
+        });
+
+        expect(updateResult.errors).toBe(undefined);
+
+        const storedUpdateData = await findById('User', createResult.data.createUser.id);
+        expect(Array.isArray(storedUpdateData.posts)).toBeTruthy();
+        expect(storedUpdateData.posts).toHaveLength(0);
+      })
+    );
+  })
+);

--- a/packages/fields/types/Relationship/Implementation.js
+++ b/packages/fields/types/Relationship/Implementation.js
@@ -161,7 +161,35 @@ class Relationship extends Implementation {
     };
   }
 
-  async resolveRelationship(input, item, context, getItem, mutationState) {
+  /**
+   * @param operations {Object}
+   * {
+   *   disconnectAll?: Boolean, (default: false),
+   *   disconnect?: Array<where>, (default: []),
+   *   connect?: Array<where>, (default: []),
+   *   create?: Array<data>, (default: []),
+   * }
+   * NOTE: If `disconnectAll` is `true`, `disconnect` is ignored.
+   * `where` is a WhereUniqueInput (eg; { id: "abc123" })
+   * `data` is an input of the type expected for the ref list (eg; { data: { name: "Sarah" } })
+   *
+   * @return {Object}
+   * {
+   *   disconnect: Array<ID>,
+   *   connect: Array<ID>,
+   *   create: Array<ID>,
+   * }
+   * The indexes within the return arrays are guaranteed to match the indexes as
+   * passed in `operations`.
+   * Due to Access Control, it is possible thata some operations result in a
+   * value of `null`. Be sure to guard against this in your code (or use the
+   * .convertResolvedOperationsToFieldValue() method which handles this for
+   * you).
+   * NOTE: If `disconnectAll` is true, `disconnect` will be an array of all
+   * previous stored values, which means indecies may not match those passed in
+   * `operations`.
+   */
+  async resolveNestedOperations(operations, item, context, getItem, mutationState) {
     const { many, isRequired } = this.config;
 
     const { refList, refField } = this.tryResolveRefList();
@@ -173,7 +201,7 @@ class Relationship extends Implementation {
     // Possible early out for null'd field
     // prettier-ignore
     if (
-      !input
+      !operations
       && (
         // If the field is not required, and the value is `null`, we can ignore
         // it and move on.
@@ -184,7 +212,12 @@ class Relationship extends Implementation {
         || (refField && this.getListByKey(refField.refListKey) === listInfo.local.list)
       )
     ) {
-      return input;
+      // Don't release the zalgo; always return a promise.
+      return Promise.resolve({
+        create: [],
+        connect: [],
+        disconnect: [],
+      });
     }
 
     let currentValue = item && item[this.path];
@@ -196,8 +229,8 @@ class Relationship extends Implementation {
 
     // Collect the IDs to be connected and disconnected. This step may trigger
     // createMutation calls in order to obtain these IDs if required.
-    const { connect, disconnect } = await resolveNested({
-      input,
+    const { create = [], connect = [], disconnect = [] } = await resolveNested({
+      input: operations,
       currentValue,
       listInfo,
       many,
@@ -208,7 +241,7 @@ class Relationship extends Implementation {
     // Enqueue backlink operations for the connections and disconnections
     if (refField) {
       enqueueBacklinkOperations(
-        { connect, disconnect },
+        { connect: [...create, ...connect], disconnect },
         mutationState.queues,
         getItem || Promise.resolve(item),
         listInfo.local,
@@ -216,11 +249,29 @@ class Relationship extends Implementation {
       );
     }
 
-    // Resolve the connections and disconnections into a final id/list of ids.
-    if (many) {
-      return [...currentValue.filter(id => !disconnect.includes(id)), ...connect];
+    return { create, connect, disconnect };
+  }
+
+  // This function codifies the order of operations for nested mutations:
+  // 1. disconnectAll
+  // 2. disconnect
+  // 3. create
+  // 4. connect
+  convertResolvedOperationsToFieldValue({ create, connect, disconnect }, item) {
+    if (this.config.many) {
+      const currentValue = ((item && item[this.path]) || []).map(id => id.toString());
+      return [...currentValue.filter(id => !disconnect.includes(id)), ...connect, ...create].filter(
+        id => !!id
+      );
     } else {
-      return connect ? connect[0] : disconnect ? null : currentValue;
+      const currentValue = (item && item[this.path] && item[this.path].toString()) || null;
+      return create && create[0]
+        ? create[0]
+        : connect && connect[0]
+        ? connect[0]
+        : disconnect && disconnect[0]
+        ? null
+        : currentValue;
     }
   }
 

--- a/packages/keystone/lib/List/index.js
+++ b/packages/keystone/lib/List/index.js
@@ -910,11 +910,20 @@ module.exports = class List {
 
   async _resolveRelationship(data, existingItem, context, getItem, mutationState) {
     const fields = this._fieldsFromObject(data).filter(field => field.isRelationship);
+    const resolvedRelationships = await this._mapToFields(fields, async field => {
+      const operations = await field.resolveNestedOperations(
+        data[field.path],
+        existingItem,
+        context,
+        getItem,
+        mutationState
+      );
+      return field.convertResolvedOperationsToFieldValue(operations, existingItem);
+    });
+
     return {
       ...data,
-      ...(await this._mapToFields(fields, async field =>
-        field.resolveRelationship(data[field.path], existingItem, context, getItem, mutationState)
-      )),
+      ...resolvedRelationships,
     };
   }
 


### PR DESCRIPTION
Enables future code to inspect the result of specific operations rather
than relying solely on a flattened array of IDs.

In particular; the Content Editor serializes data from slate.js into a
set of operations which it then needs to inject back into the slate.js
document. It does this by tracking `create`/`connect` operation indicies
but without this change was not able to map those indicies back to the
final ID.

The added complication here was the possibility of `null` results due to
Access Control or Where clauses which filtered out items. Now, those
`null` results are preserved in the operation outputs, and filtered by a
second stage function for when obtaining just the flattened ID array is
the desired goal.