### PR TITLE
Fields provide (de)serialize methods for pre-save and post-read

### DIFF
--- a/.changeset/567c67c0/changes.json
+++ b/.changeset/567c67c0/changes.json
@@ -1,0 +1,87 @@
+{
+  "releases": [
+    { "name": "@keystone-alpha/admin-ui", "type": "patch" },
+    { "name": "@keystone-alpha/fields", "type": "major" }
+  ],
+  "dependents": [
+    {
+      "name": "@keystone-alpha/fields-wysiwyg-tinymce",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields"]
+    },
+    {
+      "name": "@keystone-alpha/keystone",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields"]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-blog",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/fields-wysiwyg-tinymce",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-todo",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-access-control",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-basic",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-facebook-login",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-login",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-twitter-login",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/api-tests",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/keystone", "@keystone-alpha/fields"]
+    }
+  ]
+}

--- a/.changeset/567c67c0/changes.md
+++ b/.changeset/567c67c0/changes.md
@@ -1,0 +1,1 @@
+- Field view Controllers: Rename `.getValue()` to `.serialize()` and add `.deserialize()` to enable handling pre-save to server & post-read from server respectively.

--- a/.changeset/e6fef4ba/changes.json
+++ b/.changeset/e6fef4ba/changes.json
@@ -1,0 +1,87 @@
+{
+  "releases": [
+    { "name": "@keystone-alpha/admin-ui", "type": "patch" },
+    { "name": "@keystone-alpha/fields", "type": "major" }
+  ],
+  "dependents": [
+    {
+      "name": "@keystone-alpha/fields-wysiwyg-tinymce",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields"]
+    },
+    {
+      "name": "@keystone-alpha/keystone",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields"]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-blog",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/fields-wysiwyg-tinymce",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-todo",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-access-control",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-basic",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-facebook-login",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-login",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-twitter-login",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/api-tests",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/keystone", "@keystone-alpha/fields"]
+    }
+  ]
+}

--- a/.changeset/e6fef4ba/changes.md
+++ b/.changeset/e6fef4ba/changes.md
@@ -1,0 +1,1 @@
+- Field view Controllers: Rename `.getIntialData()` to `.getDefaultValue()` to better reflect the purpose of the function.

--- a/packages/admin-ui/client/components/CreateItemModal.js
+++ b/packages/admin-ui/client/components/CreateItemModal.js
@@ -5,7 +5,7 @@ import { Mutation } from 'react-apollo';
 
 import { Button } from '@arch-ui/button';
 import Drawer from '@arch-ui/drawer';
-import { resolveAllKeys, arrayToObject } from '@keystone-alpha/utils';
+import { arrayToObject } from '@keystone-alpha/utils';
 import { gridSize } from '@arch-ui/theme';
 import { AutocompleteCaptor } from '@arch-ui/input';
 
