### PR TITLE
Merge default block config and only pass admin config to admin UI

### DIFF
--- a/.changeset/91cec723/changes.json
+++ b/.changeset/91cec723/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/fields", "type": "minor" }], "dependents": [] }

--- a/.changeset/91cec723/changes.md
+++ b/.changeset/91cec723/changes.md
@@ -1,0 +1,1 @@
+Allow Content Blocks to specify default config which is deeply merged into user-supplied config

--- a/.changeset/b865199c/changes.json
+++ b/.changeset/b865199c/changes.json
@@ -1,0 +1,90 @@
+{
+  "releases": [
+    { "name": "@keystone-alpha/cypress-project-basic", "type": "patch" },
+    { "name": "@keystone-alpha/fields", "type": "major" }
+  ],
+  "dependents": [
+    {
+      "name": "@keystone-alpha/admin-ui",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields"]
+    },
+    {
+      "name": "@keystone-alpha/fields-wysiwyg-tinymce",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields"]
+    },
+    {
+      "name": "@keystone-alpha/keystone",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields"]
+    },
+    {
+      "name": "@keystone-alpha/passport-auth",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields"]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-blog",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/fields-wysiwyg-tinymce",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-meetup",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/fields-wysiwyg-tinymce",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-todo",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-access-control",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-login",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-social-login",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/passport-auth",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/api-tests",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/keystone", "@keystone-alpha/fields"]
+    }
+  ]
+}

--- a/.changeset/b865199c/changes.md
+++ b/.changeset/b865199c/changes.md
@@ -1,0 +1,1 @@
+Block configs specifically for use in the AdminUI must now be set on a nested `adminConfig` key. All other config options will be available to the block's server side logic only.

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "listr": "^0.14.3",
     "loader-utils": "^1.2.3",
     "lodash.debounce": "^4.0.8",
+    "lodash.defaultsdeep": "^4.6.0",
     "lodash.get": "^4.4.2",
     "lodash.groupby": "^4.6.0",
     "lodash.isempty": "^4.4.0",

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -50,6 +50,7 @@
     "inflection": "^1.12.0",
     "intersection-observer": "^0.5.1",
     "is-hotkey": "^0.1.4",
+    "lodash.defaultsdeep": "^4.6.0",
     "lodash.get": "^4.4.2",
     "lodash.groupby": "^4.6.0",
     "lodash.isequal": "^4.5.0",

--- a/packages/fields/src/types/Content/Implementation.js
+++ b/packages/fields/src/types/Content/Implementation.js
@@ -234,11 +234,11 @@ export class Content extends Relationship {
             ? [block[0], defaultsDeep({}, block[1], block[0].defaultConfig)]
             : [block, block.defaultConfig]
         )
-        .filter(([, blockConfig]) => blockConfig && Object.keys(blockConfig).length)
+        .filter(([, blockConfig]) => blockConfig && blockConfig.adminConfig)
         .reduce(
           (options, block) => ({
             ...options,
-            [block[0].type]: block[1],
+            [block[0].type]: block[1].adminConfig,
           }),
           {}
         ),

--- a/packages/fields/src/types/Content/Implementation.js
+++ b/packages/fields/src/types/Content/Implementation.js
@@ -5,6 +5,7 @@ import {
   Relationship,
 } from '../Relationship/Implementation';
 import { flatMap, unique, objMerge } from '@keystone-alpha/utils';
+import defaultsDeep from 'lodash.defaultsdeep';
 import paragraph from './blocks/paragraph';
 import { walkSlateNode } from './slate-walker';
 import RelationshipType from '../Relationship';
@@ -139,7 +140,7 @@ export class Content extends Relationship {
       .filter(([block]) => block.implementation)
       .map(
         ([block, blockConfig]) =>
-          new block.implementation(blockConfig, {
+          new block.implementation(defaultsDeep({}, blockConfig, block.defaultConfig), {
             type: block.type,
             fromList: listConfig.listKey,
             joinList: type,
@@ -228,7 +229,12 @@ export class Content extends Relationship {
 
       // Key the block options by type to be serialised and passed to the client
       blockOptions: this.blocks
-        .filter(block => Array.isArray(block) && !!block[1])
+        .map(block =>
+          Array.isArray(block)
+            ? [block[0], defaultsDeep({}, block[1], block[0].defaultConfig)]
+            : [block, block.defaultConfig]
+        )
+        .filter(([, blockConfig]) => blockConfig && Object.keys(blockConfig).length)
         .reduce(
           (options, block) => ({
             ...options,

--- a/test-projects/basic/index.js
+++ b/test-projects/basic/index.js
@@ -126,7 +126,7 @@ keystone.createList('Post', {
         Content.blocks.blockquote,
         Content.blocks.orderedList,
         Content.blocks.unorderedList,
-        [Content.blocks.embed, { apiKey: process.env.EMBEDLY_API_KEY }],
+        [Content.blocks.embed, { adminConfig: { apiKey: process.env.EMBEDLY_API_KEY } }],
         Content.blocks.link,
         Content.blocks.heading,
       ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -13013,6 +13013,11 @@ lodash.defaults@^4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
   integrity sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=
 
+lodash.defaultsdeep@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.0.tgz#bec1024f85b1bd96cbea405b23c14ad6443a6f81"
+  integrity sha1-vsECT4WxvZbL6kBbI8FK1kQ6b4E=
+
 lodash.escaperegexp@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#64762c48618082518ac3df4ccf5d5886dae20347"


### PR DESCRIPTION
## Update

Based on the below discussion, this PR has a competing implementation:

- #1121: Implement an `extendAdminMeta()` API for blocks.
## Original PR

Ref #1039

Note: I added a `adminConfig` key to block configs so we can separate the server-side config options (Cloudinary keys), and the client side options (an upcoming PR will add a `query` config for generating the correct graphQL query client side).