### PR TITLE
Blocks have default config merged into user config

### DIFF
--- a/.changeset/91cec723/changes.json
+++ b/.changeset/91cec723/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/fields", "type": "minor" }], "dependents": [] }

--- a/.changeset/91cec723/changes.md
+++ b/.changeset/91cec723/changes.md
@@ -1,0 +1,1 @@
+Allow Content Blocks to specify default config which is deeply merged into user-supplied config

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "listr": "^0.14.3",
     "loader-utils": "^1.2.3",
     "lodash.debounce": "^4.0.8",
+    "lodash.defaultsdeep": "^4.6.0",
     "lodash.get": "^4.4.2",
     "lodash.groupby": "^4.6.0",
     "lodash.isempty": "^4.4.0",

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -50,6 +50,7 @@
     "inflection": "^1.12.0",
     "intersection-observer": "^0.5.1",
     "is-hotkey": "^0.1.4",
+    "lodash.defaultsdeep": "^4.6.0",
     "lodash.get": "^4.4.2",
     "lodash.groupby": "^4.6.0",
     "lodash.isequal": "^4.5.0",

--- a/packages/fields/src/types/Content/Implementation.js
+++ b/packages/fields/src/types/Content/Implementation.js
@@ -5,6 +5,7 @@ import {
   Relationship,
 } from '../Relationship/Implementation';
 import { flatMap, unique, objMerge } from '@keystone-alpha/utils';
+import defaultsDeep from 'lodash.defaultsdeep';
 import paragraph from './blocks/paragraph';
 import { walkSlateNode } from './slate-walker';
 import RelationshipType from '../Relationship';
@@ -139,7 +140,7 @@ export class Content extends Relationship {
       .filter(([block]) => block.implementation)
       .map(
         ([block, blockConfig]) =>
-          new block.implementation(blockConfig, {
+          new block.implementation(defaultsDeep({}, blockConfig, block.defaultConfig), {
             type: block.type,
             fromList: listConfig.listKey,
             joinList: type,
@@ -228,7 +229,12 @@ export class Content extends Relationship {
 
       // Key the block options by type to be serialised and passed to the client
       blockOptions: this.blocks
-        .filter(block => Array.isArray(block) && !!block[1])
+        .map(block =>
+          Array.isArray(block)
+            ? [block[0], defaultsDeep({}, block[1], block[0].defaultConfig)]
+            : [block, block.defaultConfig]
+        )
+        .filter(([, blockConfig]) => blockConfig && Object.keys(blockConfig).length)
         .reduce(
           (options, block) => ({
             ...options,

--- a/yarn.lock
+++ b/yarn.lock
@@ -13013,6 +13013,11 @@ lodash.defaults@^4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
   integrity sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=
 
+lodash.defaultsdeep@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.0.tgz#bec1024f85b1bd96cbea405b23c14ad6443a6f81"
+  integrity sha1-vsECT4WxvZbL6kBbI8FK1kQ6b4E=
+
 lodash.escaperegexp@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#64762c48618082518ac3df4ccf5d5886dae20347"


### PR DESCRIPTION
Adds some functionality which #1099 requires; setting a default config that the user can overwrite for querying cloudinary image blocks.

NOTE: This change was originally part of #1097, but has been extracted here to avoid blocking on that discussion.