### PR TITLE
Fix dist directories not being cleared before builds causing broken builds with build-field-types

### DIFF
--- a/.changeset/d781dde1/changes.json
+++ b/.changeset/d781dde1/changes.json
@@ -1,0 +1,7 @@
+{
+  "releases": [
+    { "name": "@keystone-alpha/build-field-types", "type": "patch" },
+    { "name": "@keystone-alpha/fields", "type": "patch" }
+  ],
+  "dependents": []
+}

--- a/.changeset/d781dde1/changes.md
+++ b/.changeset/d781dde1/changes.md
@@ -1,0 +1,1 @@
+Fix dist directories not being cleared before builds causing broken builds with build-field-types

--- a/packages/build-field-types/src/build/index.js
+++ b/packages/build-field-types/src/build/index.js
@@ -11,7 +11,12 @@ import { createWorker, destroyWorker } from '../worker-client';
 
 async function buildPackage(pkg: Package, aliases: Aliases) {
   let configs = getRollupConfigs(pkg, aliases);
-  await fs.remove(path.join(pkg.directory, 'dist'));
+  await Promise.all([
+    fs.remove(path.join(pkg.directory, 'dist')),
+    ...pkg.entrypoints.map(entrypoint => {
+      return fs.remove(path.join(entrypoint.directory, 'dist'));
+    }),
+  ]);
 
   await Promise.all(
     configs.map(async ({ config, outputs }) => {

--- a/packages/build-field-types/src/build/watch.js
+++ b/packages/build-field-types/src/build/watch.js
@@ -19,7 +19,12 @@ function relativePath(id: string) {
 
 async function watchPackage(pkg: Package, aliases: Aliases) {
   const _configs = getRollupConfigs(pkg, aliases);
-  await fs.remove(path.join(pkg.directory, 'dist'));
+  await Promise.all([
+    fs.remove(path.join(pkg.directory, 'dist')),
+    ...pkg.entrypoints.map(entrypoint => {
+      return fs.remove(path.join(entrypoint.directory, 'dist'));
+    }),
+  ]);
   let configs = _configs.map(config => {
     return { ...toUnsafeRollupConfig(config.config), output: config.outputs };
   });


### PR DESCRIPTION
I fixed this a bit ago in preconstruct so here's the same thing in build-field-types.