### PR TITLE
Add .next to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,3 +10,4 @@ demo-projects/blog/app/.next
 packages/arch/www/public/**/*
 .changeset/**/*
 **/dist
+**/.next


### PR DESCRIPTION
Otherwise prettier will format next build output when run locally after you've run one of the next.js-based demos.