### PR TITLE
[website] Fix mobile menu on homepage and 404 

### DIFF
--- a/website/src/components/SidebarNav.js
+++ b/website/src/components/SidebarNav.js
@@ -1,0 +1,123 @@
+/** @jsx jsx */
+
+import React from 'react'; // eslint-disable-line no-unused-vars
+import { StaticQuery, graphql, Link } from 'gatsby';
+import { colors, gridSize } from '@arch-ui/theme';
+import { jsx } from '@emotion/core';
+
+export const SidebarNav = () => (
+  <StaticQuery
+    query={graphql`
+      query HeadingQuery {
+        allSitePage(
+          filter: { path: { ne: "/dev-404-page/" } }
+          sort: { fields: [context___sortOrder, context___pageTitle] }
+        ) {
+          edges {
+            node {
+              path
+              context {
+                navGroup
+                isPackageIndex
+                pageTitle
+              }
+            }
+          }
+        }
+      }
+    `}
+    render={data => {
+      const navData = data.allSitePage.edges.reduce((pageList, { node }) => {
+        // finding out what directory the file is in (eg '/keystone-alpha')
+        if (node.context.navGroup !== null) {
+          pageList[node.context.navGroup] = pageList[node.context.navGroup] || [];
+          pageList[node.context.navGroup].push(node);
+        }
+
+        return pageList;
+      }, {});
+
+      const navGroups = Object.keys(navData);
+
+      return (
+        <nav aria-label="Documentation Menu">
+          {navGroups.map(navGroup => {
+            const intro = navData[navGroup].find(node => node.context.pageTitle === 'Introduction');
+            const sectionId = `docs-menu-${navGroup}`;
+            return (
+              <div key={navGroup}>
+                <GroupHeading id={sectionId}>{navGroup.replace('-', ' ')}</GroupHeading>
+                <List aria-labelledby={sectionId}>
+                  {intro && (
+                    <ListItem key={intro.path} to={intro.path}>
+                      Introduction
+                    </ListItem>
+                  )}
+                  {navData[navGroup]
+                    .filter(node => node.context.pageTitle !== 'Introduction')
+                    .filter(node => navGroup !== 'packages' || node.context.isPackageIndex)
+                    .map(node => {
+                      return (
+                        <ListItem key={node.path} to={node.path}>
+                          {node.context.pageTitle}
+                        </ListItem>
+                      );
+                    })}
+                </List>
+              </div>
+            );
+          })}
+        </nav>
+      );
+    }}
+  />
+);
+
+const GroupHeading = props => (
+  <h3
+    css={{
+      color: colors.N80,
+      fontSize: '0.9rem',
+      fontWeight: 700,
+      marginTop: '2.4em',
+      textTransform: 'uppercase',
+    }}
+    {...props}
+  />
+);
+const List = props => (
+  <ul css={{ listStyle: 'none', fontSize: '0.9rem', padding: 0, margin: 0 }} {...props} />
+);
+const ListItem = props => (
+  <li>
+    <Link
+      css={{
+        color: colors.N80,
+        borderRadius: 3,
+        display: 'block',
+        overflow: 'hidden',
+        marginBottom: 1,
+        outline: 0,
+        padding: `${gridSize * 0.75}px ${gridSize * 1.5}px`,
+        textDecoration: 'none',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+
+        ':hover, :focus': {
+          backgroundColor: colors.B.A5,
+          color: colors.N100,
+          textDecoration: 'none',
+        },
+        ':active': {
+          backgroundColor: colors.B.A10,
+        },
+
+        '&[aria-current="page"]': {
+          backgroundColor: colors.B.A10,
+          fontWeight: 500,
+        },
+      }}
+      {...props}
+    />
+  </li>
+);

--- a/website/src/components/index.js
+++ b/website/src/components/index.js
@@ -3,5 +3,6 @@ export { Container } from './Container';
 export { Header } from './Header';
 export { Footer } from './Footer';
 export { Sidebar } from './Sidebar';
+export { SidebarNav } from './SidebarNav';
 export { Search } from './Search';
 export { SiteMeta } from './SiteMeta';

--- a/website/src/pages/404.js
+++ b/website/src/pages/404.js
@@ -6,14 +6,17 @@ import { globalStyles, gridSize } from '@arch-ui/theme';
 import { SkipNavContent } from '@reach/skip-nav';
 
 import Layout from '../templates/layout';
