### PR TITLE
Show loading spinner while loading views in List Table

### DIFF
--- a/.changeset/f4c4c52c/changes.json
+++ b/.changeset/f4c4c52c/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/admin-ui", "type": "patch" }], "dependents": [] }

--- a/.changeset/f4c4c52c/changes.md
+++ b/.changeset/f4c4c52c/changes.md
@@ -1,0 +1,1 @@
+- Show loading spinner while loading views in List Table

--- a/packages/admin-ui/client/components/NoResults.js
+++ b/packages/admin-ui/client/components/NoResults.js
@@ -6,7 +6,7 @@ import { Button } from '@arch-ui/button';
 import { InfoIcon } from '@arch-ui/icons';
 import { colors } from '@arch-ui/theme';
 
-import { useListPagination } from './dataHooks';
+import { useListPagination } from '../pages/List/dataHooks';
 
 const NoResultsWrapper = ({ children, ...props }) => (
   <div
@@ -27,7 +27,7 @@ const NoResultsWrapper = ({ children, ...props }) => (
   </div>
 );
 
-export const NoResults = ({ currentPage, filters, itemCount, list, search }) => {
+export const NoResults = ({ currentPage, filters, list, search }) => {
   const { onChange } = useListPagination(list.key);
   const onResetPage = () => onChange(1);
 
@@ -64,9 +64,5 @@ export const NoResults = ({ currentPage, filters, itemCount, list, search }) => 
     );
   }
 
-  if (itemCount === 0) {
-    return <NoResultsWrapper>No {list.plural.toLowerCase()} to display yet...</NoResultsWrapper>;
-  }
-
-  return null;
+  return <NoResultsWrapper>No {list.plural.toLowerCase()} to display yet...</NoResultsWrapper>;
 };

--- a/packages/admin-ui/client/pages/List/index.js
+++ b/packages/admin-ui/client/pages/List/index.js
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 
 import { jsx } from '@emotion/core';
-import { Fragment, Suspense, useEffect, useRef, useState } from 'react';
+import { Fragment, useEffect, useRef, useState } from 'react';
 import { Query } from 'react-apollo';
 
 import { IconButton } from '@arch-ui/button';
@@ -18,7 +18,6 @@ import CreateItemModal from '../../components/CreateItemModal';
 import DocTitle from '../../components/DocTitle';
 import ListTable from '../../components/ListTable';
 import PageError from '../../components/PageError';
-import PageLoading from '../../components/PageLoading';
 import { DisclosureArrow } from '../../components/Popout';
 import { deconstructErrorsToDataShape } from '../../util';
 
@@ -28,7 +27,6 @@ import SortPopout from './SortSelect';
 import Pagination, { getPaginationLabel } from './Pagination';
 import Search from './Search';
 import Management, { ManageToolbar } from './Management';
-import { NoResults } from './NoResults';
 import { useListFilter, useListSelect, useListSort, useListUrlState } from './dataHooks';
 
 const HeaderInset = props => (
@@ -204,66 +202,52 @@ function ListLayout(props: LayoutProps) {
       />
 
       <Container isFullWidth>
-        {items ? (
-          <Suspense fallback={<PageLoading />}>
-            {items.length ? (
-              <ListTable
-                adminPath={adminPath}
-                columnControl={
-                  <ColumnPopout
-                    listKey={list.key}
-                    target={handlers => (
-                      <Tooltip placement="top" content="Columns">
-                        {ref => (
-                          <Button
-                            variant="subtle"
-                            css={{
-                              background: 0,
-                              border: 0,
-                              color: colors.N40,
-                            }}
-                            {...handlers}
-                            ref={applyRefs(handlers.ref, ref)}
-                          >
-                            <KebabHorizontalIcon />
-                          </Button>
-                        )}
-                      </Tooltip>
-                    )}
-                  />
-                }
-                fields={fields}
-                handleSortChange={handleSortChange}
-                isFullWidth
-                items={items}
-                itemsErrors={itemErrors}
-                list={list}
-                onChange={onDeleteItem}
-                onSelectChange={onSelectChange}
-                selectedItems={selectedItems}
-                sortBy={sortBy}
-              />
-            ) : (
-              <NoResults
-                currentPage={currentPage}
-                filters={filters}
-                itemCount={itemCount}
-                list={list}
-                search={search}
-              />
-            )}
-          </Suspense>
-        ) : (
-          <PageLoading />
-        )}
+        <ListTable
+          adminPath={adminPath}
+          columnControl={
+            <ColumnPopout
+              listKey={list.key}
+              target={handlers => (
+                <Tooltip placement="top" content="Columns">
+                  {ref => (
+                    <Button
+                      variant="subtle"
+                      css={{
+                        background: 0,
+                        border: 0,
+                        color: colors.N40,
+                      }}
+                      {...handlers}
+                      ref={applyRefs(handlers.ref, ref)}
+                    >
+                      <KebabHorizontalIcon />
+                    </Button>
+                  )}
+                </Tooltip>
+              )}
+            />
+          }
+          fields={fields}
+          handleSortChange={handleSortChange}
+          isFullWidth
+          items={items}
+          itemsErrors={itemErrors}
+          list={list}
+          onChange={onDeleteItem}
+          onSelectChange={onSelectChange}
+          selectedItems={selectedItems}
+          sortBy={sortBy}
+          currentPage={currentPage}
+          filters={filters}
+          search={search}
+        />
       </Container>
     </main>
   );
 }
 
 function List(props: Props) {
-  const { adminMeta, list, query, routeProps } = props;
-  const { urlState } = useListUrlState(list.key);
+  const { list, query, routeProps } = props;
 
   // get item data
   let items;
@@ -295,11 +279,6 @@ function List(props: Props) {
       });
     }
   }, []);
