### PR TITLE
Refactoring out adapter config option for `dbName`

### DIFF
--- a/.changeset/b6d7a7ec/changes.json
+++ b/.changeset/b6d7a7ec/changes.json
@@ -1,0 +1,59 @@
+{
+  "releases": [{ "name": "@keystone-alpha/adapter-mongoose", "type": "major" }],
+  "dependents": [
+    {
+      "name": "@keystone-alpha/fields",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/test-utils", "@keystone-alpha/adapter-mongoose"]
+    },
+    {
+      "name": "@keystone-alpha/test-utils",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose"]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-blog",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields", "@keystone-alpha/adapter-mongoose"]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-meetup",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields", "@keystone-alpha/adapter-mongoose"]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-todo",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields", "@keystone-alpha/adapter-mongoose"]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-access-control",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields", "@keystone-alpha/adapter-mongoose"]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-basic",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields", "@keystone-alpha/adapter-mongoose"]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-login",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields", "@keystone-alpha/adapter-mongoose"]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-social-login",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields", "@keystone-alpha/adapter-mongoose"]
+    },
+    {
+      "name": "@keystone-alpha/api-tests",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/fields",
+        "@keystone-alpha/test-utils",
+        "@keystone-alpha/adapter-mongoose"
+      ]
+    }
+  ]
+}

--- a/.changeset/b6d7a7ec/changes.md
+++ b/.changeset/b6d7a7ec/changes.md
@@ -1,0 +1,1 @@
+Removing 'dbName' config option

--- a/demo-projects/meetup/server.js
+++ b/demo-projects/meetup/server.js
@@ -1,3 +1,5 @@
+require('dotenv').config();
+
 const keystone = require('@keystone-alpha/core');
 const { Wysiwyg } = require('@keystone-alpha/fields-wysiwyg-tinymce');
 const next = require('next');
@@ -6,6 +8,7 @@ const initialData = require('./initialData');
 const routes = require('./routes');
 
 const port = process.env.PORT || 3000;
