### PR TITLE
Consistent support for isRequired across all field types.

### DIFF
--- a/.changeset/brown-snails-drum/changes.json
+++ b/.changeset/brown-snails-drum/changes.json
@@ -1,0 +1,8 @@
+{
+  "releases": [
+    { "name": "@keystone-alpha/api-tests", "type": "patch" },
+    { "name": "@keystone-alpha/fields", "type": "patch" },
+    { "name": "@keystone-alpha/keystone", "type": "patch" }
+  ],
+  "dependents": []
+}

--- a/.changeset/brown-snails-drum/changes.md
+++ b/.changeset/brown-snails-drum/changes.md
@@ -1,0 +1,1 @@
+Fields configured with isRequired now behave as expected on create and update, returning a validation error if they are null. 

--- a/.changeset/calm-pandas-work/changes.json
+++ b/.changeset/calm-pandas-work/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/adapter-mongoose", "type": "minor" }], "dependents": [] }

--- a/.changeset/calm-pandas-work/changes.md
+++ b/.changeset/calm-pandas-work/changes.md
@@ -1,0 +1,1 @@
+Removed the isRequired parameter from MongooseFieldAdapter.buildValidator()

--- a/api-tests/required.test.js
+++ b/api-tests/required.test.js
@@ -1,0 +1,101 @@
+const fs = require('fs');
+const path = require('path');
+const cuid = require('cuid');
+const { multiAdapterRunners, setupServer } = require('@keystone-alpha/test-utils');
+const { Text } = require('@keystone-alpha/fields');
+
+const SCHEMA_NAME = 'testing';
+
+function graphqlRequest({ keystone, query }) {
+  return keystone._graphQLQuery[SCHEMA_NAME](query, keystone.getAccessContext(SCHEMA_NAME, {}));
+}
+
+describe('Test isRequired flag for all field types', () => {
+  const typesLoc = path.resolve('packages/fields/src/types');
+  const testModules = fs
+    .readdirSync(typesLoc)
+    .map(name => `${typesLoc}/${name}/filterTests.js`)
+    .filter(filename => fs.existsSync(filename));
+  multiAdapterRunners().map(({ runner, adapterName }) =>
+    describe(`Adapter: ${adapterName}`, () => {
+      testModules.map(require).forEach(mod => {
+        describe(`Test isRequired flag for module: ${mod.name}`, () => {
+          const type = mod.type;
+          const listName = 'Test';
+          const keystoneTestWrapper = (testFn = () => {}) =>
+            runner(
+              () =>
+                setupServer({
+                  name: `Field tests for ${type.type} ${cuid}`,
+                  adapterName,
+                  createLists: keystone => {
+                    if (type.type === 'Select') {
+                      keystone.createList(listName, {
+                        fields: {
+                          name: { type: Text },
+                          testField: {
+                            type,
+                            isRequired: true,
+                            options: [
+                              { label: 'Thinkmill', value: 'thinkmill' },
+                              { label: 'Atlassian', value: 'atlassian' },
+                            ],
+                          },
+                        },
+                      });
+                    } else {
+                      keystone.createList(listName, {
+                        fields: {
+                          name: { type: Text },
+                          testField: { type, isRequired: true },
+                        },
+                      });
+                    }
+                  },
+                }),
+              async ({ keystone, ...rest }) => testFn({ keystone, adapterName, ...rest })
+            );
+          test(
+            'Create an object without the required field',
+            keystoneTestWrapper(({ keystone }) => {
+              return graphqlRequest({
+                keystone,
+                query: `mutation { createTest(data: { name: "test entry" } ) { id name } }`,
+              }).then(({ data, errors }) => {
+                expect(data.createTest).toBe(null);
+                expect(errors).not.toBe(null);
+                expect(errors.length).toEqual(1);
+                expect(errors[0].message).toEqual('You attempted to perform an invalid mutation');
+                expect(errors[0].path[0]).toEqual('createTest');
+              });
+            })
+          );
+          test(
+            'Update an object without the required field',
+            keystoneTestWrapper(({ keystone }) => {
+              return graphqlRequest({
+                keystone,
+                query: `mutation { createTest(data: { name: "test entry", testField: ${
+                  mod.exampleValue
+                } } ) { id name } }`,
+              }).then(({ data }) => {
+                return graphqlRequest({
+                  keystone,
+                  query: `mutation { updateTest(id: "${
+                    data.createTest.id
+                  }" data: { name: "updated test entry", testField: null } ) { id name } }`,
+                }).then(({ data, errors }) => {
+                  expect(data.updateTest).toBe(null);
+                  expect(errors).not.toBe(null);
+                  expect(errors.length).toEqual(1);
+                  expect(errors[0].message).toEqual('You attempted to perform an invalid mutation');
+                  expect(errors[0].path[0]).toEqual('updateTest');
+                });
+              });
+            })
+          );
+        });
+      });
+    })
+  );
+});

