### PR TITLE
Add support for PORT and CONNECT_TO environment variables

### DIFF
--- a/.changeset/09105a67/changes.json
+++ b/.changeset/09105a67/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/keystone", "type": "minor" }], "dependents": [] }

--- a/.changeset/09105a67/changes.md
+++ b/.changeset/09105a67/changes.md
@@ -1,0 +1,1 @@
+Add support for setting PORT and CONNECT_TO environment variables

--- a/packages/keystone/bin/utils.js
+++ b/packages/keystone/bin/utils.js
@@ -2,7 +2,7 @@ const express = require('express');
 const endent = require('endent');
 const path = require('path');
 
-const { DEFAULT_ENTRY, DEFAULT_PORT } = require('../constants');
+const { DEFAULT_CONNECT_TO, DEFAULT_ENTRY, DEFAULT_PORT } = require('../constants');
 
 function getEntryFileFullPath(args, { exeName, _cwd }) {
   const entryFile = args['--entry'] ? args['--entry'] : DEFAULT_ENTRY;
@@ -20,6 +20,7 @@ function getEntryFileFullPath(args, { exeName, _cwd }) {
 
 function executeDefaultServer(args, entryFile, distDir) {
   const port = args['--port'] ? args['--port'] : DEFAULT_PORT;
+  const connectTo = args['--connect-to'] ? args['--connect-to'] : DEFAULT_CONNECT_TO;
 
   const { keystone, apps } = require(path.resolve(entryFile));
 
@@ -28,7 +29,7 @@ function executeDefaultServer(args, entryFile, distDir) {
   return keystone
     .prepare({ apps, port, distDir, dev: process.env.NODE_ENV !== 'production' })
     .then(async ({ middlewares }) => {
-      await keystone.connect();
+      await keystone.connect(connectTo);
 
       app.use(middlewares);
 

--- a/packages/keystone/constants.js
+++ b/packages/keystone/constants.js
@@ -1,5 +1,6 @@
 module.exports = {
-  DEFAULT_PORT: 3000,
+  DEFAULT_PORT: process.env.PORT || 3000,
+  DEFAULT_CONNECT_TO: process.env.CONNECT_TO || undefined,
   DEFAULT_ENTRY: 'index.js',
   DEFAULT_SERVER: 'server.js',
   DEFAULT_DIST_DIR: 'dist',


### PR DESCRIPTION
Follow up to #1200

Allows both the port and the connection `to` argument to be set using environment variables in the CLI.

I'm not a major fan of _many ways to do a thing_ but in this case it's necessary, because for heroku deployments both of these need to be provided as environment variables and not hard-coded into the CLI command.

`PORT` is pretty standard. There are a lot of conventions for providing the database connection string so I went with `CONNECT_TO` because it seemed the most accurate / descriptive. It's the `to` argument that the `keystone.connect` method supports.

I know there have been intentions to change the way ports and connection strings can be configured in keystone and the adapters, so I don't mind if this gets cleaned up later, but for now it's critical for us to be able to deploy the meetup website without using a custom `server.js` file.