+const mongoUri = process.env.MONGODB_URI || 'mongodb://localhost:27017/keystonejs-meetup';
 
 const nextApp = next({
   dir: 'site',
@@ -16,7 +19,7 @@ const handler = routes.getRequestHandler(nextApp);
 
 Promise.all([keystone.prepare({ port }), nextApp.prepare()])
   .then(async ([{ server, keystone: keystoneApp }]) => {
-    await keystoneApp.connect();
+    await keystoneApp.connect(mongoUri);
 
     // Attach the auth routes
     server.app.use('/api', createAuthRoutes(keystoneApp));

--- a/packages/adapter-mongoose/README.md
+++ b/packages/adapter-mongoose/README.md
@@ -27,15 +27,11 @@ keystone.connect(mongoDbUri, mongooseOptions);
 
 ### `mongoDbUri`
 
-_**Default:**_ `'mongodb://localhost:27017/'`
+_**Default:**_ `'mongodb://localhost:27017/${SAFE_KEYSTONE_NAME}'`
 
 This URI will be passed directly to Mongoose (and hence MongoDB) as the location of the database.
 
 ### `mongooseOptions`
-
-#### `mongooseOptions.dbName`
-
-When set, this will overwrite any name specified in the `mongoDbUri` string.
 
 #### `mongooseOptions.*`
 

--- a/packages/adapter-mongoose/lib/adapter-mongoose.js
+++ b/packages/adapter-mongoose/lib/adapter-mongoose.js
@@ -285,19 +285,19 @@ class MongooseListAdapter extends BaseListAdapter {
       query.$count = 'count';
     }
 
-    return this.queryBuilder(query, pipeline =>
-      this.model.aggregate(pipeline).exec()
-    ).then(foundItems => {
-      if (meta) {
-        // When there are no items, we get undefined back, so we simulate the
-        // normal result of 0 items.
-        if (!foundItems[0]) {
-          return { count: 0 };
+    return this.queryBuilder(query, pipeline => this.model.aggregate(pipeline).exec()).then(
+      foundItems => {
+        if (meta) {
+          // When there are no items, we get undefined back, so we simulate the
+          // normal result of 0 items.
+          if (!foundItems[0]) {
+            return { count: 0 };
+          }
+          return foundItems[0];
         }
-        return foundItems[0];
+        return foundItems;
       }
-      return foundItems;
-    });
+    );
   }
 }
 

--- a/packages/adapter-mongoose/lib/adapter-mongoose.js
+++ b/packages/adapter-mongoose/lib/adapter-mongoose.js
@@ -84,7 +84,6 @@ class MongooseAdapter extends BaseKeystoneAdapter {
   }
 
   async _connect(to, config = {}) {
-
     // NOTE: We pull out `name` here, but don't use it, so it
     // doesn't conflict with the options the user wants passed to mongodb.
     const { name: _, ...adapterConnectOptions } = config;
@@ -97,10 +96,11 @@ class MongooseAdapter extends BaseKeystoneAdapter {
       logger.warn(`No MongoDB connection URI specified. Defaulting to '${uri}'`);
     }
 
-    await this.mongoose.connect(
-      uri,
-      { useNewUrlParser: true, useFindAndModify: false, ...adapterConnectOptions }
-    );
+    await this.mongoose.connect(uri, {
+      useNewUrlParser: true,
+      useFindAndModify: false,
+      ...adapterConnectOptions,
+    });
   }
   async postConnect() {
     return await pSettle(
@@ -285,19 +285,19 @@ class MongooseListAdapter extends BaseListAdapter {
       query.$count = 'count';
     }
 
-    return this.queryBuilder(query, pipeline => this.model.aggregate(pipeline).exec()).then(
-      foundItems => {
-        if (meta) {
-          // When there are no items, we get undefined back, so we simulate the
-          // normal result of 0 items.
-          if (!foundItems[0]) {
-            return { count: 0 };
-          }
-          return foundItems[0];
+    return this.queryBuilder(query, pipeline =>
+      this.model.aggregate(pipeline).exec()
+    ).then(foundItems => {
+      if (meta) {
+        // When there are no items, we get undefined back, so we simulate the
+        // normal result of 0 items.
+        if (!foundItems[0]) {
+          return { count: 0 };
         }
-        return foundItems;
+        return foundItems[0];
       }
-    );
+      return foundItems;
+    });
   }
 }
 

--- a/packages/keystone/lib/Keystone/index.js
+++ b/packages/keystone/lib/Keystone/index.js
@@ -33,11 +33,9 @@ module.exports = class Keystone {
     adapter,
     defaultAdapter,
     name,
-    dbName,
     adapterConnectOptions = {},
   }) {
     this.name = name;
-    this.dbName = dbName;
     this.adapterConnectOptions = adapterConnectOptions;
     this.defaultAccess = { list: true, field: true, ...defaultAccess };
     this.auth = {};
@@ -97,12 +95,11 @@ module.exports = class Keystone {
    * @return Promise<null>
    */
   connect(to, options) {
-    const { adapters, name, dbName, adapterConnectOptions } = this;
+    const { adapters, name, adapterConnectOptions } = this;
     return resolveAllKeys(
       mapKeys(adapters, adapter =>
         adapter.connect(to, {
           name,
-          dbName,
           ...adapterConnectOptions,
           ...options,
         })

--- a/packages/test-utils/lib/test-utils.js
+++ b/packages/test-utils/lib/test-utils.js
@@ -1,9 +1,10 @@
-const pFinally = require('p-finally');
-const { Keystone } = require('@keystone-alpha/keystone');
-const { createApolloServer } = require('@keystone-alpha/server');
-const { MongooseAdapter } = require('@keystone-alpha/adapter-mongoose');
-const { KnexAdapter } = require('@keystone-alpha/adapter-knex');
 const MongoDBMemoryServer = require('mongodb-memory-server').default;
+const pFinally = require('p-finally');
+const url = require('url');
+const { createApolloServer } = require('@keystone-alpha/server');
+const { Keystone } = require('@keystone-alpha/keystone');
+const { KnexAdapter } = require('@keystone-alpha/adapter-knex');
+const { MongooseAdapter } = require('@keystone-alpha/adapter-mongoose');
 
 const SCHEMA_NAME = 'testing';
 
@@ -36,8 +37,8 @@ async function getMongoMemoryServerConfig() {
   mongoServerReferences++;
   // Passing `true` here generates a new, random DB name for us
   const mongoUri = await mongoServer.getConnectionString(true);
-  // The dbName is the last part of the URI path
-  const dbName = mongoUri.split('/').pop();
+  // In theory the dbName can contain query params so lets parse it then extract the db name
+  const dbName = url.parse(mongoUri).pathname.split('/').pop();
 
   return { mongoUri, dbName };
 }

--- a/packages/test-utils/lib/test-utils.js
+++ b/packages/test-utils/lib/test-utils.js
@@ -38,7 +38,10 @@ async function getMongoMemoryServerConfig() {
   // Passing `true` here generates a new, random DB name for us
   const mongoUri = await mongoServer.getConnectionString(true);
   // In theory the dbName can contain query params so lets parse it then extract the db name
-  const dbName = url.parse(mongoUri).pathname.split('/').pop();
+  const dbName = url
+    .parse(mongoUri)
+    .pathname.split('/')
+    .pop();
 
   return { mongoUri, dbName };
 }


### PR DESCRIPTION
The `dbName` option is redundant and confusing. This info should be supplied in the connection URI. 

Default mongoose connection URI updated to include default db name based on Keystone `name`; if you want to specify a different DB name in dev, just supply the whole URI, eg: 'mongodb://localhost:27017/my-other-db'.