--- a/packages/adapter-mongoose/lib/adapter-mongoose.js
+++ b/packages/adapter-mongoose/lib/adapter-mongoose.js
@@ -306,8 +306,8 @@ class MongooseFieldAdapter extends BaseFieldAdapter {
     throw new Error(`Field type [${this.fieldName}] does not implement addToMongooseSchema()`);
   }
 
-  buildValidator(validator, isRequired) {
-    return isRequired ? validator : a => validator(a) || typeof a === 'undefined' || a === null;
+  buildValidator(validator) {
+    return a => validator(a) || typeof a === 'undefined' || a === null;
   }
 
   mergeSchemaOptions(schemaOptions, { mongooseOptions }) {

--- a/packages/fields/src/types/CalendarDay/Implementation.js
+++ b/packages/fields/src/types/CalendarDay/Implementation.js
@@ -57,7 +57,7 @@ export class MongoCalendarDayInterface extends CommonCalendarInterface(MongooseF
     const schemaOptions = {
       type: String,
       validate: {
-        validator: this.buildValidator(validator, this.isRequired),
+        validator: this.buildValidator(validator),
         message: '{VALUE} is not an ISO8601 date string (YYYY-MM-DD)',
       },
     };

--- a/packages/fields/src/types/CalendarDay/filterTests.js
+++ b/packages/fields/src/types/CalendarDay/filterTests.js
@@ -3,6 +3,8 @@ import Text from '../Text';
 import CalendarDay from './';
 
 export const name = 'CalendarDay';
+export { CalendarDay as type };
+export const exampleValue = '"1990-12-31"';
 
 export const getTestFields = () => {
   return {

--- a/packages/fields/src/types/Checkbox/filterTests.js
+++ b/packages/fields/src/types/Checkbox/filterTests.js
@@ -3,6 +3,8 @@ import Text from '../Text';
 import Checkbox from './';
 
 export const name = 'Checkbox';
+export { Checkbox as type };
+export const exampleValue = 'true';
 
 export const getTestFields = () => {
   return {

--- a/packages/fields/src/types/Content/Implementation.js
+++ b/packages/fields/src/types/Content/Implementation.js
@@ -158,7 +158,6 @@ export class Content extends Relationship {
           // TODO: Change to a native JSON type
           document: {
             type: TextType,
-            isRequired: true,
             schemaDoc: 'The serialized Slate.js Document structure',
           },
 

--- a/packages/fields/src/types/DateTime/filterTests.js
+++ b/packages/fields/src/types/DateTime/filterTests.js
@@ -3,6 +3,8 @@ import Text from '../Text';
 import DateTime from './';
 
 export const name = 'DateTime';
+export { DateTime as type };
+export const exampleValue = '"1990-12-31T12:34:56.789+01:23"';
 
 export const getTestFields = () => {
   return {

--- a/packages/fields/src/types/Decimal/Implementation.js
+++ b/packages/fields/src/types/Decimal/Implementation.js
@@ -43,7 +43,7 @@ export class MongoDecimalInterface extends MongooseFieldAdapter {
     const schemaOptions = {
       type: mongoose.Decimal128,
       validate: {
-        validator: this.buildValidator(validator, this.isRequired),
+        validator: this.buildValidator(validator),
         message: '{VALUE} is not a Decimal value',
       },
     };

--- a/packages/fields/src/types/Decimal/filterTests.js
+++ b/packages/fields/src/types/Decimal/filterTests.js
@@ -3,6 +3,8 @@ import Text from '../Text';
 import Decimal from './';
 
 export const name = 'Decimal';
+export { Decimal as type };
+export const exampleValue = '"6.28"';
 
 export const getTestFields = () => {
   return {

--- a/packages/fields/src/types/Float/filterTests.js
+++ b/packages/fields/src/types/Float/filterTests.js
@@ -3,6 +3,8 @@ import Text from '../Text';
 import Float from '.';
 
 export const name = 'Float';
+export { Float as type };
+export const exampleValue = '6.28';
 
 export const getTestFields = () => {
   return {

--- a/packages/fields/src/types/Integer/Implementation.js
+++ b/packages/fields/src/types/Integer/Implementation.js
@@ -45,10 +45,7 @@ export class MongoIntegerInterface extends CommonIntegerInterface(MongooseFieldA
     const schemaOptions = {
       type: Number,
       validate: {
-        validator: this.buildValidator(
-          a => typeof a === 'number' && Number.isInteger(a),
-          this.isRequired
-        ),
+        validator: this.buildValidator(a => typeof a === 'number' && Number.isInteger(a)),
         message: '{VALUE} is not an integer value',
       },
     };

--- a/packages/fields/src/types/Integer/filterTests.js
+++ b/packages/fields/src/types/Integer/filterTests.js
@@ -3,6 +3,8 @@ import Text from '../Text';
 import Integer from './';
 
 export const name = 'Integer';
+export { Integer as type };
+export const exampleValue = '37';
 
 export const getTestFields = () => {
   return {

--- a/packages/fields/src/types/Password/filterTests.js
+++ b/packages/fields/src/types/Password/filterTests.js
@@ -3,6 +3,8 @@ import Password from './';
 import Text from '../Text';
 
 export const name = 'Password';
+export { Password as type };
+export const exampleValue = '"password"';
 
 export const getTestFields = () => {
   return {

--- a/packages/fields/src/types/Select/filterTests.js
+++ b/packages/fields/src/types/Select/filterTests.js
@@ -4,6 +4,9 @@ import Text from '../Text';
 
 export const name = 'Select';
 
+export { Select as type };
+export const exampleValue = 'thinkmill';
+
 export const getTestFields = () => {
   return {
     name: { type: Text }, // Provide a field to sort on

--- a/packages/fields/src/types/Text/filterTests.js
+++ b/packages/fields/src/types/Text/filterTests.js
@@ -4,6 +4,9 @@ import Text from './';
 const fieldType = 'Text';
 export { fieldType as name };
 
+export { Text as type };
+export const exampleValue = '"foo"';
+
 export const getTestFields = () => {
   return {
     order: { type: Text },

--- a/packages/fields/tests/idFilterTests.js
+++ b/packages/fields/tests/idFilterTests.js
@@ -1,6 +1,5 @@
 import { matchFilter } from '@keystone-alpha/test-utils';
 import Text from '../src/types/Text';
-// import Checkbox from './';
 
 export const name = 'ID';
 

--- a/packages/keystone/lib/List/graphqlErrors.js
+++ b/packages/keystone/lib/List/graphqlErrors.js
@@ -8,7 +8,7 @@ module.exports = {
     },
   }),
   ValidationFailureError: createError('ValidationFailureError', {
-    message: 'You attemped to perform an invalid mutation',
+    message: 'You attempted to perform an invalid mutation',
     options: {
       showPath: true,
     },

--- a/packages/keystone/lib/List/index.js
+++ b/packages/keystone/lib/List/index.js
@@ -1098,10 +1098,10 @@ module.exports = class List {
     // Check for isRequired
     const fieldValidationErrors = this.fields
       .filter(
-        f =>
-          f.isRequired &&
-          !f.isRelationship &&
-          (resolvedData[f.path] === undefined || resolvedData[f.path] === null)
+        field =>
+          field.isRequired &&
+          !field.isRelationship &&
+          (resolvedData[field.path] === undefined || resolvedData[field.path] === null)
       )
       .map(f => ({
         msg: `Required field "${f.path}" is null or undefined.`,

--- a/packages/keystone/lib/List/index.js
+++ b/packages/keystone/lib/List/index.js
@@ -1094,6 +1094,24 @@ module.exports = class List {
       originalInput,
       actions: mapKeys(this.hooksActions, hook => hook(context)),
     };
+
+    // Check for isRequired
+    const fieldValidationErrors = this.fields
+      .filter(
+        f =>
+          f.isRequired &&
+          !f.isRelationship &&
+          (resolvedData[f.path] === undefined || resolvedData[f.path] === null)
+      )
+      .map(f => ({
+        msg: `Required field "${f.path}" is null or undefined.`,
+        data: { resolvedData, operation, originalInput },
+        internalData: {},
+      }));
+    if (fieldValidationErrors.length) {
+      this._throwValidationFailure(fieldValidationErrors, operation, originalInput);
+    }
+
     const fields = this._fieldsFromObject(resolvedData);
     await this._validateHook(args, fields, operation, 'validateInput');
   }


### PR DESCRIPTION
Fixes #1245

Add a check during for the `_validateInput` phase for non-relationship fields which have `isRequired` set but have not supplied/supplied a null value.