### PR TITLE
Add docs on Apps

### DIFF
--- a/docs/discussions/README.md
+++ b/docs/discussions/README.md
@@ -12,3 +12,5 @@ Some discussion papers to help you perform various tasks in the KeystoneJS ecosy
 - [Hooks](./hooks.md)
 - [Mutation Lifecycle](./mutation-lifecycle.md)
 - [Performance](./performance.md)
+- [KeystoneJS Apps](./apps.md)
+- [Custom Server](./custom-server.md)

--- a/docs/discussions/apps.md
+++ b/docs/discussions/apps.md
@@ -1,0 +1,75 @@
+---
+section: discussions
+title: KeystoneJS Apps
+---
+
+# KeystoneJS Apps
+
+A KeystoneJS instance can be summarised as a function of your schema which
+creates a GraphQL API for querying, and an AdminUI for managing your data:
+
+```
+schema => ({ GraphQL, AdminUI })
+```
+
+Here, `GraphQL` and `AdminUI` are referred to as **Apps**.
+
+A KeystoneJS **App** has two primary purposes
+
+1. Prepare an `express`-compatible middleware for handling incoming http requests
+2. Provide a `build()` method to create a static production build for this app
+
+The mimimum KeystoneJS application requires at least one app, the [GraphQL
+API](../keystone-alpha/app-graphql):
+
+`index.js`
+```javascript
+const { GraphQLApp } = require('@keystone-alpha/app-graphql');
+const { Keystone } = require('@keystone-alpha/keystone');
+
+const keystone = new Keystone(/* ... */);
+
+// ...
+
+module.exports = {
+  keystone,
+  apps: [
+    new GraphQLApp(),
+  ]
+}
+```
+
+Most of the time the `GraphQLApp` will be paired with an `AdminUIApp` which
+provides the functionality of the KeystoneJS Admin UI:
+
+`index.js`
+```diff
+ const { GraphQLApp } = require('@keystone-alpha/app-graphql');
++const { AdminUIApp } = require('@keystone-alpha/app-admin-ui');
+ const { Keystone } = require('@keystone-alpha/keystone');
+
+ const keystone = new Keystone(/* ... */);
+
+ // ...
+
+ module.exports = {
+   keystone,
+   apps: [
+     new GraphQLApp(),
++    new AdminUIApp(),
+   ]
+ }
+```
+
+In both cases, the `keystone dev` and `keystone start` commands will consume the
+exported `.apps` array, making their middleware available in the order the apps
+are specified.
+
+If you're using a [Custom Server](./custom-server.md), it will be your
+responsibility to ensure each app's middleware is correctly injected into any
+http server you setup.
+
+Other interesting KeystoneJS compatible Apps are:
+
+- [Static App](../keystone-alpha/app-static) for serving static files.
+- [Next.js App](../keystone-alpha/app-next) for serving a Next.js App on the same server as the API

--- a/docs/discussions/custom-server.md
+++ b/docs/discussions/custom-server.md
@@ -5,17 +5,32 @@ title: Custom Server
 
 # Custom Server
 
-In some circumstances, you may want to do custom processing, or add extra routes
-the server which handles API requests.
+By default, the KeystoneJS CLI starts an `express`-powered server for you when
+running the `keystone dev` or `keystone start` commands.
 
-By default, the `keystone` CLI provides a server powered by `express` which is
-started for you when you run the CLI.
+In some circumstances, you may want to have more control over the server which
+handles the GraphQL API and Admin UI. Things such as:
 
-A _Custom Server_  will act as the entry point to your application (either in
-combination with, or as part of `index.js` which defines your schema) and must
-handle initialising a server and applying the Keystone Apps.
+- Add additional routes
+- Setup additional server middleware (`compress`/`brotli`/etc)
+- Notify a 3rd party service when the API is ready
+- ... etc
 
-Here are some different ways of creating a custom server:
+A **Custom Server** can replace the default and act as the entry point to your
+application which consumes your [schema definition](./schema.md). A Custom
+Server must handle initialising a http server which correctly executes any given
+[KeystoneJS Apps](./apps.md).
+
+_NOTE_: Before reaching for a custom server, consider using a [KeystoneJS
+App](./apps.md) which can enhance the functionality of the default server. Apps
+available in Keystone include:
+
+- [Static App](../keystone-alpha/app-static) for serving static files.
+- [Next.js App](../keystone-alpha/app-next) for serving a Next.js App on the same server as the API
+- ...[plus more](./apps.md)
+
+The following are some possible ways of setting up a custom server, roughly in
+order of complexity.
 
 ## Minimal Custom Server
 


### PR DESCRIPTION
To complement the Custom Server docs added in #1213, here are docs about the newly added _apps_ (see #1109).

See a preview of the docs here: https://5ce3fd9bf4d2be0009a59c34--v5keystonejs.netlify.com/discussions/apps