### PR TITLE
isMultiline support for Text fields

### DIFF
--- a/packages/arch/packages/day-picker/src/DayTimePicker.js
+++ b/packages/arch/packages/day-picker/src/DayTimePicker.js
@@ -79,7 +79,6 @@ export const DayTimePicker = (props: Props) => {
         value={time}
         onChange={handleTimeChange}
         disabled={isDisabled || false}
-        isMultiline={false}
         id={`${htmlID}-time`}
       />
       <Select

--- a/packages/arch/packages/input/src/Input.js
+++ b/packages/arch/packages/input/src/Input.js
@@ -35,13 +35,14 @@ export const inputStyles = (props: InputProps = {}) => ({
   ...(props.isMultiline
     ? {
         lineHeight: 'inherit',
-        height: 'auto',
+        height: 100,
       }
     : undefined),
 });
 
 type InputProps = { isMultiline?: boolean, disabled?: boolean };
 export const Input = forwardRef<InputProps, any>((props: InputProps, ref) => {
-  const Component = props.isMultiline ? 'textarea' : 'input';
-  return <Component ref={ref} css={inputStyles(props)} {...props} />;
+  const { isMultiline, ...inputProps } = props;
+  const Component = isMultiline ? 'textarea' : 'input';
+  return <Component ref={ref} css={inputStyles(props)} {...inputProps} />;
 });

--- a/packages/fields/Implementation.js
+++ b/packages/fields/Implementation.js
@@ -111,7 +111,6 @@ class Field {
   get gqlQueryInputFields() {
     return [];
   }
-
   equalityInputFields(type) {
     return [`${this.path}: ${type}`, `${this.path}_not: ${type}`];
   }
@@ -149,14 +148,12 @@ class Field {
       `${this.path}_not_ends_with_i: ${type}`,
     ];
   }
-
   get gqlCreateInputFields() {
     return [];
   }
   get gqlUpdateInputFields() {
     return [];
   }
-
   getAdminMeta() {
     return this.extendAdminMeta({
       label: this.label,

--- a/packages/fields/types/Text/Implementation.js
+++ b/packages/fields/types/Text/Implementation.js
@@ -6,14 +6,12 @@ class Text extends Implementation {
   constructor() {
     super(...arguments);
   }
-
   get gqlOutputFields() {
     return [`${this.path}: String`];
   }
   get gqlOutputFieldResolvers() {
     return { [`${this.path}`]: item => item[this.path] };
   }
-
   get gqlQueryInputFields() {
     return [
       ...this.equalityInputFields('String'),
@@ -28,6 +26,10 @@ class Text extends Implementation {
   }
   get gqlCreateInputFields() {
     return [`${this.path}: String`];
+  }
+  extendAdminMeta(meta) {
+    const { isMultiline } = this.config;
+    return { isMultiline, ...meta };
   }
 }
 

--- a/packages/fields/types/Text/views/Field/Field.js
+++ b/packages/fields/types/Text/views/Field/Field.js
@@ -15,6 +15,7 @@ export default class TextField extends Component {
   };
   render() {
     const { autoFocus, field, error, value: serverValue } = this.props;
+    const { isMultiline } = field.config;
     const value = serverValue || '';
     const htmlID = `ks-input-${field.path}`;
     const canRead = !(error instanceof Error && error.name === 'AccessDeniedError');
@@ -43,6 +44,7 @@ export default class TextField extends Component {
             placeholder={canRead ? undefined : error.message}
             onChange={this.onChange}
             id={htmlID}
+            isMultiline={isMultiline}
           />
         </FieldInput>
       </FieldContainer>


### PR DESCRIPTION
@dcousens mentioned this so I fixed it.

Our blog demo specifies the `isMultiline` option for the content Text field in the Comments lists, but the field wasn't passing the value through to the Arch component.