### PR TITLE
Simplify Content Type setup to extend Relationship

### DIFF
--- a/.changeset/9048213f/changes.json
+++ b/.changeset/9048213f/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/fields", "type": "patch" }], "dependents": [] }

--- a/.changeset/9048213f/changes.md
+++ b/.changeset/9048213f/changes.md
@@ -1,0 +1,1 @@
+- Refactor Content Type to extend Relationship Type to simplify implementation and enable future enhancements

--- a/packages/fields/src/Block.js
+++ b/packages/fields/src/Block.js
@@ -33,4 +33,8 @@ export class Block {
   get path() {
     throw new Error(`${this.constructor.name} must have a 'path' getter`);
   }
+
+  get fieldDefinitions() {
+    return {};
+  }
 }

--- a/packages/fields/src/types/Content/Implementation.js
+++ b/packages/fields/src/types/Content/Implementation.js
@@ -1,8 +1,14 @@
 import getByPath from 'lodash.get';
-import { MongoTextInterface, KnexTextInterface, Text } from '../Text/Implementation';
-import { flatMap, unique, resolveAllKeys, mapKeys } from '@keystone-alpha/utils';
+import {
+  MongoRelationshipInterface,
+  KnexRelationshipInterface,
+  Relationship,
+} from '../Relationship/Implementation';
+import { flatMap, unique, objMerge } from '@keystone-alpha/utils';
 import paragraph from './blocks/paragraph';
 import { walkSlateNode } from './slate-walker';
+import RelationshipType from '../Relationship';
+import TextType from '../Text';
 
 const GQL_TYPE_PREFIX = '_ContentType';
 
@@ -36,27 +42,18 @@ function flattenBlockViews(block) {
  *   },
  * }
  */
