### PR TITLE
Fix demo scripts

### DIFF
--- a/demo-projects/blog/package.json
+++ b/demo-projects/blog/package.json
@@ -9,8 +9,8 @@
     "node": ">=8.4.0"
   },
   "scripts": {
-    "dev": "cross-env NODE_ENV=development DISABLE_LOGGING=true keystone dev",
     "build": "cross-env keystone build",
+    "dev": "cross-env NODE_ENV=development DISABLE_LOGGING=true keystone dev",
     "start": "cross-env NODE_ENV=production keystone start"
   },
   "dependencies": {

--- a/demo-projects/meetup/package.json
+++ b/demo-projects/meetup/package.json
@@ -9,8 +9,9 @@
     "node": ">=8.4.0"
   },
   "scripts": {
-    "start": "cross-env NODE_ENV=development DISABLE_LOGGING=true keystone",
-    "build": "cross-env NODE_ENV=production next build"
+    "build": "cross-env keystone build",
+    "dev": "cross-env NODE_ENV=development DISABLE_LOGGING=true keystone dev",
+    "start": "cross-env NODE_ENV=production keystone start"
   },
   "dependencies": {
     "@emotion/core": "^10.0.10",

--- a/demo-projects/todo/package.json
+++ b/demo-projects/todo/package.json
@@ -9,6 +9,7 @@
     "node": ">=8.4.0"
   },
   "scripts": {
+    "build": "cross-env keystone build",
     "dev": "cross-env NODE_ENV=development DISABLE_LOGGING=true keystone dev",
     "start": "cross-env NODE_ENV=production keystone start"
   },

--- a/demo-projects/todo/package.json
+++ b/demo-projects/todo/package.json
@@ -9,7 +9,8 @@
     "node": ">=8.4.0"
   },
   "scripts": {
-    "start": "cross-env NODE_ENV=development DISABLE_LOGGING=true keystone"
+    "dev": "cross-env NODE_ENV=development DISABLE_LOGGING=true keystone dev",
+    "start": "cross-env NODE_ENV=production keystone start"
   },
   "dependencies": {
     "@keystone-alpha/adapter-mongoose": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint:markdown": "remark . --frail --quiet",
     "lint": "yarn lint:prettier && yarn lint:eslint && yarn lint:flow && yarn lint:markdown",
     "start": "yarn start:demo",
-    "start:demo": "/bin/sh -c 'cd demo-projects/${1:-$0} && yarn start' todo",
+    "start:demo": "/bin/sh -c 'cd demo-projects/${1:-$0} && yarn dev' todo",
     "start:test": "/bin/sh -c 'cd test-projects/${1:-$0} && yarn start' basic",
     "website:start": "cd website && yarn start",
     "website:build": "cd website && yarn build",


### PR DESCRIPTION
Fixing a paper cut: our demo projects aren't consistent with their scripts, and the main demo start script in the root package doesn't actually "work out of the box" because it runs `start` instead of `dev` and you need to go into the blog demo project directory first to build it.

Also the meetup project was only doing a next build, etc.

I made the slightly opinionated decision that `yarn start :project?` in the root script would run the project's `dev` script, because that's _probably_ the intention if you're running keystone in the monorepo. The individual packages themselves have `build` and `start` scripts so that from the project directory they behave as keystone projects should.

@jesstelford you might want to eyeball this and make sure I've gotten it right.