### PR TITLE
restore process.env.MONGODB_URI for test-project

### DIFF
--- a/.changeset/cb278d0e/changes.json
+++ b/.changeset/cb278d0e/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "@keystone-alpha/cypress-project-basic", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/cb278d0e/changes.md
+++ b/.changeset/cb278d0e/changes.md
@@ -1,0 +1,1 @@
+Restore process.env.MONGODB_URI to test project example

--- a/test-projects/basic/server.js
+++ b/test-projects/basic/server.js
@@ -7,7 +7,7 @@ const initialData = require('./data');
 keystone
   .prepare({ apps, port, dev: process.env.NODE_ENV !== 'production' })
   .then(async ({ middlewares }) => {
-    await keystone.connect();
+    await keystone.connect(process.env.MONGODB_URI);
 
     // Initialise some data.
     // NOTE: This is only for test purposes and should not be used in production


### PR DESCRIPTION
@jesstelford as discussed,  #1201 did __not__ introduce `CONNECT_TO` as a Keystone-wide environment variable,  but only for the `keystone` command.  Thereby this had nothing set.

This resolves that,  possibly. 