@@ -38,12 +38,12 @@ class CreateItemModal extends Component {
     if (isLoading) return;
     const { item } = this.state;
 
-    resolveAllKeys(arrayToObject(fields, 'path', field => field.getValue(item)))
-      .then(data => createItem({ variables: { data } }))
-      .then(data => {
-        this.props.onCreate(data);
-        this.setState({ item: this.props.list.getInitialItemData() });
-      });
+    createItem({
+      variables: { data: arrayToObject(fields, 'path', field => field.serialize(item)) },
+    }).then(data => {
+      this.props.onCreate(data);
+      this.setState({ item: this.props.list.getInitialItemData() });
+    });
   };
   onClose = () => {
     const { isLoading } = this.props;

--- a/packages/admin-ui/client/components/UpdateManyItemsModal.js
+++ b/packages/admin-ui/client/components/UpdateManyItemsModal.js
@@ -4,7 +4,7 @@ import { Button } from '@arch-ui/button';
 import Drawer from '@arch-ui/drawer';
 import { FieldContainer, FieldLabel, FieldInput } from '@arch-ui/fields';
 import Select from '@arch-ui/select';
-import { omit, arrayToObject, resolveAllKeys } from '@keystone-alpha/utils';
+import { omit, arrayToObject } from '@keystone-alpha/utils';
 
 let Render = ({ children }) => children();
 
@@ -21,18 +21,16 @@ class UpdateManyModal extends Component {
     const { item, selectedFields } = this.state;
     if (isLoading) return;
 
-    resolveAllKeys(arrayToObject(selectedFields, 'path', field => field.getValue(item)))
-      .then(data => {
-        updateItem({
-          variables: {
-            data: items.map(id => ({ id, data })),
-          },
-        });
-      })
-      .then(() => {
-        this.props.onUpdate();
-        this.resetState();
-      });
+    const data = arrayToObject(selectedFields, 'path', field => field.serialize(item));
+
+    updateItem({
+      variables: {
+        data: items.map(id => ({ id, data })),
+      },
+    }).then(() => {
+      this.props.onUpdate();
+      this.resetState();
+    });
   };
 
   resetState = () => {

--- a/packages/admin-ui/client/pages/List/dataHooks.js
+++ b/packages/admin-ui/client/pages/List/dataHooks.js
@@ -166,7 +166,7 @@ export function useListItems(listKey) {
 
   useEffect(() => {
     if (data[list.gqlNames.listQueryName]) {
-      setItems(data[list.gqlNames.listQueryName]);
+      setItems(data[list.gqlNames.listQueryName].map(item => list.deserializeItemData(item)));
       setErrors(deconstructErrorsToDataShape(data.error)[list.gqlNames.listQueryName]);
     }
     if (data[list.gqlNames.listQueryMetaName]) {

--- a/packages/admin-ui/client/pages/List/index.js
+++ b/packages/admin-ui/client/pages/List/index.js
@@ -53,7 +53,6 @@ function ListLayout(props: LayoutProps) {
 
   const { urlState } = useListUrlState(list.key);
   const { filters } = useListFilter(list.key);
-  // const { items, itemCount, itemErrors } = useListItems(list.key);
   const [sortBy, handleSortChange] = useListSort(list.key);
 
   const { adminPath } = adminMeta;
@@ -271,7 +270,7 @@ function List(props: Props) {
   let itemCount;
   let itemErrors;
   if (query.data && query.data[list.gqlNames.listQueryName]) {
-    items = query.data[list.gqlNames.listQueryName];
+    items = query.data[list.gqlNames.listQueryName].map(item => list.deserializeItemData(item));
     itemErrors = deconstructErrorsToDataShape(query.data.error)[list.gqlNames.listQueryName];
   }
   if (query.data && query.data[list.gqlNames.listQueryMetaName]) {

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -68,7 +68,6 @@
     "graphql-tag": "^2.10.1",
     "html-webpack-plugin": "^3.2.0",
     "lodash.debounce": "^4.0.8",
-    "lodash.isequal": "^4.5.0",
     "lodash.set": "^4.3.2",
     "memoize-one": "^4.0.2",
     "preconstruct": "0.0.60",

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -50,6 +50,7 @@
     "intersection-observer": "^0.5.1",
     "is-hotkey": "^0.1.4",
     "lodash.groupby": "^4.6.0",
+    "lodash.isequal": "^4.5.0",
     "lodash.omitby": "^4.6.0",
     "luxon": "^1.11.4",
     "memoize-one": "^4.0.2",

--- a/packages/fields/src/Controller.js
+++ b/packages/fields/src/Controller.js
@@ -1,3 +1,5 @@
+import isEqual from 'lodash.isequal';
+
 export default class FieldController {
   constructor(config, list, adminMeta, views) {
     this.config = config;
@@ -13,6 +15,34 @@ export default class FieldController {
   // by the implementations gqlOutputFields
   getQueryFragment = () => this.path;
 
-  getValue = data => data[this.config.path] || '';
-  getInitialData = () => this.config.defaultValue || '';
+  // Prepare data for this field to be sent to the server as part of a GraphQL
+  // mutation. It must be serialized into the format expected within the field's
+  // Implementation#gqlCreateInputFields()/Implementation#gqlUpdateInputFields()
+  // NOTE: This function is run synchronously
+  serialize = data => data[this.config.path] || null;
+
+  // When receiving data from the server, it needs to be processed into a
+  // format ready for display. The format received will be the same as specified
+  // in the field's Implementation#gqlOutputFields()
+  // NOTE: This function is run synchronously
+  deserialize = data => data[this.config.path];
+
+  /**
+   * @description Before sending data to the GraphQL server, this check is run to exclude
+   * possibly expensive data from being sent. It also prevents issues where "no
+   * change" can be destructive (eg; uploading a file - we no longer have the
+   * file, so cannot update it and may accidentally send `null`).
+   * @param initialData {Object} An object containing the most recently received
+   * data from the server, keyed by the field's path. The values have already
+   * been passed to this.serialize() for you.
+   * @param initialData {Object} An object containing all of the data for the
+   * current item, keyed by the field's path. The values have already been
+   * passed to this.serialize() for you
+   * @return boolean
+   */
+  hasChanged = async (initialData, currentData) =>
+    isEqual(initialData[this.config.path], currentData[this.config.path]);
+
+  // eslint-disable-next-line no-unused-vars
+  getDefaultValue = data => this.config.defaultValue || '';
 }

--- a/packages/fields/src/types/CalendarDay/views/Controller.js
+++ b/packages/fields/src/types/CalendarDay/views/Controller.js
@@ -11,7 +11,7 @@ export default class CalendarDayController extends FieldController {
   formatFilter = ({ label, value }) => {
     return `${this.getFilterLabel({ label })}: "${value}"`;
   };
-  getValue = data => {
+  serialize = data => {
     let value = data[this.config.path];
     if (typeof value !== 'string') {
       return null;

--- a/packages/fields/src/types/Checkbox/views/Controller.js
+++ b/packages/fields/src/types/Checkbox/views/Controller.js
@@ -1,8 +1,9 @@
 import FieldController from '../../../Controller';
 
 export default class CheckboxController extends FieldController {
-  getValue = data => data[this.config.path] || false;
-  getInitialData = () => this.config.defaultValue || false;
+  serialize = data => !!data[this.config.path];
+  deserialize = data => data[this.config.path] || this.getDefaultValue();
+  getDefaultValue = () => this.config.defaultValue || false;
   getFilterGraphQL = ({ type, value }) => {
     const key = type === 'is' ? `${this.path}` : `${this.path}_${type}`;
     return `${key}: ${value}`;

--- a/packages/fields/src/types/Content/views/Controller.js
+++ b/packages/fields/src/types/Content/views/Controller.js
@@ -54,14 +54,16 @@ export default class ContentController extends TextController {
     });
   }
 
-  getValue = data => {
+  serialize = data => {
     const { path } = this.config;
-    if (!data || !data[path] || !data[path].document) {
+    if (!data[path] || !data[path].document) {
       // Forcibly return null if empty string
       return { document: null };
     }
     return { document: data[path].document };
   };
+
+  deserialize = data => (data[this.config.path] ? data[this.config.path] : { document: {} });
 
   getQueryFragment = () => {
     return `

--- a/packages/fields/src/types/DateTime/views/Controller.js
+++ b/packages/fields/src/types/DateTime/views/Controller.js
@@ -19,7 +19,7 @@ export default class DateTimeController extends FieldController {
 
     return `${this.getFilterLabel({ label })}: "${formattedValue}"`;
   };
-  getValue = data => {
+  serialize = data => {
     let value = data[this.config.path];
     if (typeof value !== 'string') {
       return null;

--- a/packages/fields/src/types/Decimal/views/Controller.js
+++ b/packages/fields/src/types/Decimal/views/Controller.js
@@ -11,7 +11,7 @@ export default class TextController extends FieldController {
   formatFilter = ({ label, value }) => {
     return `${this.getFilterLabel({ label })}: "${value}"`;
   };
-  getValue = data => {
+  serialize = data => {
     const value = data[this.config.path];
     // Make the value a string to prevent loss of accuracy and precision.
     if (typeof value === 'string') {

--- a/packages/fields/src/types/File/views/Controller.js
+++ b/packages/fields/src/types/File/views/Controller.js
@@ -1,7 +1,7 @@
 import FieldController from '../../../Controller';
 
 export default class FileController extends FieldController {
-  getValue = data => {
+  serialize = data => {
     const { path } = this.config;
     if (!data || !data[path]) {
       // Forcibly return null if empty string

--- a/packages/fields/src/types/Float/views/Controller.js
+++ b/packages/fields/src/types/Float/views/Controller.js
@@ -11,7 +11,7 @@ export default class TextController extends FieldController {
   formatFilter = ({ label, value }) => {
     return `${this.getFilterLabel({ label })}: "${value}"`;
   };
-  getValue = data => {
+  serialize = data => {
     const value = data[this.config.path];
     if (typeof value === 'number') {
       return value;

--- a/packages/fields/src/types/Integer/views/Controller.js
+++ b/packages/fields/src/types/Integer/views/Controller.js
@@ -11,7 +11,7 @@ export default class TextController extends FieldController {
   formatFilter = ({ label, value }) => {
     return `${this.getFilterLabel({ label })}: "${value}"`;
   };
-  getValue = data => {
+  serialize = data => {
     const value = data[this.config.path];
     if (typeof value === 'number') {
       return value;

--- a/packages/fields/src/types/Relationship/views/Controller.js
+++ b/packages/fields/src/types/Relationship/views/Controller.js
@@ -32,7 +32,7 @@ export default class RelationshipController extends FieldController {
   buildRelateToOneInput = ({ id }) => ({ connect: { id } });
   buildRelateToManyInput = data => ({ connect: data.map(({ id }) => ({ id })) });
 
-  getValue = data => {
+  serialize = data => {
     const { many, path } = this.config;
 
     if (!data[path]) {
@@ -48,7 +48,7 @@ export default class RelationshipController extends FieldController {
 
     return this.buildRelateToOneInput(data[path], path);
   };
-  getInitialData = () => {
+  getDefaultValue = () => {
     const { defaultValue, many } = this.config;
     return many ? defaultValue || [] : defaultValue || null;
   };

--- a/packages/fields/src/types/Relationship/views/CreateItemModal.js
+++ b/packages/fields/src/types/Relationship/views/CreateItemModal.js
@@ -5,7 +5,7 @@ import { Mutation } from 'react-apollo';
 
 import { Button } from '@arch-ui/button';
 import Drawer from '@arch-ui/drawer';
-import { resolveAllKeys, arrayToObject } from '@keystone-alpha/utils';
+import { arrayToObject } from '@keystone-alpha/utils';
 import { gridSize } from '@arch-ui/theme';
 import { AutocompleteCaptor } from '@arch-ui/input';
 
@@ -38,12 +38,14 @@ class CreateItemModal extends Component {
     if (isLoading) return;
     const { item } = this.state;
 
-    resolveAllKeys(arrayToObject(fields, 'path', field => field.getValue(item)))
-      .then(data => createItem({ variables: { data } }))
-      .then(data => {
-        this.props.onCreate(data);
-        this.setState({ item: this.props.list.getInitialItemData() });
-      });
+    createItem({
+      variables: {
+        data: arrayToObject(fields, 'path', field => field.serialize(item)),
+      },
+    }).then(data => {
+      this.props.onCreate(data);
+      this.setState({ item: this.props.list.getInitialItemData() });
+    });
   };
   onClose = () => {
     const { isLoading } = this.props;

--- a/packages/fields/src/types/Select/views/Controller.js
+++ b/packages/fields/src/types/Select/views/Controller.js
@@ -5,11 +5,7 @@ export default class SelectController extends FieldController {
     super(...args);
     this.options = this.config.options;
   }
-  getValue = data => {
-    const { path } = this.config;
-    return data[path] ? data[path] : null;
-  };
-  getInitialData = () => {
+  getDefaultValue = () => {
     return this.config.defaultValue || null;
   };
   getFilterGraphQL = ({ value: { inverted, options } }) => {

--- a/packages/fields/tests/Controller.test.js
+++ b/packages/fields/tests/Controller.test.js
@@ -29,30 +29,44 @@ test('getQueryFragment()', () => {
   expect(value).toEqual('path');
 });
 
-describe('getValue()', () => {
-  test('getValue() - path exists', () => {
+describe('serialize()', () => {
+  test('serialize() - path exists', () => {
     const controller = new FieldController(config, 'list', 'adminMeta');
-    let value = controller.getValue({ path: 'some_value' });
+    let value = controller.serialize({ path: 'some_value' });
     expect(value).toEqual('some_value');
   });
 
-  test('getValue() - path does not exist', () => {
+  test('serialize() - path does not exist', () => {
     const controller = new FieldController(config, 'list', 'adminMeta');
-    const value = controller.getValue({});
-    expect(value).toEqual('');
+    const value = controller.serialize({});
+    expect(value).toEqual(null);
   });
 });
 
-describe('getInitialData()', () => {
-  test('getInitialData() - Default defined', () => {
+describe('deserialize()', () => {
+  test('deserialize() - path exists', () => {
     const controller = new FieldController(config, 'list', 'adminMeta');
-    const value = controller.getInitialData();
+    let value = controller.deserialize({ path: 'some_value' });
+    expect(value).toEqual('some_value');
+  });
+
+  test('deserialize() - path does not exist', () => {
+    const controller = new FieldController(config, 'list', 'adminMeta');
+    const value = controller.deserialize({});
+    expect(value).toEqual(undefined);
+  });
+});
+
+describe('getDefaultValue()', () => {
+  test('getDefaultValue() - Default defined', () => {
+    const controller = new FieldController(config, 'list', 'adminMeta');
+    const value = controller.getDefaultValue();
     expect(value).toEqual('default');
   });
 
-  test('getInitialData() - No default', () => {
+  test('getDefaultValue() - No default', () => {
     const controller = new FieldController({}, 'list', 'adminMeta');
-    const value = controller.getInitialData();
+    const value = controller.getDefaultValue();
     expect(value).toEqual('');
   });
 });


### PR DESCRIPTION
The `deserialize` method in particular will be used by the `Content` type to handle reconstructing the Slate.js editor state after reading from the API.

For each field Controller:
- Renames `.getInitialData()` -> `.getDefaultValue()`
- Renames `.getValue()` -> `.serialize()`
- Adds `.deserialize()` (where necessary)