### PR TITLE
Add authenticate<List>With<Strategy> and unauthenticate<List> mutations

### DIFF
--- a/.changeset/2c1ef3a6/changes.json
+++ b/.changeset/2c1ef3a6/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/fields", "type": "patch" }], "dependents": [] }

--- a/.changeset/2c1ef3a6/changes.md
+++ b/.changeset/2c1ef3a6/changes.md
@@ -1,0 +1,1 @@
+- Correctly read auth strategy info for displaying the "setCurrentUser" toggle on Relationship fields in the Admin UI

--- a/.changeset/8215a7c0/changes.json
+++ b/.changeset/8215a7c0/changes.json
@@ -1,0 +1,68 @@
+{
+  "releases": [{ "name": "@keystone-alpha/keystone", "type": "major" }],
+  "dependents": [
+    {
+      "name": "@keystone-alpha/adapter-mongoose",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/adapter-knex",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/test-utils",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/adapter-knex",
+        "@keystone-alpha/keystone"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-blog",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-meetup",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-todo",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-access-control",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-basic",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-login",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-social-login",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/api-tests",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/test-utils",
+        "@keystone-alpha/keystone"
+      ]
+    }
+  ]
+}

--- a/.changeset/8215a7c0/changes.md
+++ b/.changeset/8215a7c0/changes.md
@@ -1,0 +1,39 @@
+- `PasswordAuthStrategy#validate()` now accepts an object of `{ [identityField], [secretField] }` (was `{ identity, secret }`).
+- Auth Strategies can now add AdminMeta via a `#getAdminMeta()` method which will be attached to the `authStrategy` key of `adminMeta` in the Admin UI.
+- Added (un)authentication GraphQL mutations:
+    - ```graphql
+      mutation {
+        authenticate<List>With<Strategy>(<strategy-args) {
+          token # Add this token as a header: { Authorization: 'Bearer <token>' }
+          item # The authenticated item from <List>
+        }
+      }
+      ```
+      For the `PasswordAuthStrategy`, that is:
+      ```javascript
+      const authStrategy = keystone.createAuthStrategy({
+        type: PasswordAuthStrategy,
+        list: 'User',
+        config: {
+          identityField: 'username',
+          secretField: 'pass'
+        }
+      });
+      ```
+      ```graphql
+      mutation {
+        authenticateUserWithPassword(username: "jesstelford", pass: "abc123") {
+          token
+          item {
+            username
+          }
+        }
+      }
+      ```
+    - ```graphql
+      mutation {
+        unauthenticate<List> {
+          success
+        }
+      }
+      ```

--- a/.changeset/8b25666b/changes.json
+++ b/.changeset/8b25666b/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "@keystone-alpha/demo-project-meetup", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/8b25666b/changes.md
+++ b/.changeset/8b25666b/changes.md
@@ -1,0 +1,1 @@
+Use latest (un)authenticate mutations

--- a/.changeset/def5861d/changes.json
+++ b/.changeset/def5861d/changes.json
@@ -1,0 +1,59 @@
+{
+  "releases": [{ "name": "@keystone-alpha/session", "type": "major" }],
+  "dependents": [
+    {
+      "name": "@keystone-alpha/app-graphql",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/session"]
+    },
+    {
+      "name": "@keystone-alpha/app-admin-ui",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/session"]
+    },
+    {
+      "name": "@keystone-alpha/keystone",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/app-graphql", "@keystone-alpha/session"]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-meetup",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/app-graphql",
+        "@keystone-alpha/app-admin-ui",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/session"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-login",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/app-graphql",
+        "@keystone-alpha/app-admin-ui",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/session"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-social-login",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/app-graphql",
+        "@keystone-alpha/app-admin-ui",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/session"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/api-tests",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/app-graphql",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/session"
+      ]
+    }
+  ]
+}

--- a/.changeset/def5861d/changes.md
+++ b/.changeset/def5861d/changes.md
@@ -1,0 +1,8 @@
+- Removed `createSessionMiddleware` export. Most functionality has been replaced by the new `authenticate<List>With<Strategy>` & `unauthenticate<List>` mutations (see `@keystone-alpha/keystone` `CHANGELOG.md` for more details), and remaining functionality that was specific to `@keystone-alpha/app-admin-ui` and has been moved there.
+- Auth tokens received by header `Authorization: Bearer <token>` must now
+  include the signature (removing a potential attack vector where a client could
+  guess with an unsigned token until it matched a logged in user). The `token`
+  returned by `authenticate<List>With<Strategy>` includes this signature
+  automatically for you.
+- `startAuthedSession` now requires a fourth paramter: `cookieSecret` for
+  generating the signed `token`.

--- a/.changeset/e474d560/changes.json
+++ b/.changeset/e474d560/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/app-graphql", "type": "minor" }], "dependents": [] }

--- a/.changeset/e474d560/changes.md
+++ b/.changeset/e474d560/changes.md
@@ -1,0 +1,4 @@
+- GraphQL Playground now correctly sends auth cookies by default.
+- The GraphQL `context` object now has `startAuthedSession` and
+  `endAuthedSession` methods bound to the current request (from
+  `@keystone-alpha/session`)

--- a/.changeset/fe4e2a23/changes.json
+++ b/.changeset/fe4e2a23/changes.json
@@ -1,0 +1,40 @@
+{
+  "releases": [{ "name": "@keystone-alpha/app-admin-ui", "type": "major" }],
+  "dependents": [
+    {
+      "name": "@keystone-alpha/demo-project-blog",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/app-admin-ui"]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-meetup",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/app-admin-ui"]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-todo",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/app-admin-ui"]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-access-control",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/app-admin-ui"]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-login",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/app-admin-ui"]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-social-login",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/app-admin-ui"]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-basic",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/app-admin-ui"]
+    }
+  ]
+}

--- a/.changeset/fe4e2a23/changes.md
+++ b/.changeset/fe4e2a23/changes.md
@@ -1,0 +1,11 @@
+- Removed the `<adminPath>/signin`, `<adminPath>/signout`, and
+  `<adminPath>/session` routes.
+    - The REST routes have been replaced with GraphQL mutations
+      `authenticate<List>With<Strategy>` & `unauthenticate<List>` (see
+      `@keystone-alpha/keystone`'s `CHANGELOG.md` for details)
+- Admin UI now uses the new `(un)authenticate` mutations for sigin/signout
+  pages.
+- Signout page correctly renders again (previously was erroring and showing a
+  blank page)
+- Generate Admin UI login form field labels based on the identity and secret
+  fields set in the PasswordAuthStrategy.

--- a/demo-projects/meetup/initialData.js
+++ b/demo-projects/meetup/initialData.js
@@ -103,9 +103,11 @@ const initialData = {
       name: 'Keystone Launch',
       status: 'active',
       themeColor: '#334455',
-      startTime: '2019-05-15T18:00:00+11:00',
+      // Default to "1 month from now"
+      startTime: new Date(Date.now() + (1000 * 60 * 60 * 24 * 30)).toISOString(),
       durationMins: 150,
       maxRsvps: 120,
+      isRsvpAvailable: true,
     },
   ],
   Talk: [{ name: 'Introducing Keystone 5 🎉' }, { name: 'Keystone 5 - Under the hood' }],

