### PR TITLE
Make Blocks have similar API to fields

### DIFF
--- a/packages/fields/src/Block.js
+++ b/packages/fields/src/Block.js
@@ -5,10 +5,6 @@ export class Block {
     this.auxList = undefined;
   }
 
-  static get isComplexDataType() {
-    return false;
-  }
-
   getGqlInputType() {
     if (!this.constructor.type) {
       throw new Error(`${this.constructor.name} must have a static 'type' property`);
@@ -32,5 +28,9 @@ export class Block {
   // Array of Keystone Field Types (most likely a `Relationship`)
   getGqlOutputFields() {
     return [];
+  }
+
+  get path() {
+    throw new Error(`${this.constructor.name} must have a 'path' getter`);
   }
 }

--- a/packages/fields/src/types/CloudinaryImage/index.js
+++ b/packages/fields/src/types/CloudinaryImage/index.js
@@ -1,11 +1,12 @@
+import { importView } from '@keystone-alpha/build-field-types';
+
 import {
   CloudinaryImage,
   MongoCloudinaryImageInterface,
   KnexCloudinaryImageInterface,
 } from './Implementation';
-
-import { CloudinaryBlock } from './Block';
-import { importView } from '@keystone-alpha/build-field-types';
+import { ImageBlock } from './ImageBlock';
+import imageContainer from '../Content/blocks/image-container';
 
 export default {
   type: 'CloudinaryImage',
@@ -19,5 +20,11 @@ export default {
     mongoose: MongoCloudinaryImageInterface,
     knex: KnexCloudinaryImageInterface,
   },
-  block: CloudinaryBlock,
+  blocks: {
+    image: {
+      type: 'cloudinaryImage',
+      viewPath: imageContainer.viewPath,
+      implementation: ImageBlock,
+    },
+  },
 };

--- a/packages/fields/src/types/Content/Implementation.js
+++ b/packages/fields/src/types/Content/Implementation.js
@@ -60,27 +60,18 @@ export class Content extends Text {
     }
 
     this.complexBlocks = this.blocks
-      .map(blockConfig => {
-        let Impl = blockConfig;
-        let fieldConfig = {};
-
-        if (Array.isArray(blockConfig)) {
-          Impl = blockConfig[0];
-          fieldConfig = blockConfig[1];
-        }
-
-        if (!Impl.isComplexDataType) {
-          return null;
-        }
-
-        return new Impl(fieldConfig, {
-          fromList: this.listKey,
-          createAuxList: listConfig.createAuxList,
-          getListByKey: listConfig.getListByKey,
-          listConfig: this.listConfig,
-        });
-      })
-      .filter(block => block);
+      .map(block => (Array.isArray(block) ? block : [block, {}]))
+      .filter(([block]) => block.implementation)
+      .map(
+        ([block, blockConfig]) =>
+          new block.implementation(blockConfig, {
+            type: block.type,
+            fromList: this.listKey,
+            createAuxList: listConfig.createAuxList,
+            getListByKey: listConfig.getListByKey,
+            listConfig: this.listConfig,
+          })
+      );
   }
 
   /*

--- a/test-projects/basic/index.js
+++ b/test-projects/basic/index.js
@@ -122,7 +122,7 @@ keystone.createList('Post', {
     value: {
       type: Content,
       blocks: [
-        [CloudinaryImage.block, { adapter: cloudinaryAdapter }],
+        [CloudinaryImage.blocks.image, { adapter: cloudinaryAdapter }],
         Content.blocks.blockquote,
         Content.blocks.image,
         Content.blocks.orderedList,


### PR DESCRIPTION
Taking a page from the Field API; Blocks can now optionally have a `.implementation` which defines the server-side logic to run.