-
-  // TODO: put this in some effect to limit calls
-  // we want to preload the Field components
-  // so that we don't have a waterfall after the data loads
-  adminMeta.preloadViews(urlState.fields.map(({ views }) => views && views.Cell).filter(x => x));
 
   // Error
   // ------------------------------

--- a/test-projects/access-control/cypress/integration/list/admin-ui.js
+++ b/test-projects/access-control/cypress/integration/list/admin-ui.js
@@ -363,11 +363,17 @@ describe('Access Control Lists > Admin UI', () => {
 
             cy.visit(`admin/${slug}`);
 
+            cy.get('#ks-list-table > [data-test-table-loaded=true]');
+
             // The first label inside thead wraps a visibly-hidden checkbox which
             // cypress can't find
             cy.get('#ks-list-table > thead label')
               .first()
-              .click();
+              // It's there, it's visible in the recordings, but Cypress
+              // _sometimes_ refuses to click it.
+              // See an image of it incorrectly failing here:
+              // https://17679-128193054-gh.circle-artifacts.com/0/tmp/screenshots/list/admin-ui.js/Access%20Control%20Lists%20%20Admin%20UI%20--%20updating%20--%20static%20--%20does%20not%20show%20update%20option%20when%20not%20updatable%20%28list%20view%29%20%7Bcreatefalse%2Creadtrue%2Cupdatefalse%2Cdeletefalse%7D%20%28failed%29.png
+              .click({ force: true });
             cy.get('button[data-test-name="update"]').should('exist');
           });
 
@@ -396,11 +402,17 @@ describe('Access Control Lists > Admin UI', () => {
 
             cy.visit(`admin/${slug}`);
 
+            cy.get('#ks-list-table > [data-test-table-loaded=true]');
+
             // The first label inside thead wraps a visibly-hidden checkbox which
             // cypress can't find
             cy.get('#ks-list-table > thead label')
               .first()
-              .click();
+              // It's there, it's visible in the recordings, but Cypress
+              // _sometimes_ refuses to click it.
+              // See an image of it incorrectly failing here:
+              // https://17679-128193054-gh.circle-artifacts.com/0/tmp/screenshots/list/admin-ui.js/Access%20Control%20Lists%20%20Admin%20UI%20--%20updating%20--%20static%20--%20does%20not%20show%20update%20option%20when%20not%20updatable%20%28list%20view%29%20%7Bcreatefalse%2Creadtrue%2Cupdatefalse%2Cdeletefalse%7D%20%28failed%29.png
+              .click({ force: true });
             cy.get('button[data-test-name="update"]').should('not.exist');
           });
 

--- a/test-projects/basic/cypress/integration/relationship-field-re-hydration_spec.js
+++ b/test-projects/basic/cypress/integration/relationship-field-re-hydration_spec.js
@@ -11,7 +11,11 @@ describe('Testing re-hydration', () => {
       // And now select and click the actually rendered element.
       cy.get('#react-select-ks-input-categories div[aria-hidden="true"]')
         .first()
-        .click();
+        // It's there, it's visible in the recordings, but Cypress _sometimes_
+        // refuses to click it.
+        // See an image of it incorrectly failing here:
+        // https://17680-128193054-gh.circle-artifacts.com/0/tmp/screenshots/relationship-field-re-hydration_spec.js/Testing%20re-hydration%20--%20Our%20new%20category%20should%20appear%20after%20we%20add%20it%20%28failed%29.png
+        .click({ force: true });
     }
 
     cy.visit('/admin/posts');


### PR DESCRIPTION
_NOTE: PR best viewed [with whitespace changes disabled](https://github.com/keystonejs/keystone-5/pull/1085/files?w=1)_

This moves the loading spinner _inside_ the table which allows the user to interact with the sorting / columns display even while data is loading.

It also implements the things in #1077 so the data and the views can load in parallel.

![posts-load-views-in-table](https://user-images.githubusercontent.com/612020/57124766-5184f480-6dca-11e9-9d5c-c12e45ce5a11.gif)