--- a/demo-projects/meetup/initialData.js
+++ b/demo-projects/meetup/initialData.js
@@ -104,7 +104,7 @@ const initialData = {
       status: 'active',
       themeColor: '#334455',
       // Default to "1 month from now"
-      startTime: new Date(Date.now() + (1000 * 60 * 60 * 24 * 30)).toISOString(),
+      startTime: new Date(Date.now() + 1000 * 60 * 60 * 24 * 30).toISOString(),
       durationMins: 150,
       maxRsvps: 120,
       isRsvpAvailable: true,

--- a/demo-projects/meetup/site/components/auth/signin.js
+++ b/demo-projects/meetup/site/components/auth/signin.js
@@ -20,16 +20,14 @@ export default ({ onSuccess, onClickForgot }) => {
     event.preventDefault();
 
     setIsLoading(true);
-    const result = await signin({ email, password });
-    setIsLoading(false);
-
-    if (result.success) {
+    try {
+      await signin({ email, password });
+      setIsLoading(false);
       setErrorState(false);
-
       if (onSuccess && typeof onSuccess === 'function') {
         onSuccess();
       }
-    } else {
+    } catch (error) {
       setErrorState(true);
     }
   };

--- a/demo-projects/meetup/site/components/auth/signup.js
+++ b/demo-projects/meetup/site/components/auth/signup.js
@@ -27,12 +27,12 @@ export default () => {
 
   const handleSignin = async () => {
     setIsLoading(true);
-    const result = await signin({ email, password });
-    setIsLoading(false);
-    if (!result.success) {
-      setErrorState(true);
-    } else {
+    try {
+      await signin({ email, password });
+      setIsLoading(false);
       setErrorState(false);
+    } catch (error) {
+      setErrorState(true);
     }
   };
 

--- a/demo-projects/meetup/site/helpers/index.js
+++ b/demo-projects/meetup/site/helpers/index.js
@@ -60,5 +60,5 @@ export function useKeydown(key, callback) {
 
 // Strip Tags
 export const stripTags = htmlString => {
-  return htmlString.replace(/(<([^>]+)>)/gi, '');
+  return (htmlString || '').replace(/(<([^>]+)>)/gi, '');
 };

--- a/demo-projects/meetup/site/lib/authetication.js
+++ b/demo-projects/meetup/site/lib/authetication.js
@@ -122,12 +122,12 @@ class AuthProviderClass extends Component {
     return this.props.client
       .mutate({
         mutation: gql`
-        mutation {
-          unauthenticateUser {
-            success
+          mutation {
+            unauthenticateUser {
+              success
+            }
           }
-        }
-      `,
+        `,
         fetchPolicy: 'no-cache',
       })
       .then(async ({ data: { unauthenticateUser }, error }) => {

--- a/demo-projects/meetup/site/lib/authetication.js
+++ b/demo-projects/meetup/site/lib/authetication.js
@@ -1,13 +1,6 @@
 import React, { Component, createContext, useContext } from 'react';
-import getConfig from 'next/config';
 import { withApollo } from 'react-apollo';
 import gql from 'graphql-tag';
-
-const {
-  publicRuntimeConfig: { serverUrl },
-} = getConfig();
-
-const apiEndpoint = `${serverUrl}/admin`;
 
 /**
  * AuthContext
@@ -23,6 +16,10 @@ export const AuthContext = createContext();
  * A hook which provides access to the AuthContext
  */
 export const useAuth = () => useContext(AuthContext);
+
+const userFragment = `
+  id
+`;
 
 /**
  * AuthProvider
@@ -44,52 +41,118 @@ class AuthProviderClass extends Component {
     this.checkSession();
   }
 
+  setUserData = user => {
+    this.setState({
+      isInitialising: false,
+      isLoading: false,
+      isAuthenticated: !!user,
+      user,
+    });
+  };
+
   checkSession = async () => {
-    if (!this.state.isLoading) {
+    // Avoid an extra re-render
+    const { isLoading } = this.state;
+    if (!isLoading) {
       this.setState({ isLoading: true });
     }
-    const result = await checkSession(this.props.client);
-    const { user, isSignedIn } = result;
-    this.setState({
-      user,
-      isSignedIn,
-      isLoading: false,
-    });
-    return result;
+
+    return this.props.client
+      .query({
+        query: gql`
+          query {
+            authenticatedUser {
+              ${userFragment}
+            }
+          }
+        `,
+        fetchPolicy: 'no-cache',
+      })
+      .then(({ data: { authenticatedUser }, error }) => {
+        if (error) {
+          throw error;
+        }
+        this.setUserData(authenticatedUser);
+      })
+      .catch(error => {
+        console.error(error);
+        this.setState({ error, isLoading: false });
+        throw error;
+      });
   };
 
   signin = async ({ email, password }) => {
-    this.setState({ isLoading: true });
-    const result = await signInWithEmail({ email, password });
-
-    if (!result.success) {
-      this.setState({ isLoading: false });
-      return { success: false };
-    }
-
-    return this.checkSession(this.props.client);
+    this.setState({ error: null, isLoading: true });
+    // NOTE: We are not capturing the `token` here on purpose; The GraphQL API
+    // will set a `keystone.sid` cookie on its domain, which will be
+    // automatically read for each subsequent query.
+    return this.props.client
+      .mutate({
+        mutation: gql`
+          mutation signin($email: String, $password: String) {
+            authenticateUserWithPassword(email: $email, password: $password) {
+              item {
+                ${userFragment}
+              }
+            }
+          }
+        `,
+        fetchPolicy: 'no-cache',
+        variables: { email, password },
+      })
+      .then(async ({ data: { authenticateUserWithPassword }, error }) => {
+        if (error) {
+          throw error;
+        }
+        // Ensure there's no old unauthenticated data hanging around
+        await this.props.client.resetStore();
+        if (authenticateUserWithPassword && authenticateUserWithPassword.item) {
+          this.setUserData(authenticateUserWithPassword.item);
+        }
+      })
+      .catch(error => {
+        console.error(error);
+        this.setState({ error, isLoading: false });
+        throw error;
+      });
   };
 
   signout = async () => {
-    this.setState({ isLoading: true });
-    const result = await signout();
-    if (result.success) {
-      this.setState({
-        user: undefined,
-        isLoading: false,
+    this.setState({ error: null, isLoading: true });
+    return this.props.client
+      .mutate({
+        mutation: gql`
+        mutation {
+          unauthenticateUser {
+            success
+          }
+        }
+      `,
+        fetchPolicy: 'no-cache',
+      })
+      .then(async ({ data: { unauthenticateUser }, error }) => {
+        if (error) {
+          throw error;
+        }
+        // Ensure there's no old authenticated data hanging around
+        await this.props.client.resetStore();
+        if (unauthenticateUser && unauthenticateUser.success) {
+          this.setUserData(null);
+        }
+      })
+      .catch(error => {
+        console.error(error);
+        this.setState({ error, isLoading: false });
+        throw error;
       });
-      return { success: true };
-    } else {
-      return { success: false };
-    }
   };
 
   render() {
-    const { user, isLoading } = this.state;
+    const { user, isLoading, isAuthenticated } = this.state;
     return (
       <AuthContext.Provider
         value={{
-          isAuthenticated: !!user,
+          isAuthenticated,
           isLoading,
           signin: this.signin,
           signout: this.signout,
@@ -103,68 +166,3 @@ class AuthProviderClass extends Component {
 }
 
 export const AuthProvider = withApollo(AuthProviderClass);
-
-const signInWithEmail = async ({ email, password }) => {
-  try {
-    const res = await fetch(`${apiEndpoint}/signin`, {
-      method: 'POST',
-      credentials: 'same-origin',
-      headers: { 'Content-Type': 'application/json; charset=utf-8', Accept: 'application/json' },
-      body: JSON.stringify({ username: email, password }),
-    }).then(r => r.json());
-
-    if (res.success) {
-      return { success: true };
-    } else {
-      return { success: false, message: res.message };
-    }
-  } catch (error) {
-    console.error('Error signing in:', error);
-    return { success: false };
-  }
-};
-
-const signout = async () => {
-  try {
-    const res = await fetch(`${apiEndpoint}/signout`, {
-      method: 'POST',
-      credentials: 'same-origin',
-      headers: { Accept: 'application/json' },
-    }).then(r => r.json());
-
-    return {
-      success: res.success === true,
-    };
-  } catch (error) {
-    console.error('Error signing out:', error);
-    return { success: false };
-  }
-};
-
-const checkSession = async apolloClient => {
-  try {
-    const {
-      data: { authenticatedUser },
-    } = await apolloClient.query({
-      query: gql`
-        query {
-          authenticatedUser {
-            id
-            name
-            isAdmin
-          }
-        }
-      `,
-      fetchPolicy: 'network-only',
-    });
-
-    if (authenticatedUser) {
-      return { success: true, isSignedIn: true, user: authenticatedUser };
-    } else {
-      return { success: true, isSignedIn: false };
-    }
-  } catch (error) {
-    console.error('Error checking session:', error);
-    return { success: false, error: error.message };
-  }
-};

--- a/packages/app-admin-ui/client/components/Nav/NavIcons.js
+++ b/packages/app-admin-ui/client/components/Nav/NavIcons.js
@@ -12,10 +12,10 @@ import { useAdminMeta } from '../../providers/AdminMeta';
 const GITHUB_PROJECT = 'https://github.com/keystonejs/keystone-5';
 
 export function NavIcons() {
-  let { adminPath, graphiqlPath, signoutPath, withAuth } = useAdminMeta();
-  return ENABLE_DEV_FEATURES || withAuth ? (
+  let { adminPath, graphiqlPath, signoutPath, authStrategy } = useAdminMeta();
+  return ENABLE_DEV_FEATURES || authStrategy ? (
     <NavGroupIcons>
-      {withAuth ? (
+      {authStrategy ? (
         <PrimaryNavItem href={signoutPath} title="Sign Out">
           <SignOutIcon />
           <A11yText>Sign Out</A11yText>

--- a/packages/app-admin-ui/client/index.js
+++ b/packages/app-admin-ui/client/index.js
@@ -9,7 +9,6 @@ import { Global } from '@emotion/core';
 import { globalStyles } from '@arch-ui/theme';
 
 import ApolloClient from './apolloClient';
-
 import Nav from './components/Nav';
 import ScrollToTop from './components/ScrollToTop';
 import ConnectivityListener from './components/ConnectivityListener';

--- a/packages/app-admin-ui/client/pages/Signin.js
+++ b/packages/app-admin-ui/client/pages/Signin.js
@@ -10,6 +10,8 @@ import SessionProvider from '../providers/Session';
 
 import logo from '../assets/logo.png';
 
+const upcase = str => str.substr(0, 1).toUpperCase() + str.substr(1);
+
 const Container = styled.div({
   alignItems: 'center',
   display: 'flex',
@@ -65,24 +67,24 @@ const Spacer = styled.div({
 class SigninPage extends Component {
   reloading = false;
   state = {
-    username: '',
-    password: '',
+    identity: '',
+    secret: '',
   };
   onSubmit = e => {
     e.preventDefault();
     const { isLoading, signIn } = this.props;
-    const { username, password } = this.state;
+    const { identity, secret } = this.state;
     if (isLoading) return;
-    signIn({ username, password });
+    signIn({ identity, secret });
   };
   render() {
-    const { error, isLoading, isSignedIn } = this.props;
+    const { error, isLoading, isSignedIn, authStrategy } = this.props;
     if (isSignedIn && !this.reloading) {
       // Avoid reloading on subsequent renders
       this.reloading = true;
       window.location.reload(true);
     }
-    const { username, password } = this.state;
+    const { identity, secret } = this.state;
     return (
       <Container>
         <Alerts>
@@ -95,19 +97,19 @@ class SigninPage extends Component {
           <Divider />
           <div>
             <Fields>
-              <FieldLabel>Email</FieldLabel>
+              <FieldLabel>{upcase(authStrategy.identityField)}</FieldLabel>
               <Input
-                name="username"
+                name="identity"
                 autoFocus
-                value={username}
-                onChange={e => this.setState({ username: e.target.value })}
+                value={identity}
+                onChange={e => this.setState({ identity: e.target.value })}
               />
-              <FieldLabel>Password</FieldLabel>
+              <FieldLabel>{upcase(authStrategy.secretField)}</FieldLabel>
               <Input
                 type="password"
-                name="password"
-                value={password}
-                onChange={e => this.setState({ password: e.target.value })}
+                name="secret"
+                value={secret}
+                onChange={e => this.setState({ secret: e.target.value })}
               />
             </Fields>
             <LoadingButton
@@ -126,8 +128,8 @@ class SigninPage extends Component {
   }
 }
 
-export default ({ sessionPath, signinPath, signoutPath }) => (
-  <SessionProvider signinPath={signinPath} signoutPath={signoutPath} sessionPath={sessionPath}>
-    {props => <SigninPage {...props} />}
+export default ({ signinPath, signoutPath, authStrategy }) => (
+  <SessionProvider signinPath={signinPath} signoutPath={signoutPath}>
+    {props => <SigninPage {...props} authStrategy={authStrategy} />}
   </SessionProvider>
 );

--- a/packages/app-admin-ui/client/pages/Signout.js
+++ b/packages/app-admin-ui/client/pages/Signout.js
@@ -80,8 +80,8 @@ const SignedOutPage = ({ isLoading, isSignedIn, signinPath, signOut }) => {
   );
 };
 
-export default ({ signinPath, signoutPath, sessionPath }) => (
-  <SessionProvider signinPath={signinPath} signoutPath={signoutPath} sessionPath={sessionPath}>
+export default ({ signinPath, signoutPath }) => (
+  <SessionProvider signinPath={signinPath} signoutPath={signoutPath}>
     {props => <SignedOutPage signinPath={signinPath} {...props} />}
   </SessionProvider>
 );

--- a/packages/app-admin-ui/client/providers/Session.js
+++ b/packages/app-admin-ui/client/providers/Session.js
@@ -1,32 +1,12 @@
+import { withApollo } from 'react-apollo';
 import { Component } from 'react';
+import gql from 'graphql-tag';
 
-function getJSON(url) {
-  return fetch(url, {
-    cache: 'no-cache',
-    credentials: 'same-origin',
-    headers: {
-      'content-type': 'application/json',
-      Accept: 'application/json',
-    },
-    mode: 'cors',
-    redirect: 'follow',
-  }).then(response => response.json());
-}
+import { withAdminMeta } from './AdminMeta';
 
-function postJSON(url, data = {}) {
-  return fetch(url, {
-    body: JSON.stringify(data),
-    cache: 'no-cache',
-    credentials: 'same-origin',
-    headers: {
-      'content-type': 'application/json',
-      Accept: 'application/json',
-    },
-    method: 'POST',
-    mode: 'cors',
-    redirect: 'follow',
-  }).then(response => response.json());
-}
+const userFragment = `
+  id
+`;
 
 class Session extends Component {
   state = {
@@ -34,6 +14,8 @@ class Session extends Component {
     session: {},
     isLoading: true,
     isInitialising: true,
+    isSignedIn: false,
+    user: null,
   };
 
   componentDidMount() {
@@ -41,59 +23,119 @@ class Session extends Component {
     if (autoSignout) {
       this.signOut();
     } else {
-      this.getSession(autoSignout);
+      this.getSession();
     }
   }
 
+  setUserData = user => {
+    this.setState({
+      isInitialising: false,
+      isLoading: false,
+      isSignedIn: !!user,
+      user,
+    });
+  };
+
   getSession = () => {
-    const { sessionPath } = this.props;
     // Avoid an extra re-render
     const { isLoading } = this.state;
     if (!isLoading) {
       this.setState({ isLoading: true });
     }
-    // TODO: Handle errors
-    getJSON(sessionPath).then(data => {
-      this.setState({ isInitialising: false, isLoading: false, session: data });
-    });
+
+    this.props.client
+      .query({
+        query: gql`
+        query {
+          user: authenticated${this.props.adminMeta.authStrategy.listKey} {
+            ${userFragment}
+          }
+        }
+      `,
+        fetchPolicy: 'no-cache',
+      })
+      .then(({ data: { user }, error }) => {
+        if (error) {
+          throw error;
+        }
+        this.setUserData(user);
+      })
+      .catch(error => {
+        console.error(error);
+        this.setState({ error, isLoading: false });
+      });
   };
 
-  signIn = ({ username, password }) => {
-    const { signinPath } = this.props;
+  signIn = ({ identity, secret }) => {
     this.setState({ error: null, isLoading: true });
-    // TODO: Handle caught errors
-    postJSON(signinPath, { username, password })
-      .then(data => {
-        if (!data.success) {
-          this.setState({ error: data });
+    const { listKey, identityField, secretField } = this.props.adminMeta.authStrategy;
+    // NOTE: We are not capturing the `token` here on purpose; The GraphQL API
+    // will set a `keystone.sid` cookie on its domain, which will be
+    // automatically read for each subsequent query.
+    this.props.client
+      .mutate({
+        mutation: gql`
+        mutation signin($identity: String, $secret: String) {
+          authenticate: authenticate${listKey}WithPassword(${identityField}: $identity, ${secretField}: $secret) {
+            item {
+              ${userFragment}
+            }
+          }
         }
-        this.getSession();
+      `,
+        fetchPolicy: 'no-cache',
+        variables: { identity, secret },
       })
-      .catch(error => console.error(error));
+      .then(({ data: { authenticate }, error }) => {
+        if (error) {
+          throw error;
+        }
+        // Ensure there's no old unauthenticated data hanging around
+        this.props.client.resetStore();
+        if (authenticate && authenticate.item) {
+          this.setUserData(authenticate.item);
+        }
+      })
+      .catch(error => {
+        console.error(error);
+        this.setState({ error, isLoading: false });
+      });
   };
 
   signOut = () => {
-    const { signoutPath } = this.props;
-    // Avoid an extra re-render
-    const { isLoading, error } = this.state;
-    if (error || !isLoading) {
-      this.setState({ error: null, isLoading: true });
-    }
-    // TODO: Handle errors
-    postJSON(signoutPath)
-      .then(() => this.getSession())
-      .catch(e => console.error(e));
+    this.setState({ error: null, isLoading: true });
+    const { listKey } = this.props.adminMeta.authStrategy;
+    this.props.client
+      .mutate({
+        mutation: gql`
+        mutation {
+          unauthenticate: unauthenticate${listKey} {
+            success
+          }
+        }
+      `,
+        fetchPolicy: 'no-cache',
+      })
+      .then(({ data: { unauthenticate }, error }) => {
+        if (error) {
+          throw error;
+        }
+        // Ensure there's no old authenticated data hanging around
+        this.props.client.resetStore();
+        if (unauthenticate && unauthenticate.success) {
+          this.setUserData(null);
+        }
+      })
+      .catch(error => {
+        console.error(error);
+        this.setState({ error, isLoading: false });
+      });
   };
 
   render() {
     const { signIn, signOut } = this;
     const { children } = this.props;
-    const {
-      error,
-      session: { user, signedIn: isSignedIn },
-      isInitialising,
-      isLoading,
-    } = this.state;
+    const { error, user, isSignedIn, isInitialising, isLoading } = this.state;
 
     return children({
       error,
@@ -107,4 +149,4 @@ class Session extends Component {
   }
 }
 
-export default Session;
+export default withAdminMeta(withApollo(Session));

--- a/packages/app-admin-ui/client/providers/Session.js
+++ b/packages/app-admin-ui/client/providers/Session.js
@@ -43,15 +43,15 @@ class Session extends Component {
       this.setState({ isLoading: true });
     }
 
-    this.props.client
+    return this.props.client
       .query({
         query: gql`
-        query {
-          user: authenticated${this.props.adminMeta.authStrategy.listKey} {
-            ${userFragment}
+          query {
+            user: authenticated${this.props.adminMeta.authStrategy.listKey} {
+              ${userFragment}
+            }
           }
-        }
-      `,
+        `,
         fetchPolicy: 'no-cache',
       })
       .then(({ data: { user }, error }) => {
@@ -63,6 +63,7 @@ class Session extends Component {
       .catch(error => {
         console.error(error);
         this.setState({ error, isLoading: false });
+        throw error;
       });
   };
 
@@ -72,17 +73,17 @@ class Session extends Component {
     // NOTE: We are not capturing the `token` here on purpose; The GraphQL API
     // will set a `keystone.sid` cookie on its domain, which will be
     // automatically read for each subsequent query.
-    this.props.client
+    return this.props.client
       .mutate({
         mutation: gql`
-        mutation signin($identity: String, $secret: String) {
-          authenticate: authenticate${listKey}WithPassword(${identityField}: $identity, ${secretField}: $secret) {
-            item {
-              ${userFragment}
+          mutation signin($identity: String, $secret: String) {
+            authenticate: authenticate${listKey}WithPassword(${identityField}: $identity, ${secretField}: $secret) {
+              item {
+                ${userFragment}
+              }
             }
           }
-        }
-      `,
+        `,
         fetchPolicy: 'no-cache',
         variables: { identity, secret },
       })
@@ -99,13 +100,14 @@ class Session extends Component {
       .catch(error => {
         console.error(error);
         this.setState({ error, isLoading: false });
+        throw error;
       });
   };
 
   signOut = () => {
     this.setState({ error: null, isLoading: true });
     const { listKey } = this.props.adminMeta.authStrategy;
-    this.props.client
+    return this.props.client
       .mutate({
         mutation: gql`
         mutation {
@@ -129,6 +131,7 @@ class Session extends Component {
       .catch(error => {
         console.error(error);
         this.setState({ error, isLoading: false });
+        throw error;
       });
   };
 

--- a/packages/app-admin-ui/client/public.js
+++ b/packages/app-admin-ui/client/public.js
@@ -36,7 +36,7 @@ const Keystone = () => {
           <ConnectivityListener />
           <Global styles={globalStyles} />
 
-          {adminMeta.withAuth ? (
+          {adminMeta.authStrategy ? (
             <BrowserRouter>
               <Switch>
                 <Route

--- a/packages/app-admin-ui/tests/server/AdminUI.test.js
+++ b/packages/app-admin-ui/tests/server/AdminUI.test.js
@@ -38,7 +38,6 @@ describe('Add Middleware', () => {
       adminPath,
       signinPath: '/signin',
       signoutPath: '/signout',
-      sessionPath: '/session',
     });
 
     //expect(adminUI.createSessionMiddleware()).not.toBe(null);

--- a/packages/app-admin-ui/tests/server/AdminUI.test.js
+++ b/packages/app-admin-ui/tests/server/AdminUI.test.js
@@ -36,7 +36,6 @@ describe('Add Middleware', () => {
   test('Smoke test', () => {
     const adminUI = new AdminUIApp({
       adminPath,
-      signoutPath: '/signout',
     });
 
     //expect(adminUI.createSessionMiddleware()).not.toBe(null);

--- a/packages/app-admin-ui/tests/server/AdminUI.test.js
+++ b/packages/app-admin-ui/tests/server/AdminUI.test.js
@@ -36,7 +36,6 @@ describe('Add Middleware', () => {
   test('Smoke test', () => {
     const adminUI = new AdminUIApp({
       adminPath,
-      signinPath: '/signin',
       signoutPath: '/signout',
     });
 

--- a/packages/app-graphql/index.js
+++ b/packages/app-graphql/index.js
@@ -43,7 +43,13 @@ class GraphQLApp {
       middlewares.push(commonSessionMiddleware(keystone, this._cookieSecret, this._sessionStore));
     }
 
-    const server = createApolloServer(keystone, this._apollo, this._schemaName, dev);
+    const server = createApolloServer(
+      keystone,
+      this._apollo,
+      this._schemaName,
+      dev,
+      this._cookieSecret
+    );
     // GraphQL API always exists independent of any adminUI or Session
     // settings We currently make the admin UI public. In the future we want
     // to be able to restrict this to a limited audience, while setting up a

--- a/packages/app-graphql/lib/graphql.js
+++ b/packages/app-graphql/lib/graphql.js
@@ -14,7 +14,14 @@ const graphiqlMiddleware = endpoint => (req, res) => {
   }
 
   res.setHeader('Content-Type', 'text/html');
-  res.write(renderPlaygroundPage({ endpoint, version: playgroundPkg.version, tabs: [tab] }));
+  res.write(
+    renderPlaygroundPage({
+      endpoint,
+      version: playgroundPkg.version,
+      tabs: [tab],
+      settings: { 'request.credentials': 'same-origin' },
+    })
+  );
   res.end();
 };
 

--- a/packages/fields/src/types/Relationship/views/Field.js
+++ b/packages/fields/src/types/Relationship/views/Field.js
@@ -109,7 +109,7 @@ export default class RelationshipField extends Component {
   render() {
     const { autoFocus, field, value, renderContext, error, onChange } = this.props;
     const { many, ref } = field.config;
-    const { authList, withAuth } = field.adminMeta;
+    const { authStrategy } = field.adminMeta;
     const htmlID = `ks-input-${field.path}`;
     const canRead = !(error instanceof Error && error.name === 'AccessDeniedError');
     return (
@@ -146,14 +146,14 @@ export default class RelationshipField extends Component {
             }}
             field={field}
           />
-          {withAuth && ref === authList && (
+          {authStrategy && ref === authStrategy.listKey && (
             <SetAsCurrentUser
               many={many}
               onAddUser={user => {
                 onChange(many ? (value || []).concat(user) : user);
               }}
               value={value}
-              listKey={authList}
+              listKey={authStrategy.listKey}
             />
           )}
         </FieldInput>

--- a/packages/keystone/lib/Keystone/index.js
+++ b/packages/keystone/lib/Keystone/index.js
@@ -79,7 +79,7 @@ module.exports = class Keystone {
       getGraphQLQuery: schemaName => this._graphQLQuery[schemaName],
       adapter: adapters[adapterName],
       defaultAccess: this.defaultAccess,
-      getAuth: () => this.auth[key],
+      getAuth: () => this.auth[key] || {},
       registerType: type => this.registeredTypes.add(type),
       isAuxList,
       createAuxList: (auxKey, auxConfig) => {

--- a/packages/keystone/package.json
+++ b/packages/keystone/package.json
@@ -16,6 +16,7 @@
     "@keystone-alpha/build-field-types": "^1.0.2",
     "@keystone-alpha/fields": "^6.2.2",
     "@keystone-alpha/logger": "^2.0.0",
+    "@keystone-alpha/session": "^1.0.2",
     "@keystone-alpha/utils": "^3.0.0",
     "apollo-errors": "^1.9.0",
     "arg": "^4.1.0",

--- a/packages/keystone/tests/List.test.js
+++ b/packages/keystone/tests/List.test.js
@@ -65,6 +65,10 @@ class MockAdapter {
   newListAdapter = () => new MockListAdapter();
 }
 
+class MockPasswordAuthStrategy {
+  getInputFragment = () => 'password: String';
+}
+
 Text.adapters['mock'] = {};
 Checkbox.adapters['mock'] = {};
 Float.adapters['mock'] = {};
@@ -111,7 +115,7 @@ const getListByKey = listKey => {
   }
 };
 
-const listExtras = (getAuth = () => true, queryMethod = undefined) => ({
+const listExtras = (getAuth = () => {}, queryMethod = undefined) => ({
   getListByKey,
   adapter: new MockAdapter(),
   getAuth,
@@ -171,6 +175,10 @@ describe('new List()', () => {
       listQueryMetaName: '_allTestsMeta',
       listMetaName: '_TestsMeta',
       authenticatedQueryName: 'authenticatedTest',
+      authenticateMutationPrefix: 'authenticateTest',
+      authenticateOutputName: 'authenticateTestOutput',
+      unauthenticateMutationName: 'unauthenticateTest',
+      unauthenticateOutputName: 'unauthenticateTestOutput',
       deleteMutationName: 'deleteTest',
       deleteManyMutationName: 'deleteTests',
       updateMutationName: 'updateTest',
@@ -336,6 +344,10 @@ describe('getAdminMeta()', () => {
       listQueryMetaName: '_allTestsMeta',
       listMetaName: '_TestsMeta',
       authenticatedQueryName: 'authenticatedTest',
+      authenticateMutationPrefix: 'authenticateTest',
+      authenticateOutputName: 'authenticateTestOutput',
+      unauthenticateMutationName: 'unauthenticateTest',
+      unauthenticateOutputName: 'unauthenticateTestOutput',
       deleteMutationName: 'deleteTest',
       deleteManyMutationName: 'deleteTests',
       updateMutationName: 'updateTest',
@@ -405,169 +417,217 @@ describe('getAdminMeta()', () => {
   });
 });
 
-test('getGqlTypes()', () => {
-  const otherInput = `input OtherRelateToOneInput {
-    create: createOther
-    connect: OtherWhereUniqueInput
-    disconnect: OtherWhereUniqueInput
-    disconnectAll: Boolean
-  }`;
-  const type = `""" A keystone list """
-  type Test {
-    id: ID
-    """
-    This virtual field will be resolved in one of the following ways (in this order):
-     1. Execution of 'labelResolver' set on the Test List config, or
-     2. As an alias to the field set on 'labelField' in the Test List config, or
-     3. As an alias to a 'name' field on the Test List (if one exists), or
-     4. As an alias to the 'id' field on the Test List.
-    """
-    _label_: String
-    name: String
-    email: String
-    other: Other
-    writeOnce: String
-  }`;
-  const whereInput = `input TestWhereInput {
-    id: ID
-    id_not: ID
-    id_in: [ID!]
-    id_not_in: [ID!]
-    AND: [TestWhereInput]
-    OR: [TestWhereInput]
-    name: String
-    name_not: String
-    name_contains: String
-    name_not_contains: String
-    name_starts_with: String
-    name_not_starts_with: String
-    name_ends_with: String
-    name_not_ends_with: String
-    name_i: String
-    name_not_i: String
-    name_contains_i: String
-    name_not_contains_i: String
-    name_starts_with_i: String
-    name_not_starts_with_i: String
-    name_ends_with_i: String
-    name_not_ends_with_i: String
-    name_in: [String]
-    name_not_in: [String]
-    email: String
-    email_not: String
-    email_contains: String
-    email_not_contains: String
-    email_starts_with: String
-    email_not_starts_with: String
-    email_ends_with: String
-    email_not_ends_with: String
-    email_i: String
-    email_not_i: String
-    email_contains_i: String
-    email_not_contains_i: String
-    email_starts_with_i: String
-    email_not_starts_with_i: String
-    email_ends_with_i: String
-    email_not_ends_with_i: String
-    email_in: [String]
-    email_not_in: [String]
-    other: OtherWhereInput
-    other_is_null: Boolean
-    writeOnce: String
-    writeOnce_not: String
-    writeOnce_contains: String
-    writeOnce_not_contains: String
-    writeOnce_starts_with: String
-    writeOnce_not_starts_with: String
-    writeOnce_ends_with: String
-    writeOnce_not_ends_with: String
-    writeOnce_i: String
-    writeOnce_not_i: String
-    writeOnce_contains_i: String
-    writeOnce_not_contains_i: String
-    writeOnce_starts_with_i: String
-    writeOnce_not_starts_with_i: String
-    writeOnce_ends_with_i: String
-    writeOnce_not_ends_with_i: String
-    writeOnce_in: [String]
-    writeOnce_not_in: [String]
-  }`;
-  const whereUniqueInput = `input TestWhereUniqueInput {
-    id: ID!
-  }`;
-  const updateInput = `input TestUpdateInput {
-    name: String
-    email: String
-    other: OtherRelateToOneInput
-    hidden: String
-  }`;
-  const updateManyInput = `input TestsUpdateInput {
-    id: ID!
-    data: TestUpdateInput
-  }`;
-  const createInput = `input TestCreateInput {
-    name: String
-    email: String
-    other: OtherRelateToOneInput
-    hidden: String
-    writeOnce: String
-  }`;
-  const createManyInput = `input TestsCreateInput {
-    data: TestCreateInput
-  }`;
+[false, true].forEach(withAuth => {
+  test(`getGqlTypes() ${withAuth ? 'with' : 'without'} auth`, () => {
+    const otherInput = `input OtherRelateToOneInput {
+      create: createOther
+      connect: OtherWhereUniqueInput
+      disconnect: OtherWhereUniqueInput
+      disconnectAll: Boolean
+    }`;
+    const type = `""" A keystone list """
+    type Test {
+      id: ID
+      """
+      This virtual field will be resolved in one of the following ways (in this order):
+       1. Execution of 'labelResolver' set on the Test List config, or
+       2. As an alias to the field set on 'labelField' in the Test List config, or
+       3. As an alias to a 'name' field on the Test List (if one exists), or
+       4. As an alias to the 'id' field on the Test List.
+      """
+      _label_: String
+      name: String
+      email: String
+      other: Other
+      writeOnce: String
+    }`;
+    const whereInput = `input TestWhereInput {
+      id: ID
+      id_not: ID
+      id_in: [ID!]
+      id_not_in: [ID!]
+      AND: [TestWhereInput]
+      OR: [TestWhereInput]
+      name: String
+      name_not: String
+      name_contains: String
+      name_not_contains: String
+      name_starts_with: String
+      name_not_starts_with: String
+      name_ends_with: String
+      name_not_ends_with: String
+      name_i: String
+      name_not_i: String
+      name_contains_i: String
+      name_not_contains_i: String
+      name_starts_with_i: String
+      name_not_starts_with_i: String
+      name_ends_with_i: String
+      name_not_ends_with_i: String
+      name_in: [String]
+      name_not_in: [String]
+      email: String
+      email_not: String
+      email_contains: String
+      email_not_contains: String
+      email_starts_with: String
+      email_not_starts_with: String
+      email_ends_with: String
+      email_not_ends_with: String
+      email_i: String
+      email_not_i: String
+      email_contains_i: String
+      email_not_contains_i: String
+      email_starts_with_i: String
+      email_not_starts_with_i: String
+      email_ends_with_i: String
+      email_not_ends_with_i: String
+      email_in: [String]
+      email_not_in: [String]
+      other: OtherWhereInput
+      other_is_null: Boolean
+      writeOnce: String
+      writeOnce_not: String
+      writeOnce_contains: String
+      writeOnce_not_contains: String
+      writeOnce_starts_with: String
+      writeOnce_not_starts_with: String
+      writeOnce_ends_with: String
+      writeOnce_not_ends_with: String
+      writeOnce_i: String
+      writeOnce_not_i: String
+      writeOnce_contains_i: String
+      writeOnce_not_contains_i: String
+      writeOnce_starts_with_i: String
+      writeOnce_not_starts_with_i: String
+      writeOnce_ends_with_i: String
+      writeOnce_not_ends_with_i: String
+      writeOnce_in: [String]
+      writeOnce_not_in: [String]
+    }`;
+    const whereUniqueInput = `input TestWhereUniqueInput {
+      id: ID!
+    }`;
+    const updateInput = `input TestUpdateInput {
+      name: String
+      email: String
+      other: OtherRelateToOneInput
+      hidden: String
+    }`;
+    const updateManyInput = `input TestsUpdateInput {
+      id: ID!
+      data: TestUpdateInput
+    }`;
+    const createInput = `input TestCreateInput {
+      name: String
+      email: String
+      other: OtherRelateToOneInput
+      hidden: String
+      writeOnce: String
+    }`;
+    const createManyInput = `input TestsCreateInput {
+      data: TestCreateInput
+    }`;
+    const unauthenticateOutput = `type unauthenticateTestOutput {
+      """
+      \`true\` when unauthentication succeeds.
+      NOTE: unauthentication always succeeds when the request has an invalid or missing authentication token.
+      """
+      success: Boolean
+    }`;
+    const authenticateOutput = `type authenticateTestOutput {
+      """ Used to make subsequent authenticated requests by setting this token in a header: 'Authorization: Bearer <token>'. """
+      token: String
+      """ Retreive information on the newly authenticated Test here. """
+      item: Test
+    }`;
 
-  expect(
-    setup({ access: true })
-      .getGqlTypes()
-      .map(s => print(gql(s)))
-  ).toEqual(
-    [
-      otherInput,
-      type,
-      whereInput,
-      whereUniqueInput,
-      updateInput,
-      updateManyInput,
-      createInput,
-      createManyInput,
-    ].map(s => print(gql(s)))
-  );
+    const getAuth = withAuth ? () => ({ password: new MockPasswordAuthStrategy() }) : undefined;
 
-  expect(
-    setup({ access: false })
-      .getGqlTypes()
-      .map(s => print(gql(s)))
-  ).toEqual([].map(s => print(gql(s))));
+    expect(
+      setup({ access: true }, getAuth)
+        .getGqlTypes()
+        .map(s => print(gql(s)))
+    ).toEqual(
+      [
+        otherInput,
+        type,
+        whereInput,
+        whereUniqueInput,
+        updateInput,
+        updateManyInput,
+        createInput,
+        createManyInput,
+        ...(withAuth ? [unauthenticateOutput, authenticateOutput] : []),
+      ].map(s => print(gql(s)))
+    );
 
-  expect(
-    setup({ access: { read: true, create: false, update: false, delete: false } })
-      .getGqlTypes()
-      .map(s => print(gql(s)))
-  ).toEqual([otherInput, type, whereInput, whereUniqueInput].map(s => print(gql(s))));
+    expect(
+      setup({ access: false }, getAuth)
+        .getGqlTypes()
+        .map(s => print(gql(s)))
+    ).toEqual(
+      [...(withAuth ? [unauthenticateOutput, authenticateOutput] : [])].map(s => print(gql(s)))
+    );
 
-  expect(
-    setup({ access: { read: false, create: true, update: false, delete: false } })
-      .getGqlTypes()
-      .map(s => print(gql(s)))
-  ).toEqual(
-    [otherInput, type, whereInput, whereUniqueInput, createInput, createManyInput].map(s =>
-      print(gql(s))
-    )
-  );
-  expect(
-    setup({ access: { read: false, create: false, update: true, delete: false } })
-      .getGqlTypes()
-      .map(s => print(gql(s)))
-  ).toEqual(
-    [otherInput, type, whereInput, whereUniqueInput, updateInput, updateManyInput].map(s =>
-      print(gql(s))
-    )
-  );
-  expect(
-    setup({ access: { read: false, create: false, update: false, delete: true } })
-      .getGqlTypes()
-      .map(s => print(gql(s)))
-  ).toEqual([otherInput, type, whereInput, whereUniqueInput].map(s => print(gql(s))));
+    expect(
+      setup({ access: { read: true, create: false, update: false, delete: false } }, getAuth)
+        .getGqlTypes()
+        .map(s => print(gql(s)))
+    ).toEqual(
+      [
+        otherInput,
+        type,
+        whereInput,
+        whereUniqueInput,
+        ...(withAuth ? [unauthenticateOutput, authenticateOutput] : []),
+      ].map(s => print(gql(s)))
+    );
+
+    expect(
+      setup({ access: { read: false, create: true, update: false, delete: false } }, getAuth)
+        .getGqlTypes()
+        .map(s => print(gql(s)))
+    ).toEqual(
+      [
+        otherInput,
+        type,
+        whereInput,
+        whereUniqueInput,
+        createInput,
+        createManyInput,
+        ...(withAuth ? [unauthenticateOutput, authenticateOutput] : []),
+      ].map(s => print(gql(s)))
+    );
+    expect(
+      setup({ access: { read: false, create: false, update: true, delete: false } }, getAuth)
+        .getGqlTypes()
+        .map(s => print(gql(s)))
+    ).toEqual(
+      [
+        otherInput,
+        type,
+        whereInput,
+        whereUniqueInput,
+        updateInput,
+        updateManyInput,
+        ...(withAuth ? [unauthenticateOutput, authenticateOutput] : []),
+      ].map(s => print(gql(s)))
+    );
+    expect(
+      setup({ access: { read: false, create: false, update: false, delete: true } }, getAuth)
+        .getGqlTypes()
+        .map(s => print(gql(s)))
+    ).toEqual(
+      [
+        otherInput,
+        type,
+        whereInput,
+        whereUniqueInput,
+        ...(withAuth ? [unauthenticateOutput, authenticateOutput] : []),
+      ].map(s => print(gql(s)))
+    );
+  });
 });
 
 test('getGraphqlFilterFragment', () => {
@@ -581,81 +641,47 @@ test('getGraphqlFilterFragment', () => {
   ]);
 });
 
-test('getGqlQueries()', () => {
-  expect(
-    setup({ access: true })
-      .getGqlQueries()
-      .map(normalise)
-  ).toEqual(
-    [
-      `""" Search for all Test items which match the where clause. """
-      allTests(
-      where: TestWhereInput
-      search: String
-      orderBy: String
-      first: Int
-      skip: Int
-    ): [Test]`,
-      `""" Search for the Test item with the matching ID. """
-      Test(
-      where: TestWhereUniqueInput!
-    ): Test`,
-      `""" Perform a meta-query on all Test items which match the where clause. """
-      _allTestsMeta(
-      where: TestWhereInput
-      search: String
-      orderBy: String
-      first: Int
-      skip: Int
-    ): _QueryMeta`,
-      `""" Retrieve the meta-data for the Test list. """
-      _TestsMeta: _ListMeta`,
-      `authenticatedTest: Test`,
-    ].map(normalise)
-  );
+[false, true].forEach(withAuth => {
+  test(`getGqlQueries() ${withAuth ? 'with' : 'without'} auth`, () => {
+    const getAuth = withAuth ? () => ({ password: new MockPasswordAuthStrategy() }) : undefined;
+    expect(
+      setup({ access: true }, getAuth)
+        .getGqlQueries()
+        .map(normalise)
+    ).toEqual(
+      [
+        `""" Search for all Test items which match the where clause. """
+          allTests(
+          where: TestWhereInput
+          search: String
+          orderBy: String
+          first: Int
+          skip: Int
+        ): [Test]`,
+        `""" Search for the Test item with the matching ID. """
+          Test(
+          where: TestWhereUniqueInput!
+        ): Test`,
+        `""" Perform a meta-query on all Test items which match the where clause. """
+          _allTestsMeta(
+          where: TestWhereInput
+          search: String
+          orderBy: String
+          first: Int
+          skip: Int
+        ): _QueryMeta`,
+        `""" Retrieve the meta-data for the Test list. """
+        _TestsMeta: _ListMeta`,
+        ...(withAuth ? [`authenticatedTest: Test`] : []),
+      ].map(normalise)
+    );
 
-  expect(
-    setup({ access: false })
-      .getGqlQueries()
-      .map(normalise)
-  ).toEqual([`authenticatedTest: Test`].map(normalise));
-
-  expect(
-    setup({ access: true }, () => false)
-      .getGqlQueries()
-      .map(normalise)
-  ).toEqual(
-    [
-      `""" Search for all Test items which match the where clause. """
-      allTests(
-      where: TestWhereInput
-      search: String
-      orderBy: String
-      first: Int
-      skip: Int
-    ): [Test]`,
-      `""" Search for the Test item with the matching ID. """
-      Test(
-      where: TestWhereUniqueInput!
-    ): Test`,
-      `""" Perform a meta-query on all Test items which match the where clause. """
-      _allTestsMeta(
-      where: TestWhereInput
-      search: String
-      orderBy: String
-      first: Int
-      skip: Int
-    ): _QueryMeta`,
-      `""" Retrieve the meta-data for the Test list. """
-      _TestsMeta: _ListMeta`,
-    ].map(normalise)
-  );
-
-  expect(
-    setup({ access: false }, () => false)
-      .getGqlQueries()
-      .map(normalise)
-  ).toEqual([].map(normalise));
+    expect(
+      setup({ access: false }, getAuth)
+        .getGqlQueries()
+        .map(normalise)
+    ).toEqual(withAuth ? [`authenticatedTest: Test`].map(normalise) : []);
+  });
 });
 
 test('getFieldsRelatedTo', () => {
@@ -732,75 +758,134 @@ test('gqlAuxMutationResolvers', () => {
   expect(list.gqlAuxMutationResolvers.example).toBeInstanceOf(Function);
 });
 
-test('getGqlMutations()', () => {
-  const resolver = id => `Hello, ${id}`;
-  const mutations = [
-    {
-      schema: 'example(id: ID): String',
-      resolver,
-    },
-  ];
-  const extraConfig = { mutations };
-  expect(
-    setup({ access: true, ...extraConfig })
-      .getGqlMutations()
-      .map(normalise)
-  ).toEqual(
-    [
-      `example(id: ID): String`,
-      `""" Create a single Test item. """ createTest(data: TestCreateInput): Test`,
-      `""" Create multiple Test items. """ createTests(data: [TestsCreateInput]): [Test]`,
-      `""" Update a single Test item by ID. """ updateTest(id: ID! data: TestUpdateInput): Test`,
-      `""" Update multiple Test items by ID. """ updateTests(data: [TestsUpdateInput]): [Test]`,
-      `""" Delete a single Test item by ID. """ deleteTest(id: ID!): Test`,
-      `""" Delete multiple Test items by ID. """ deleteTests(ids: [ID!]): [Test]`,
-    ].map(normalise)
-  );
+[false, true].forEach(withAuth => {
+  test(`getGqlMutations() ${withAuth ? 'with' : 'without'} auth`, () => {
+    const getAuth = withAuth ? () => ({ password: new MockPasswordAuthStrategy() }) : undefined;
+    const resolver = id => `Hello, ${id}`;
+    const mutations = [
+      {
+        schema: 'example(id: ID): String',
+        resolver,
+      },
+    ];
+    const extraConfig = { mutations };
+    expect(
+      setup({ access: true, ...extraConfig }, getAuth)
+        .getGqlMutations()
+        .map(normalise)
+    ).toEqual(
+      [
+        `example(id: ID): String`,
+        `""" Create a single Test item. """ createTest(data: TestCreateInput): Test`,
+        `""" Create multiple Test items. """ createTests(data: [TestsCreateInput]): [Test]`,
+        `""" Update a single Test item by ID. """ updateTest(id: ID! data: TestUpdateInput): Test`,
+        `""" Update multiple Test items by ID. """ updateTests(data: [TestsUpdateInput]): [Test]`,
+        `""" Delete a single Test item by ID. """ deleteTest(id: ID!): Test`,
+        `""" Delete multiple Test items by ID. """ deleteTests(ids: [ID!]): [Test]`,
+        ...(withAuth
+          ? [
+              `unauthenticateTest: unauthenticateTestOutput`,
+              `""" Authenticate and generate a token for a Test with the Password Authentication Strategy. """ authenticateTestWithPassword(password: String): authenticateTestOutput`,
+            ]
+          : []),
+      ].map(normalise)
+    );
 
-  expect(
-    setup({ access: false, ...extraConfig })
-      .getGqlMutations()
-      .map(normalise)
-  ).toEqual([`example(id: ID): String`].map(normalise));
+    expect(
+      setup({ access: false, ...extraConfig }, getAuth)
+        .getGqlMutations()
+        .map(normalise)
+    ).toEqual(
+      [
+        `example(id: ID): String`,
+        ...(withAuth
+          ? [
+              `unauthenticateTest: unauthenticateTestOutput`,
+              `""" Authenticate and generate a token for a Test with the Password Authentication Strategy. """ authenticateTestWithPassword(password: String): authenticateTestOutput`,
+            ]
+          : []),
+      ].map(normalise)
+    );
 
-  expect(
-    setup({ access: { read: true, create: false, update: false, delete: false }, ...extraConfig })
-      .getGqlMutations()
-      .map(normalise)
-  ).toEqual([`example(id: ID): String`].map(normalise));
-  expect(
-    setup({ access: { read: false, create: true, update: false, delete: false }, ...extraConfig })
-      .getGqlMutations()
-      .map(normalise)
-  ).toEqual(
-    [
-      `example(id: ID): String`,
-      `""" Create a single Test item. """ createTest(data: TestCreateInput): Test`,
-      `""" Create multiple Test items. """ createTests(data: [TestsCreateInput]): [Test]`,
-    ].map(normalise)
-  );
-  expect(
-    setup({ access: { read: false, create: false, update: true, delete: false }, ...extraConfig })
-      .getGqlMutations()
-      .map(normalise)
-  ).toEqual(
-    [
-      `example(id: ID): String`,
-      `""" Update a single Test item by ID. """ updateTest(id: ID! data: TestUpdateInput): Test`,
-      `""" Update multiple Test items by ID. """ updateTests(data: [TestsUpdateInput]): [Test]`,
-    ].map(normalise)
-  );
-  expect(
-    setup({ access: { read: false, create: false, update: false, delete: true }, ...extraConfig })
-      .getGqlMutations()
-      .map(normalise)
-  ).toEqual(
-    [
-      `example(id: ID): String`,
-      `""" Delete a single Test item by ID. """ deleteTest(id: ID!): Test`,
-      `""" Delete multiple Test items by ID. """ deleteTests(ids: [ID!]): [Test]`,
-    ].map(normalise)
-  );
+    expect(
+      setup(
+        { access: { read: true, create: false, update: false, delete: false }, ...extraConfig },
+        getAuth
+      )
+        .getGqlMutations()
+        .map(normalise)
+    ).toEqual(
+      [
+        `example(id: ID): String`,
+        ...(withAuth
+          ? [
+              `unauthenticateTest: unauthenticateTestOutput`,
+              `""" Authenticate and generate a token for a Test with the Password Authentication Strategy. """ authenticateTestWithPassword(password: String): authenticateTestOutput`,
+            ]
+          : []),
+      ].map(normalise)
+    );
+    expect(
+      setup(
+        { access: { read: false, create: true, update: false, delete: false }, ...extraConfig },
+        getAuth
+      )
+        .getGqlMutations()
+        .map(normalise)
+    ).toEqual(
+      [
+        `example(id: ID): String`,
+        `""" Create a single Test item. """ createTest(data: TestCreateInput): Test`,
+        `""" Create multiple Test items. """ createTests(data: [TestsCreateInput]): [Test]`,
+        ...(withAuth
+          ? [
+              `unauthenticateTest: unauthenticateTestOutput`,
+              `""" Authenticate and generate a token for a Test with the Password Authentication Strategy. """ authenticateTestWithPassword(password: String): authenticateTestOutput`,
+            ]
+          : []),
+      ].map(normalise)
+    );
+    expect(
+      setup(
+        { access: { read: false, create: false, update: true, delete: false }, ...extraConfig },
+        getAuth
+      )
+        .getGqlMutations()
+        .map(normalise)
+    ).toEqual(
+      [
+        `example(id: ID): String`,
+        `""" Update a single Test item by ID. """ updateTest(id: ID! data: TestUpdateInput): Test`,
+        `""" Update multiple Test items by ID. """ updateTests(data: [TestsUpdateInput]): [Test]`,
+        ...(withAuth
+          ? [
+              `unauthenticateTest: unauthenticateTestOutput`,
+              `""" Authenticate and generate a token for a Test with the Password Authentication Strategy. """ authenticateTestWithPassword(password: String): authenticateTestOutput`,
+            ]
+          : []),
+      ].map(normalise)
+    );
+    expect(
+      setup(
+        { access: { read: false, create: false, update: false, delete: true }, ...extraConfig },
+        getAuth
+      )
+        .getGqlMutations()
+        .map(normalise)
+    ).toEqual(
+      [
+        `example(id: ID): String`,
+        `""" Delete a single Test item by ID. """ deleteTest(id: ID!): Test`,
+        `""" Delete multiple Test items by ID. """ deleteTests(ids: [ID!]): [Test]`,
+        ...(withAuth
+          ? [
+              `unauthenticateTest: unauthenticateTestOutput`,
+              `""" Authenticate and generate a token for a Test with the Password Authentication Strategy. """ authenticateTestWithPassword(password: String): authenticateTestOutput`,
+            ]
+          : []),
+      ].map(normalise)
+    );
+  });
 });
 
 test('checkFieldAccess', () => {
@@ -988,30 +1073,31 @@ test('getAccessControlledItems', async () => {
   ]);
 });
 
-test('gqlQueryResolvers', () => {
-  const resolvers = setup({ access: true }).gqlQueryResolvers;
-  expect(resolvers['allTests']).toBeInstanceOf(Function); // listQueryName
-  expect(resolvers['_allTestsMeta']).toBeInstanceOf(Function); // listQueryMetaName
-  expect(resolvers['_TestsMeta']).toBeInstanceOf(Function); // listMetaName
-  expect(resolvers['Test']).toBeInstanceOf(Function); // itemQueryName
-  expect(resolvers['authenticatedTest']).toBeInstanceOf(Function); // authenticatedQueryName
+[false, true].forEach(withAuth => {
+  test(`gqlQueryResolvers ${withAuth ? 'with' : 'without'} auth`, () => {
+    const getAuth = withAuth ? () => ({ password: new MockPasswordAuthStrategy() }) : undefined;
+    const resolvers = setup({ access: true }, getAuth).gqlQueryResolvers;
+    expect(resolvers['allTests']).toBeInstanceOf(Function); // listQueryName
+    expect(resolvers['_allTestsMeta']).toBeInstanceOf(Function); // listQueryMetaName
+    expect(resolvers['_TestsMeta']).toBeInstanceOf(Function); // listMetaName
+    expect(resolvers['Test']).toBeInstanceOf(Function); // itemQueryName
+    if (withAuth) {
+      expect(resolvers['authenticatedTest']).toBeInstanceOf(Function); // authenticatedQueryName
+    } else {
+      expect(resolvers['authenticatedTest']).toBe(undefined); // authenticatedQueryName
+    }
 
-  const resolvers2 = setup({ access: false }).gqlQueryResolvers;
-  expect(resolvers2['allTests']).toBe(undefined); // listQueryName
-  expect(resolvers2['_allTestsMeta']).toBe(undefined); // listQueryMetaName
-  expect(resolvers2['_TestsMeta']).toBe(undefined); // listMetaName
-  expect(resolvers2['Test']).toBe(undefined); // itemQueryName
-  expect(resolvers2['authenticatedTest']).toBeInstanceOf(Function); // authenticatedQueryName
-
-  const resolvers3 = setup({ access: true }, () => false).gqlQueryResolvers;
-  expect(resolvers3['allTests']).toBeInstanceOf(Function); // listQueryName
-  expect(resolvers3['_allTestsMeta']).toBeInstanceOf(Function); // listQueryMetaName
-  expect(resolvers3['_TestsMeta']).toBeInstanceOf(Function); // listMetaName
-  expect(resolvers3['Test']).toBeInstanceOf(Function); // itemQueryName
-  expect(resolvers3['authenticatedTest']).toBe(undefined); // authenticatedQueryName
-
-  const resolvers4 = setup({ access: false }, () => false).gqlQueryResolvers;
-  expect(resolvers4).toEqual({});
+    const resolvers2 = setup({ access: false }, getAuth).gqlQueryResolvers;
+    expect(resolvers2['allTests']).toBe(undefined); // listQueryName
+    expect(resolvers2['_allTestsMeta']).toBe(undefined); // listQueryMetaName
+    expect(resolvers2['_TestsMeta']).toBe(undefined); // listMetaName
+    expect(resolvers2['Test']).toBe(undefined); // itemQueryName
+    if (withAuth) {
+      expect(resolvers['authenticatedTest']).toBeInstanceOf(Function); // authenticatedQueryName
+    } else {
+      expect(resolvers['authenticatedTest']).toBe(undefined); // authenticatedQueryName
+    }
+  });
 });
 
 test('listQuery', async () => {
@@ -1031,38 +1117,41 @@ test('listQueryMeta', async () => {
   ).toEqual(2);
 });
 
-test('listMeta', () => {
-  const meta = setup().listMeta(context);
-  expect(meta.getAccess).toBeInstanceOf(Function);
-  expect(meta.getSchema).toBeInstanceOf(Function);
-  expect(meta.name).toEqual('Test');
+[false, true].forEach(withAuth => {
+  test(`listMeta ${withAuth ? 'with' : 'without'} auth`, () => {
+    const getAuth = withAuth ? () => ({ password: new MockPasswordAuthStrategy() }) : undefined;
+    const meta = setup({}, getAuth).listMeta(context);
+    expect(meta.getAccess).toBeInstanceOf(Function);
+    expect(meta.getSchema).toBeInstanceOf(Function);
+    expect(meta.name).toEqual('Test');
 
-  const access = meta.getAccess();
-  expect(access.getCreate).toBeInstanceOf(Function);
-  expect(access.getDelete).toBeInstanceOf(Function);
-  expect(access.getRead).toBeInstanceOf(Function);
-  expect(access.getUpdate).toBeInstanceOf(Function);
+    const access = meta.getAccess();
+    expect(access.getCreate).toBeInstanceOf(Function);
+    expect(access.getDelete).toBeInstanceOf(Function);
+    expect(access.getRead).toBeInstanceOf(Function);
+    expect(access.getUpdate).toBeInstanceOf(Function);
 
-  expect(access.getCreate()).toEqual(true);
-  expect(access.getDelete()).toEqual(true);
-  expect(access.getRead()).toEqual(true);
-  expect(access.getUpdate()).toEqual(true);
+    expect(access.getCreate()).toEqual(true);
+    expect(access.getDelete()).toEqual(true);
+    expect(access.getRead()).toEqual(true);
+    expect(access.getUpdate()).toEqual(true);
 
-  const schema = meta.getSchema();
-  expect(schema).toEqual({
-    key: 'Test',
-    queries: ['Test', 'allTests', '_allTestsMeta', 'authenticatedTest'],
-    type: 'Test',
-  });
+    const schema = meta.getSchema();
+    expect(schema).toEqual({
+      key: 'Test',
+      queries: ['Test', 'allTests', '_allTestsMeta', ...(withAuth ? ['authenticatedTest'] : [])],
+      type: 'Test',
+    });
 
-  expect(
-    setup({ access: true }, () => false)
-      .listMeta(context)
-      .getSchema()
-  ).toEqual({
-    key: 'Test',
-    queries: ['Test', 'allTests', '_allTestsMeta'],
-    type: 'Test',
+    expect(
+      setup({ access: true }, () => false)
+        .listMeta(context)
+        .getSchema()
+    ).toEqual({
+      key: 'Test',
+      queries: ['Test', 'allTests', '_allTestsMeta'],
+      type: 'Test',
+    });
   });
 });
 
@@ -1087,40 +1176,90 @@ test('authenticatedQuery', async () => {
   expect(await list.authenticatedQuery({ ...context, authedListKey: 'Other' })).toBe(null);
 });
 
-test('gqlMutationResolvers', () => {
-  let resolvers = setup({ access: true }).gqlMutationResolvers;
-  expect(resolvers['createTest']).toBeInstanceOf(Function);
-  expect(resolvers['updateTest']).toBeInstanceOf(Function);
-  expect(resolvers['deleteTest']).toBeInstanceOf(Function);
-  expect(resolvers['deleteTests']).toBeInstanceOf(Function);
+[false, true].forEach(withAuth => {
+  test(`gqlMutationResolvers ${withAuth ? 'with' : 'without'} auth`, () => {
+    const getAuth = withAuth ? () => ({ password: new MockPasswordAuthStrategy() }) : undefined;
+    let resolvers = setup({ access: true }, getAuth).gqlMutationResolvers;
+    expect(resolvers['createTest']).toBeInstanceOf(Function);
+    expect(resolvers['updateTest']).toBeInstanceOf(Function);
+    expect(resolvers['deleteTest']).toBeInstanceOf(Function);
+    expect(resolvers['deleteTests']).toBeInstanceOf(Function);
+    if (withAuth) {
+      expect(resolvers['authenticateTestWithPassword']).toBeInstanceOf(Function);
+      expect(resolvers['unauthenticateTest']).toBeInstanceOf(Function);
+    } else {
+      expect(resolvers['authenticateTestWithPassword']).toBe(undefined);
+      expect(resolvers['unauthenticateTest']).toBe(undefined);
+    }
+    resolvers = setup({ access: false }, getAuth).gqlMutationResolvers;
+    if (withAuth) {
+      expect(resolvers['authenticateTestWithPassword']).toBeInstanceOf(Function);
+      expect(resolvers['unauthenticateTest']).toBeInstanceOf(Function);
+    } else {
+      expect(resolvers['authenticateTestWithPassword']).toBe(undefined);
+      expect(resolvers['unauthenticateTest']).toBe(undefined);
+    }
 
-  resolvers = setup({ access: false }).gqlMutationResolvers;
-  expect(resolvers).toEqual({});
+    resolvers = setup(
+      { access: { read: true, create: false, update: false, delete: false } },
+      getAuth
+    ).gqlMutationResolvers;
+    if (withAuth) {
+      expect(resolvers['authenticateTestWithPassword']).toBeInstanceOf(Function);
+      expect(resolvers['unauthenticateTest']).toBeInstanceOf(Function);
+    } else {
+      expect(resolvers['authenticateTestWithPassword']).toBe(undefined);
+      expect(resolvers['unauthenticateTest']).toBe(undefined);
+    }
 
-  resolvers = setup({ access: { read: true, create: false, update: false, delete: false } })
-    .gqlMutationResolvers;
-  expect(resolvers).toEqual({});
+    resolvers = setup(
+      { access: { read: false, create: true, update: false, delete: false } },
+      getAuth
+    ).gqlMutationResolvers;
+    expect(resolvers['createTest']).toBeInstanceOf(Function);
+    expect(resolvers['updateTest']).toBe(undefined);
+    expect(resolvers['deleteTest']).toBe(undefined);
+    expect(resolvers['deleteTests']).toBe(undefined);
+    if (withAuth) {
+      expect(resolvers['authenticateTestWithPassword']).toBeInstanceOf(Function);
+      expect(resolvers['unauthenticateTest']).toBeInstanceOf(Function);
+    } else {
+      expect(resolvers['authenticateTestWithPassword']).toBe(undefined);
+      expect(resolvers['unauthenticateTest']).toBe(undefined);
+    }
 
-  resolvers = setup({ access: { read: false, create: true, update: false, delete: false } })
-    .gqlMutationResolvers;
-  expect(resolvers['createTest']).toBeInstanceOf(Function);
-  expect(resolvers['updateTest']).toBe(undefined);
-  expect(resolvers['deleteTest']).toBe(undefined);
-  expect(resolvers['deleteTests']).toBe(undefined);
+    resolvers = setup(
+      { access: { read: false, create: false, update: true, delete: false } },
+      getAuth
+    ).gqlMutationResolvers;
+    expect(resolvers['createTest']).toBe(undefined);
+    expect(resolvers['updateTest']).toBeInstanceOf(Function);
+    expect(resolvers['deleteTest']).toBe(undefined);
+    expect(resolvers['deleteTests']).toBe(undefined);
+    if (withAuth) {
+      expect(resolvers['authenticateTestWithPassword']).toBeInstanceOf(Function);
+      expect(resolvers['unauthenticateTest']).toBeInstanceOf(Function);
+    } else {
+      expect(resolvers['authenticateTestWithPassword']).toBe(undefined);
+      expect(resolvers['unauthenticateTest']).toBe(undefined);
+    }
 
-  resolvers = setup({ access: { read: false, create: false, update: true, delete: false } })
-    .gqlMutationResolvers;
-  expect(resolvers['createTest']).toBe(undefined);
-  expect(resolvers['updateTest']).toBeInstanceOf(Function);
-  expect(resolvers['deleteTest']).toBe(undefined);
-  expect(resolvers['deleteTests']).toBe(undefined);
-
-  resolvers = setup({ access: { read: false, create: false, update: false, delete: true } })
-    .gqlMutationResolvers;
-  expect(resolvers['createTest']).toBe(undefined);
-  expect(resolvers['updateTest']).toBe(undefined);
-  expect(resolvers['deleteTest']).toBeInstanceOf(Function);
-  expect(resolvers['deleteTests']).toBeInstanceOf(Function);
+    resolvers = setup(
+      { access: { read: false, create: false, update: false, delete: true } },
+      getAuth
+    ).gqlMutationResolvers;
+    expect(resolvers['createTest']).toBe(undefined);
+    expect(resolvers['updateTest']).toBe(undefined);
+    expect(resolvers['deleteTest']).toBeInstanceOf(Function);
+    expect(resolvers['deleteTests']).toBeInstanceOf(Function);
+    if (withAuth) {
+      expect(resolvers['authenticateTestWithPassword']).toBeInstanceOf(Function);
+      expect(resolvers['unauthenticateTest']).toBeInstanceOf(Function);
+    } else {
+      expect(resolvers['authenticateTestWithPassword']).toBe(undefined);
+      expect(resolvers['unauthenticateTest']).toBe(undefined);
+    }
+  });
 });
 
 test('createMutation', async () => {

--- a/packages/passport-auth/README.md
+++ b/packages/passport-auth/README.md
@@ -73,10 +73,15 @@ server.app.get(
 
       try {
         await keystone.auth.User.twitter.connectItem(req, { item: authedItem });
-        await keystone.sessionManager.startAuthedSession(req, {
-          item: authedItem,
-          list: info.list,
-        }, ['admin'], cookieSecret);
+        await keystone.sessionManager.startAuthedSession(
+          req,
+          {
+            item: authedItem,
+            list: info.list,
+          },
+          ['admin'],
+          cookieSecret
+        );
       } catch (createError) {
         return res.json({
           success: false,

--- a/packages/passport-auth/README.md
+++ b/packages/passport-auth/README.md
@@ -35,6 +35,8 @@ InitializePassportAuthStrategies(app); // you can use server.app
 ```javascript
 const { TwitterAuthStrategy } = require('@keystone-alpha/passport-auth');
 
+const cookieSecret = '<the same as passed to your `app-graphql` instance>';
+
 const twitterAuth = keystone.createAuthStrategy({
   type: TwitterAuthStrategy,
   list: 'User',
@@ -57,7 +59,7 @@ server.app.get(
     sessionExists: (itemId, req, res) => {
       console.log(`Already logged in as ${itemId} 🎉`);
       // logged in already? Send 'em home!
-      return res.redirect('/api/session');
+      return res.redirect('/');
     },
   })
 );
@@ -74,7 +76,7 @@ server.app.get(
         await keystone.sessionManager.startAuthedSession(req, {
           item: authedItem,
           list: info.list,
-        });
+        }, ['admin'], cookieSecret);
       } catch (createError) {
         return res.json({
           success: false,
@@ -83,7 +85,7 @@ server.app.get(
         });
       }
 
-      res.redirect('/api/session');
+      res.redirect('/');
     },
     failedVerification(error, req, res) {
       console.log('🤔 Failed to verify Twitter login creds');
@@ -102,6 +104,8 @@ bank's password over multiple server requests / page refreshes:
 ```javascript
 const { TwitterAuthStrategy } = require('@keystone-alpha/passport-auth');
 
+const cookieSecret = '<the same as passed to your `app-graphql` instance>';
+
 const twitterAuth = keystone.createAuthStrategy({
   type: TwitterAuthStrategy,
   list: 'User',
@@ -124,7 +128,7 @@ server.app.get(
     sessionExists: (itemId, req, res) => {
       console.log(`Already logged in as ${itemId} 🎉`);
       // logged in already? Send 'em home!
-      return res.redirect('/api/session');
+      return res.redirect('/');
     },
   })
 );
@@ -139,7 +143,7 @@ server.app.get(
         return res.redirect('/auth/twitter/details');
       }
 
-      res.redirect('/api/session');
+      res.redirect('/');
     },
     failedVerification(error, req, res) {
       console.log('🤔 Failed to verify Twitter login creds');
@@ -150,7 +154,7 @@ server.app.get(
 
 server.app.get('/auth/twitter/details', (req, res) => {
   if (req.user) {
-    return res.redirect('/api/session');
+    return res.redirect('/');
   }
 
   // Capture details somehow
@@ -166,7 +170,7 @@ server.app.use(server.express.urlencoded({ extended: true }));
 
 server.app.post('/auth/twitter/complete', async (req, res, next) => {
   if (req.user) {
-    return res.redirect('/api/session');
+    return res.redirect('/');
   }
 
   // Finally, we have all the info we need to create a new user and log that
@@ -179,8 +183,8 @@ server.app.post('/auth/twitter/complete', async (req, res, next) => {
     });
 
     await keystone.auth.User.twitter.connectItem(req, { item });
-    await keystone.sessionManager.startAuthedSession(req, { item, list });
-    res.redirect('/api/session');
+    await keystone.sessionManager.startAuthedSession(req, { item, list }, ['admin'], cookieSecret);
+    res.redirect('/');
   } catch (createError) {
     next(createError);
   }

--- a/packages/session/index.js
+++ b/packages/session/index.js
@@ -1,6 +1,5 @@
 const {
   commonSessionMiddleware,
-  createSessionMiddleware,
   restrictAudienceMiddleware,
   startAuthedSession,
   endAuthedSession,
@@ -8,7 +7,6 @@ const {
 
 module.exports = {
   commonSessionMiddleware,
-  createSessionMiddleware,
   restrictAudienceMiddleware,
   startAuthedSession,
   endAuthedSession,

--- a/test-projects/access-control/cypress/support/commands.js
+++ b/test-projects/access-control/cypress/support/commands.js
@@ -10,7 +10,7 @@
 //
 //
 // -- This is a parent command --
-// Cypress.Commands.add("login", (email, password) => { ... })
+// Cypress.Commands.add("login", (identity, secret) => { ... })
 //
 //
 // -- This is a child command --
@@ -110,16 +110,16 @@ function graphqlOperation(type) {
 Cypress.Commands.add('graphql_query', graphqlOperation('query'));
 Cypress.Commands.add('graphql_mutate', graphqlOperation('mutate'));
 
-Cypress.Commands.add('loginToKeystone', (email, password) => {
+Cypress.Commands.add('loginToKeystone', (identity, secret) => {
   cy.visit('/admin');
 
-  cy.get('input[name="username"]')
+  cy.get('input[name="identity"]')
     .clear({ force: true })
-    .type(email, { force: true });
+    .type(identity, { force: true });
 
-  cy.get('[name="password"]')
+  cy.get('[name="secret"]')
     .clear({ force: true })
-    .type(password, { force: true });
+    .type(secret, { force: true });
 
   cy.get('button[type="submit"]').click();
 

--- a/test-projects/login/cypress/integration/login_spec.js
+++ b/test-projects/login/cypress/integration/login_spec.js
@@ -1,11 +1,11 @@
-const USERNAME = 'boris@keystone-alpha.com';
-const PASSWORD = 'correctbattery';
+const IDENTITY = 'boris@keystone-alpha.com';
+const SECRET = 'correctbattery';
 
 describe('Testing Login', () => {
   it('Shows login screen instead of admin page', () => {
     cy.visit('/admin');
-    cy.get('[name="username"]').should('exist');
-    cy.get('[name="password"]').should('exist');
+    cy.get('[name="identity"]').should('exist');
+    cy.get('[name="secret"]').should('exist');
     cy.get('button[type="submit"]')
       .should('exist')
       .should('contain', 'Sign In');
@@ -14,8 +14,8 @@ describe('Testing Login', () => {
   it('Shows login screen instead of users page', () => {
     cy.visit('/admin/users');
     cy.get('body').should('not.contain', 'Users');
-    cy.get('[name="username"]').should('exist');
-    cy.get('[name="password"]').should('exist');
+    cy.get('[name="identity"]').should('exist');
+    cy.get('[name="secret"]').should('exist');
     cy.get('button[type="submit"]')
       .should('exist')
       .should('contain', 'Sign In');
@@ -34,11 +34,11 @@ describe('Testing Login', () => {
     it('Does not log in with invalid credentials', () => {
       cy.visit('/admin');
 
-      cy.get('input[name="username"]')
+      cy.get('input[name="identity"]')
         .clear({ force: true })
         .type('fake@example.com', { force: true });
 
-      cy.get('[name="password"]')
+      cy.get('[name="secret"]')
         .clear({ force: true })
         .type('gibberish', { force: true });
 
@@ -46,29 +46,29 @@ describe('Testing Login', () => {
       cy.get('body').should('contain', 'Your username and password were incorrect');
     });
 
-    it('Does not log in with invalid username', () => {
+    it('Does not log in with invalid identity', () => {
       cy.visit('/admin');
 
-      cy.get('input[name="username"]')
+      cy.get('input[name="identity"]')
         .clear({ force: true })
         .type('fake@example.com', { force: true });
 
-      cy.get('[name="password"]')
+      cy.get('[name="secret"]')
         .clear({ force: true })
-        .type(PASSWORD, { force: true });
+        .type(SECRET, { force: true });
 
       cy.get('button[type="submit"]').click();
       cy.get('body').should('contain', 'Your username and password were incorrect');
     });
 
-    it('Does not log in with invalid password', () => {
+    it('Does not log in with invalid secret', () => {
       cy.visit('/admin');
 
-      cy.get('input[name="username"]')
+      cy.get('input[name="identity"]')
         .clear({ force: true })
-        .type(USERNAME, { force: true });
+        .type(IDENTITY, { force: true });
 
-      cy.get('[name="password"]')
+      cy.get('[name="secret"]')
         .clear({ force: true })
         .type('gibberish', { force: true });
 
@@ -91,13 +91,13 @@ describe('Testing Login', () => {
     it('Logs in with valid credentials', () => {
       cy.visit('/admin');
 
-      cy.get('input[name="username"]')
+      cy.get('input[name="identity"]')
         .clear({ force: true })
-        .type(USERNAME, { force: true });
+        .type(IDENTITY, { force: true });
 
-      cy.get('[name="password"]')
+      cy.get('[name="secret"]')
         .clear({ force: true })
-        .type(PASSWORD, { force: true });
+        .type(SECRET, { force: true });
 
       cy.get('button[type="submit"]').click();
 
@@ -108,13 +108,13 @@ describe('Testing Login', () => {
     it('Redirects to requested page after login', () => {
       cy.visit('/admin/users');
 
-      cy.get('input[name="username"]')
+      cy.get('input[name="identity"]')
         .clear({ force: true })
-        .type(USERNAME, { force: true });
+        .type(IDENTITY, { force: true });
 
-      cy.get('[name="password"]')
+      cy.get('[name="secret"]')
         .clear({ force: true })
-        .type(PASSWORD, { force: true });
+        .type(SECRET, { force: true });
 
       cy.get('button[type="submit"]').click();
 
@@ -143,13 +143,13 @@ describe('authenticated item', () => {
     before(() => {
       cy.visit('/admin');
 
-      cy.get('input[name="username"]')
+      cy.get('input[name="identity"]')
         .clear({ force: true })
-        .type(USERNAME, { force: true });
+        .type(IDENTITY, { force: true });
 
-      cy.get('[name="password"]')
+      cy.get('[name="secret"]')
         .clear({ force: true })
-        .type(PASSWORD, { force: true });
+        .type(SECRET, { force: true });
 
       cy.get('button[type="submit"]').click();
 

--- a/test-projects/social-login/auth/setupAuthRoutes.js
+++ b/test-projects/social-login/auth/setupAuthRoutes.js
@@ -1,12 +1,15 @@
 const { startAuthedSession } = require('@keystone-alpha/session');
 const express = require('express');
 
+const { cookieSecret } = require('../config');
+
 module.exports = ({
   strategy,
   app,
   authRoot = '/auth',
   successRedirect = '/api/session',
   failureRedirect = '/',
+  audiences = ['admin'],
 }) => {
   const basePath = `${authRoot}/${strategy.authType}`;
   // Hit this route to start the auth process for service
@@ -40,7 +43,7 @@ module.exports = ({
         }
 
         // Otherwise create a session based on the user we have already
-        await startAuthedSession(req, { item, list });
+        await startAuthedSession(req, { item, list }, audiences, cookieSecret);
         // Redirect on sign in
         res.redirect(successRedirect);
       },
@@ -91,7 +94,7 @@ module.exports = ({
         });
 
         await strategy.connectItem(req, { item });
-        await startAuthedSession(req, { item, list });
+        await startAuthedSession(req, { item, list }, audiences, cookieSecret);
         res.redirect(successRedirect);
       } catch (createError) {
         next(createError);

--- a/test-projects/social-login/config.js
+++ b/test-projects/social-login/config.js
@@ -23,6 +23,8 @@ exports.wpAppKey = process.env.WP_APP_KEY;
 exports.wpAppSecret = process.env.WP_APP_SECRET;
 exports.wpAuthEnabled = exports.wpAppKey && exports.wpAppSecret;
 
+exports.cookieSecret = 'qwerty';
+
 exports.staticRoute = '/public'; // The URL portion
 exports.staticPath = path.join(process.cwd(), 'public'); // The local path on disk
 

--- a/test-projects/social-login/index.js
+++ b/test-projects/social-login/index.js
@@ -13,7 +13,7 @@ const { GraphQLApp } = require('@keystone-alpha/app-graphql');
 const { AdminUIApp } = require('@keystone-alpha/app-admin-ui');
 const { StaticApp } = require('@keystone-alpha/app-static');
 
-const { staticRoute, staticPath, cloudinary } = require('./config');
+const { staticRoute, staticPath, cloudinary, cookieSecret } = require('./config');
 
 const { DISABLE_AUTH } = process.env;
 const LOCAL_FILE_PATH = `${staticPath}/avatars`;
@@ -156,7 +156,7 @@ keystone.createList('PostCategory', {
 module.exports = {
   keystone,
   apps: [
-    new GraphQLApp(),
+    new GraphQLApp({ cookieSecret }),
     new StaticApp({ path: staticRoute, src: staticPath }),
     new AdminUIApp({ authStrategy: DISABLE_AUTH ? undefined : authStrategy }),
   ],

--- a/test-projects/social-login/server.js
+++ b/test-projects/social-login/server.js
@@ -52,6 +52,8 @@ keystone
 
     const app = express();
 
+    app.use(middlewares);
+
     if (socialLogins.length > 0) {
       InitializePassportAuthStrategies(app);
     }
@@ -94,8 +96,6 @@ keystone
         next(e);
       }
     });
-
-    app.use(middlewares);
 
     app.listen(port, error => {
       if (error) throw error;


### PR DESCRIPTION
Fixes #1176
Refs #878

## `@keystone-alpha/keystone`

- `PasswordAuthStrategy#validate()` now accepts an object of `{ [identityField], [secretField] }` (was `{ identity, secret }`).
- Auth Strategies can now add AdminMeta via a `#getAdminMeta()` method which will be attached to the `authStrategy` key of `adminMeta` in the Admin UI.
- Added (un)authentication GraphQL mutations:
    - ```graphql
      mutation {
        authenticate<List>With<Strategy>(<strategy-args) {
          token # Add this token as a header: { Authorization: 'Bearer <token>' }
          item # The authenticated item from <List>
        }
      }
      ```
      For the `PasswordAuthStrategy`, that is:
      ```javascript
      const authStrategy = keystone.createAuthStrategy({
        type: PasswordAuthStrategy,
        list: 'User',
        config: {
          identityField: 'username',
          secretField: 'pass'
        }
      });
      ```
      ```graphql
      mutation {
        authenticateUserWithPassword(username: "jesstelford", pass: "abc123") {
          token
          item {
            username
          }
        }
      }
      ```
    - ```graphql
      mutation {
        unauthenticate<List> {
          success
        }
      }
      ```

## `@keystone-alpha/session`

- Removed `createSessionMiddleware` export. Most functionality has been replaced by the new `authenticate<List>With<Strategy>` & `unauthenticate<List>` mutations (see `@keystone-alpha/keystone` `CHANGELOG.md` for more details), and remaining functionality that was specific to `@keystone-alpha/app-admin-ui` and has been moved there.
- Auth tokens received by header `Authorization: Bearer <token>` must now
  include the signature (removing a potential attack vector where a client could
  guess with an unsigned token until it matched a logged in user). The `token`
  returned by `authenticate<List>With<Strategy>` includes this signature
  automatically for you.
- `startAuthedSession` now requires a fourth paramter: `cookieSecret` for
  generating the signed `token`.

## `@keystone-alpha/app-graphql`

- GraphQL Playground now correctly sends auth cookies by default.
- The GraphQL `context` object now has `startAuthedSession` and
  `endAuthedSession` methods bound to the current request (from
  `@keystone-alpha/session`)

## `@keystone-alpha/app-admin-ui`

- Removed the `<adminPath>/signin`, `<adminPath>/signout`, and
  `<adminPath>/session` routes.
    - The REST routes have been replaced with GraphQL mutations
      `authenticate<List>With<Strategy>` & `unauthenticate<List>` (see
      `@keystone-alpha/keystone`'s `CHANGELOG.md` for details)
- Admin UI now uses the new `(un)authenticate` mutations for sigin/signout
  pages.
- Signout page correctly renders again (previously was erroring and showing a
  blank page)
- Generate Admin UI login form field labels based on the identity and secret
  fields set in the PasswordAuthStrategy.