### PR TITLE
Verify Keystone Session id on complete

### DIFF
--- a/test-projects/social-login/auth/setupAuthRoutes.js
+++ b/test-projects/social-login/auth/setupAuthRoutes.js
@@ -81,7 +81,12 @@ module.exports = ({
       if (req.user) {
         return res.redirect(successRedirect);
       }
-
+      // If we don't have a keystone[serviceName]SessionId at this point
+      // send back to the loginMiddleware
+      if (!req.session[strategy.config.keystoneSessionIdField]) {
+        return res.redirect(basePath);
+      }
+      
       // Create a new User
       try {
         const list = strategy.getList();


### PR DESCRIPTION
If we don't have a keystoneSessionId on complete it will fail and send back to the loginMiddleware