### PR TITLE
Fix "Invalid Date" message when creating new items

### DIFF
--- a/.changeset/8668f664/changes.json
+++ b/.changeset/8668f664/changes.json
@@ -1,0 +1,6 @@
+{
+  "releases": [{ "name": "@arch-ui/day-picker", "type": "patch" }],
+  "dependents": [
+    { "name": "@keystone-alpha/fields", "type": "patch", "dependencies": ["@arch-ui/day-picker"] }
+  ]
+}

--- a/.changeset/8668f664/changes.md
+++ b/.changeset/8668f664/changes.md
@@ -1,0 +1,1 @@
+Fix "Invalid Date" message when creating new items

--- a/packages/arch/packages/day-picker/src/TextDayTimePicker.js
+++ b/packages/arch/packages/day-picker/src/TextDayTimePicker.js
@@ -48,7 +48,7 @@ function formatDateTime(date) {
   // why are we using moment when it's so large and provides a mutable API?
   // because chrono uses it and consistency is nice and
   // will probably make bugs with conversion less likely
-  return date === null ? '' : moment.parseZone(date).format('h:mm A Do MMMM YYYY Z');
+  return date ? moment.parseZone(date).format('h:mm A Do MMMM YYYY Z') : '';
 }
 
 function parseDate(value) {


### PR DESCRIPTION
Previously, when opening the Create Item modal, DateTime fields would be prepopulated with an "Invalid Date" message instead of being empty.

This was because we were checking for a `null` value but not an empty string, which is how the field value is initialised for the new item form.