-import { Container } from '../components/Container';
+import { Container, Sidebar } from '../components';
 import { mq } from '../utils/media';
 
 export default () => (
   <Layout>
-    {() => (
+    {({ sidebarIsVisible, sidebarOffset }) => (
       <>
         <Global styles={globalStyles} />
+        <Container>
+          <Sidebar isVisible={sidebarIsVisible} offsetTop={sidebarOffset} mobileOnly />
+        </Container>
         <NotFound />
       </>
     )}

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -10,13 +10,17 @@ import { HomepageContent } from '../components/homepage/HomepageContent';
 import { VideoIntro } from '../components/homepage/VideoIntro';
 import { CONTAINER_GUTTERS } from '../components/Container';
 import { HEADER_HEIGHT } from '../components/Header';
+import { Container, Sidebar } from '../components';
 import { mq } from '../utils/media';
 
 export default () => (
   <Layout>
-    {() => (
+    {({ sidebarIsVisible, sidebarOffset }) => (
       <>
         <Global styles={globalStyles} />
+        <Container>
+          <Sidebar isVisible={sidebarIsVisible} offsetTop={sidebarOffset} mobileOnly />
+        </Container>
         <Hero />
       </>
     )}

--- a/website/src/templates/docs.js
+++ b/website/src/templates/docs.js
@@ -1,10 +1,10 @@
 /** @jsx jsx */
 
-import React, { useEffect, useRef, useState } from 'react'; // eslint-disable-line no-unused-vars
+import React from 'react'; // eslint-disable-line no-unused-vars
 import { Helmet } from 'react-helmet';
 import { Link, graphql } from 'gatsby';
 import MDXRenderer from 'gatsby-mdx/mdx-renderer';
-import throttle from 'lodash.throttle';
+
 import { MDXProvider } from '@mdx-js/tag';
 import { jsx } from '@emotion/core';
 import { SkipNavContent } from '@reach/skip-nav';
@@ -19,10 +19,9 @@ import Layout from '../templates/layout';
 import mdComponents from '../components/markdown';
 import { SiteMeta } from '../components/SiteMeta';
 import { media, mediaMax } from '../utils/media';
-import { Container, Footer, Sidebar, Search } from '../components';
+import { Container } from '../components';
 import { CONTAINER_GUTTERS } from '../components/Container';
-
-const SIDEBAR_WIDTH = 280;
+import { Sidebar, SIDEBAR_WIDTH } from '../components/Sidebar';
 
 function titleCase(str, at = '-') {
   if (!str) return str;
@@ -60,11 +59,7 @@ export default function Template({
       <Layout>
         {({ sidebarOffset, sidebarIsVisible }) => (
           <Container>
-            <Aside isVisible={sidebarIsVisible} offsetTop={sidebarOffset} key="sidebar">
-              <Search />
-              <Sidebar />
-              <Footer />
-            </Aside>
+            <Sidebar isVisible={sidebarIsVisible} offsetTop={sidebarOffset} />
             <Content>
               <main>
                 <SkipNavContent />
@@ -252,81 +247,7 @@ const PaginationButton = ({ align = 'left', ...props }) => (
 // ==============================
 
 const layoutGutter = gridSize * 4;
-let oldSidebarOffset = 0;
-let oldWindowOffset = 0;
 
-const Aside = ({ offsetTop, isVisible, ...props }) => {
-  const asideRef = useRef();
-  const [isStuck, setSticky] = useState(false);
-
-  const handleWindowScroll = () => {
-    oldWindowOffset = window.pageYOffset;
-    if (window.pageYOffset > offsetTop && !isStuck) {
-      setSticky(true);
-    }
-    if (window.pageYOffset <= offsetTop && isStuck) {
-      setSticky(false);
-    }
-  };
-
-  const maintainSidebarScroll = throttle(() => {
-    oldSidebarOffset = asideRef.current.scrollTop;
-  });
-
-  useEffect(() => {
-    const asideEl = asideRef.current; // maintain ref for cleanup
-    window.addEventListener('scroll', handleWindowScroll);
-    asideEl.addEventListener('scroll', maintainSidebarScroll);
-
-    // cleanup
-    return () => {
-      window.removeEventListener('scroll', handleWindowScroll);
-      asideEl.removeEventListener('scroll', maintainSidebarScroll);
-    };
-  });
-
-  // NOTE: maintain the user's scroll whilst navigating between pages.
-  // This is a symptom of Gatsby remounting the entire tree (template) on each
-  // page change via `createPage` in "gatsby-node.js".
-  useEffect(() => {
-    const scrollTop = oldWindowOffset ? oldSidebarOffset + offsetTop : oldSidebarOffset;
-    asideRef.current.scrollTop = scrollTop;
-  }, [asideRef.current]);
-
-  const stickyStyles = {
-    height: isStuck ? '100%' : `calc(100% - ${offsetTop}px)`,
-    position: isStuck ? 'fixed' : 'absolute',
-    width: SIDEBAR_WIDTH,
-    top: isStuck ? 0 : offsetTop,
-  };
-
-  // NOTE: the 5px gutter is to stop inner elements outline/box-shadow etc.
-  // being cropped because the aside has overflow-x hidden (due to y=auto).
-  const avoidCropGutter = 5;
-
-  return (
-    <aside
-      ref={asideRef}
-      css={{
-        boxSizing: 'border-box',
-        overflowY: 'auto',
-        paddingBottom: '3rem',
-        paddingTop: layoutGutter,
-        marginLeft: -avoidCropGutter,
-        paddingLeft: avoidCropGutter,
-
-        [mediaMax.sm]: {
-          display: isVisible ? 'block' : 'none',
-        },
-        [media.sm]: {
-          paddingRight: layoutGutter,
-          ...stickyStyles,
-        },
-      }}
-      {...props}
-    />
-  );
-};
 const Content = props => (
   <div
     css={{


### PR DESCRIPTION
On mobile, if you click the hamburger menu button on a page which does not have the sidebar menu, 
the menu does not toggle as expected. This can be seen on the [homepage](http://v5.keystonejs.com) and the [404 page](http://v5.keystonejs.com/1234). This is happening because the sidebar component isn't actually part of any non-documentation pages.

What I've done for this PR:

1. Take out the Sidebar component from `templates/docs.js` and move into its own component named `Sidebar`.
2. `Sidebar` now renders the `Footer`, `SidebarNav` and `Search` (rather than passing them as children) as it's now used in more than 1 file.
3. Added a new prop `mobileOnly` to `Sidebar` which will set display block or none 
4. Rename the current `Sidebar` component to `SidebarNav`.
5. Add the new `Sidebar` component to all pages
