### PR TITLE
Remove Docs link validator as it incorrectly fails for dynamic gatsby pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -265,8 +265,7 @@
     },
     "plugins": [
       "remark-frontmatter",
-      "remark-toc",
-      "remark-validate-links"
+      "remark-toc"
     ]
   },
   "bolt": {
@@ -351,7 +350,6 @@
     "remark-cli": "^6.0.1",
     "remark-frontmatter": "^1.3.1",
     "remark-toc": "^5.1.1",
-    "remark-validate-links": "^8.0.2",
     "start-server-and-test": "^1.7.13",
     "supertest-light": "^1.0.2",
     "terminal-link": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8356,11 +8356,6 @@ extend@^3.0.0, extend@~3.0.2:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
-extend@~2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/extend/-/extend-2.0.2.tgz#1b74985400171b85554894459c978de6ef453ab7"
-  integrity sha512-AgFD4VU+lVLP6vjnlNfF7OeInLTyeyckCNPEsuxz1vi786UuK/nk6ynPuhn/h+Ju9++TQyr5EpLRI14fc1QtTQ==
-
 extendable-error@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/extendable-error/-/extendable-error-0.1.5.tgz#122308a7097bc89a263b2c4fbf089c78140e3b6d"
@@ -9636,7 +9631,7 @@ github-from-package@0.0.0:
   resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
   integrity sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=
 
-github-slugger@^1.0.0, github-slugger@^1.2.0, github-slugger@^1.2.1:
+github-slugger@^1.0.0, github-slugger@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-1.2.1.tgz#47e904e70bf2dccd0014748142d31126cfd49508"
   integrity sha512-SsZUjg/P03KPzQBt7OxJPasGw6NRO5uOgiZ5RGXVud5iSIZ0eNZeNp5rTwCxtavrRUa/A77j8mePVc5lEvk0KQ==
@@ -10534,7 +10529,7 @@ homedir-polyfill@^1.0.1:
   dependencies:
     parse-passwd "^1.0.0"
 
-hosted-git-info@^2.1.4, hosted-git-info@^2.5.0, hosted-git-info@^2.6.0:
+hosted-git-info@^2.1.4, hosted-git-info@^2.6.0:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
   integrity sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==
@@ -12720,11 +12715,6 @@ leven@^2.0.0, leven@^2.1.0:
   resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
   integrity sha1-wuep93IJTe6dNCAq6KzORoeHVYA=
 
-levenshtein-edit-distance@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/levenshtein-edit-distance/-/levenshtein-edit-distance-1.0.0.tgz#895baf478cce8b5c1a0d27e45d7c1d978a661e49"
-  integrity sha1-iVuvR4zOi1waDSfkXXwdl4pmHkk=
-
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
@@ -13534,7 +13524,7 @@ mdast-util-compact@^1.0.0:
   dependencies:
     unist-util-visit "^1.1.0"
 
-mdast-util-definitions@^1.0.0, mdast-util-definitions@^1.2.0:
+mdast-util-definitions@^1.2.0:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/mdast-util-definitions/-/mdast-util-definitions-1.2.3.tgz#49f936b09207c45b438db19551652934312f04f0"
   integrity sha512-P6wpRO8YVQ1iv30maMc93NLh7COvufglBE8/ldcOyYmk5EbfF0YeqlLgtqP/FOBU501Kqar1x5wYWwB3Nga74g==
@@ -16965,13 +16955,6 @@ property-information@^4.0.0:
   dependencies:
     xtend "^4.0.1"
 
-propose@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/propose/-/propose-0.0.5.tgz#48a065d9ec7d4c8667f4050b15c4a2d85dbca56b"
-  integrity sha1-SKBl2ex9TIZn9AULFcSi2F28pWs=
-  dependencies:
-    levenshtein-edit-distance "^1.0.0"
-
 proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
@@ -18441,20 +18424,6 @@ remark-toc@^5.1.1:
   dependencies:
     mdast-util-toc "^3.0.0"
     remark-slug "^5.0.0"
-
-remark-validate-links@^8.0.2:
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/remark-validate-links/-/remark-validate-links-8.0.2.tgz#599fd837af8452b473576e58fed4aafaa99a621a"
-  integrity sha512-TDhmhEgyP9ivUcU2kyKl3d5dXwfN099woLoB6JVdYHRP7EFGgcQHNzZDRqs7zrSPCiVGgvna2HWhyWuNV7QPiQ==
-  dependencies:
-    github-slugger "^1.2.0"
-    hosted-git-info "^2.5.0"
-    mdast-util-definitions "^1.0.0"
-    mdast-util-to-string "^1.0.4"
-    propose "0.0.5"
-    unist-util-visit "^1.0.0"
-    urljoin "^0.1.5"
-    xtend "^4.0.1"
 
 remark@^10.0.0:
   version "10.0.1"
@@ -21609,13 +21578,6 @@ urlgrey@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/urlgrey/-/urlgrey-0.4.4.tgz#892fe95960805e85519f1cd4389f2cb4cbb7652f"
   integrity sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=
-
-urljoin@^0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/urljoin/-/urljoin-0.1.5.tgz#b25d2c6112c55ac9d50096a49a0f1fb7f4f53921"
-  integrity sha1-sl0sYRLFWsnVAJakmg8ft/T1OSE=
-  dependencies:
-    extend "~2.0.0"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
For example: https://circleci.com/gh/keystonejs/keystone-5/18146?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

```
$ remark . --frail --quiet
docs/discussions/schema.md
   126:2-126:80  warning  Link to unknown file: `keystone-alpha/fields/`                         missing-file  remark-validate-links
   655:6-656:63  warning  Link to unknown file: `keystone-alpha/fields/src/types/relationship`   missing-file  remark-validate-links
  820:39-821:59  warning  Link to unknown file: `keystone-alpha/fields/src/types/relationship/`  missing-file  remark-validate-links
```

(NOTE: No changeset is needed here as it's a CI only thing)