-async function processSerialised({ document, ...nestedMutations }, blocks, graphQlArgs) {
-  // TODO: Remove this once we use a JSON input type for the value
-  const inputDocument = JSON.parse(document);
-
-  // Each block executes its mutations
-  const resolvedMutations = await resolveAllKeys(
-    mapKeys(nestedMutations, (mutations, path) => {
-      const block = blocks.find(aBlock => aBlock.path === path);
-
-      if (!block) {
-        throw new Error(
-          `Unable to perform '${path}' mutations: No known block can handle this path.`
-        );
-      }
-
-      return block.processMutations(mutations, graphQlArgs);
-    })
+async function processSerialised(document, blocks, graphQlArgs) {
+  // Each block retreives its mutations
+  const resolvedMutations = blocks.reduce(
+    (mutations, block) => ({
+      ...mutations,
+      ...block.getMutationOperationResults(graphQlArgs),
+    }),
+    {}
   );
 
   const result = {
-    document: walkSlateNode(inputDocument, {
+    document: walkSlateNode(document, {
       visitBlock(node) {
         const block = blocks.find(({ type }) => type === node.type);
 
@@ -101,45 +98,35 @@ async function processSerialised({ document, ...nestedMutations }, blocks, graph
   return result;
 }
 
-export class Content extends Text {
-  constructor(path, config, listConfig) {
-    super(...arguments);
-
-    this.listConfig = listConfig;
-
+export class Content extends Relationship {
+  constructor(path, fieldConfig, listConfig) {
     // To maintain consistency with other types, we grab the sanitised name
     // directly from the list.
-    const { itemQueryName } = this.getListByKey(this.listKey).gqlNames;
+    const { itemQueryName } = listConfig.getListByKey(listConfig.listKey).gqlNames;
 
     // We prefix with `_` here to avoid any possible conflict with a list called
     // `ContentType`.
     // Including the list name + path to make sure these input types are unique
     // to this list+field and don't collide.
-    const type = `${GQL_TYPE_PREFIX}_${itemQueryName}_${this.path}`;
+    const type = `${GQL_TYPE_PREFIX}_${itemQueryName}_${path}`;
 
-    this.gqlTypes = {
-      create: `${type}_CreateInput`,
-      update: `${type}_UpdateInput`,
-      output: type,
-    };
+    const blocks = Array.isArray(fieldConfig.blocks) ? fieldConfig.blocks : [];
 
-    this.blocks = Array.isArray(this.config.blocks) ? this.config.blocks : [];
-
-    this.blocks.push(
+    blocks.push(
       ...DEFAULT_BLOCKS.filter(
         defaultBlock =>
-          !this.blocks.find(
+          !blocks.find(
             block => (Array.isArray(block) ? block[0] : block).type === defaultBlock.type
           )
       )
     );
 
     // Checking for duplicate block types
-    for (let currentIndex = 0; currentIndex < this.blocks.length; currentIndex++) {
-      const currentBlock = this.blocks[currentIndex];
+    for (let currentIndex = 0; currentIndex < blocks.length; currentIndex++) {
+      const currentBlock = blocks[currentIndex];
       const currentType = (Array.isArray(currentBlock) ? currentBlock[0] : currentBlock).type;
-      for (let checkIndex = currentIndex + 1; checkIndex < this.blocks.length; checkIndex++) {
-        const checkBlock = this.blocks[checkIndex];
+      for (let checkIndex = currentIndex + 1; checkIndex < blocks.length; checkIndex++) {
+        const checkBlock = blocks[checkIndex];
         const checkType = (Array.isArray(checkBlock) ? checkBlock[0] : checkBlock).type;
         if (currentType === checkType) {
           throw new Error(`Encountered duplicate Content block type '${currentType}'.`);
@@ -147,19 +134,80 @@ export class Content extends Text {
       }
     }
 
-    this.complexBlocks = this.blocks
+    const complexBlocks = blocks
       .map(block => (Array.isArray(block) ? block : [block, {}]))
       .filter(([block]) => block.implementation)
       .map(
         ([block, blockConfig]) =>
           new block.implementation(blockConfig, {
             type: block.type,
-            fromList: this.listKey,
+            fromList: listConfig.listKey,
+            joinList: type,
             createAuxList: listConfig.createAuxList,
             getListByKey: listConfig.getListByKey,
-            listConfig: this.listConfig,
+            listConfig,
           })
       );
+
+    // Ensure the list is only instantiated once per server instance.
+    let auxList = listConfig.getListByKey(type);
+
+    if (!auxList) {
+      auxList = listConfig.createAuxList(type, {
+        fields: {
+          // TODO: Change to a native JSON type
+          document: {
+            type: TextType,
+            isRequired: true,
+            schemaDoc: 'The serialized Slate.js Document structure',
+          },
+
+          // Used to do reverse lookups of Document -> Original Item
+          from: {
+            type: RelationshipType,
+            ref: `${listConfig.listKey}.${path}`,
+            schemaDoc: 'A reference back to the item this document belongs to',
+          },
+
+          // Gather up all the fields which blocks want to specify
+          // (note: They may be Relationships to Aux Lists themselves!)
+          ...objMerge(complexBlocks.map(block => block.fieldDefinitions)),
+        },
+        hooks: {
+          async resolveInput({ resolvedData, ...args }) {
+            // This method will get called twice;
+            // 1. The incoming graphql request data
+            // 2. Registering the back link in the `from` field
+            // We only want to handle the first case, so we bail early otherwise
+            if (!resolvedData.document) {
+              return resolvedData;
+            }
+
+            // TODO: Remove JSON.parse once using native JSON type
+            const documentObj = JSON.parse(resolvedData.document);
+            const { document } = await processSerialised(documentObj, complexBlocks, args);
+            return {
+              ...resolvedData,
+              // TODO: FIXME: Use a JSON type
+              document: JSON.stringify(document),
+            };
+          },
+        },
+      });
+    }
+
+    const config = {
+      ...fieldConfig,
+      many: false,
+      // Link up the back reference to keep things in sync
+      ref: `${type}.from`,
+    };
+
+    super(path, config, listConfig);
+
+    this.auxList = auxList;
+    this.listConfig = listConfig;
+    this.blocks = blocks;
   }
 
   /*
@@ -207,82 +255,15 @@ export class Content extends Text {
     };
   }
 
-  get gqlUpdateInputFields() {
-    return [`${this.path}: ${this.gqlTypes.update}`];
-  }
-  get gqlCreateInputFields() {
-    return [`${this.path}: ${this.gqlTypes.create}`];
-  }
-  getGqlAuxTypes() {
-    const inputFields = `
-      document: String
-    `;
-
-    return [
-      ...super.getGqlAuxTypes(),
-      /*
-       * For example:
-       *
-         document: String
-         cloudinaryImages: _ContentType_cloudinaryImageRelateToManyInput
-         relationships_User: _ContentType_relationship_UserRelateToManyInput
-       */
-      `
-      input ${this.gqlTypes.create} {
-        ${inputFields}
-        ${flatMap(this.complexBlocks, block =>
-          flatMap(block.getGqlInputFields(), field => field.gqlCreateInputFields)
-        ).join('\n')}
-      }
-      `,
-      `
-      input ${this.gqlTypes.update} {
-        ${inputFields}
-        ${flatMap(this.complexBlocks, block =>
-          flatMap(block.getGqlInputFields(), field => field.gqlUpdateInputFields)
-        ).join('\n')}
-      }
-      `,
-      ...flatMap(this.complexBlocks, block =>
-        flatMap(block.getGqlInputFields(), field => field.getGqlAuxTypes())
-      ),
-      `
-      type ${this.gqlTypes.output} {
-        document: String
-        ${flatMap(this.complexBlocks, block =>
-          flatMap(block.getGqlOutputFields(), field => field.gqlOutputFields)
-        ).join('\n')}
-      }
-      `,
-    ];
+  getGqlAuxTypes(...args) {
+    return [...super.getGqlAuxTypes(...args), ...this.auxList.getGqlTypes(...args)];
   }
 
   get gqlAuxFieldResolvers() {
-    return {
-      [this.gqlTypes.output]: item => item,
-    };
-  }
-
-  get gqlOutputFields() {
-    return [`${this.path}: ${this.gqlTypes.output}`];
-  }
-
-  get gqlOutputFieldResolvers() {
-    // TODO: serialize / etc
-    return {
-      [this.path]: item => ({
-        document: item[this.path],
-      }),
-    };
-  }
-
-  async resolveInput({ resolvedData, ...args }) {
-    const { document } = await processSerialised(resolvedData[this.path], this.complexBlocks, args);
-    // TODO: FIXME: Use a JSON type
-    return JSON.stringify(document);
+    return this.auxList.gqlFieldResolvers;
   }
 }
 
-export class MongoContentInterface extends MongoTextInterface {}
+export class MongoContentInterface extends MongoRelationshipInterface {}
 
-export class KnexContentInterface extends KnexTextInterface {}
+export class KnexContentInterface extends KnexRelationshipInterface {}

--- a/packages/fields/src/types/Content/views/Controller.js
+++ b/packages/fields/src/types/Content/views/Controller.js
@@ -102,7 +102,10 @@ export default class ContentController extends TextController {
     // TODO: Make this a JSON type in GraphQL so we don't have to stringify it.
     serialisedDocument.document = JSON.stringify(serialisedDocument.document);
 
-    return serialisedDocument;
+    return {
+      disconnectAll: true,
+      create: serialisedDocument,
+    };
   };
 
   deserialize = data => {


### PR DESCRIPTION
I was struck with inspiration 🛰💥, and realised that the `Content` type should extend the `Relationship` type (instead of `Text`), which means all the tricky stuff I was trying to do with manually triggering nested mutations can be handled by KS5 like normal.

This also greatly simplifies the next bit of work which is querying for the data, plus enables the `from` back-link `Relationship` to work out of the box.

