### PR TITLE
Allow blocks to pick data sent to the adminUI via extendAdminMeta()

### DIFF
--- a/.changeset/fe9769bc/changes.json
+++ b/.changeset/fe9769bc/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/fields", "type": "minor" }], "dependents": [] }

--- a/.changeset/fe9769bc/changes.md
+++ b/.changeset/fe9769bc/changes.md
@@ -1,0 +1,1 @@
+Allow blocks to pick data sent to the adminUI via extendAdminMeta()

--- a/packages/fields/src/Block.js
+++ b/packages/fields/src/Block.js
@@ -1,5 +1,7 @@
 export class Block {
-  constructor() {
+  constructor(_, { type }) {
+    this.type = type;
+
     // To be set by a Block if it creates a join table.
     // Instance of @keystone/core#List
     this.auxList = undefined;
@@ -36,5 +38,9 @@ export class Block {
 
   get fieldDefinitions() {
     return {};
+  }
+
+  extendAdminMeta(meta) {
+    return meta;
   }
 }

--- a/packages/fields/src/types/CloudinaryImage/ImageBlock.js
+++ b/packages/fields/src/types/CloudinaryImage/ImageBlock.js
@@ -18,10 +18,9 @@ const RelationshipWrapper = {
 };
 
 export class ImageBlock extends Block {
-  constructor({ adapter }, { type, fromList, joinList, createAuxList, getListByKey }) {
-    super();
+  constructor({ adapter }, { fromList, joinList, createAuxList, getListByKey }) {
+    super(...arguments);
 
-    this.type = type;
     this.joinList = joinList;
 
     const auxListKey = `_Block_${fromList}_${this.type}`;


### PR DESCRIPTION
Note: This is a competing implementation to #1097 based on the discussion there.