### PR TITLE
Pass 'savedValue' to <Field> components in AdminUI

### DIFF
--- a/.changeset/c9a931ba/changes.json
+++ b/.changeset/c9a931ba/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/app-admin-ui", "type": "minor" }], "dependents": [] }

--- a/.changeset/c9a931ba/changes.md
+++ b/.changeset/c9a931ba/changes.md
@@ -1,0 +1,1 @@
+`<Field>` views now receive a `savedValue` prop representing the current state as saved to the database.

--- a/packages/app-admin-ui/client/components/CreateItemModal.js
+++ b/packages/app-admin-ui/client/components/CreateItemModal.js
@@ -114,6 +114,7 @@ class CreateItemModal extends Component {
                           <Field
                             autoFocus={!i}
                             value={item[field.path]}
+                            savedValue={item[field.path]}
                             field={field}
                             /* TODO: Permission query results */
                             // error={}

--- a/packages/app-admin-ui/client/components/UpdateManyItemsModal.js
+++ b/packages/app-admin-ui/client/components/UpdateManyItemsModal.js
@@ -135,6 +135,9 @@ class UpdateManyModal extends Component {
                         autoFocus={!i}
                         field={field}
                         value={item[field.path]}
+                        // Explicitly pass undefined here as it doesn't make
+                        // sense to pass in any one 'saved' value
+                        savedValue={undefined}
                         onChange={onChange}
                         renderContext="dialog"
                       />

--- a/packages/app-admin-ui/client/pages/Item/index.js
+++ b/packages/app-admin-ui/client/pages/Item/index.js
@@ -39,6 +39,10 @@ const getValues = (fieldsObject, item) => mapKeys(fieldsObject, field => field.s
 const getInitialValues = memoizeOne(getValues);
 const getCurrentValues = memoizeOne(getValues);
 
+const deserializeItem = memoizeOne((list, data) =>
+  list.deserializeItemData(data[list.gqlNames.itemQueryName])
+);
+
 const ItemDetails = withRouter(
   class ItemDetails extends Component {
     constructor(props) {
@@ -160,7 +164,18 @@ const ItemDetails = withRouter(
             return null;
           });
         })
-        .then(onUpdate);
+        .then(onUpdate)
+        .then(savedItem => {
+          // No changes since we kicked off the item saving
+          if (!this.state.itemHasChanged) {
+            // Then reset the state to the current server value
+            // This ensures we are able to pass any extra information returned
+            // from the server that otherwise would be unknown to client state
+            this.setState({
+              item: savedItem,
+            });
+          }
+        });
     };
 
     /**
@@ -216,6 +231,7 @@ const ItemDetails = withRouter(
                       },
                       [field]
                     );
+
                     return useMemo(
                       () => (
                         <Field
@@ -223,11 +239,19 @@ const ItemDetails = withRouter(
                           field={field}
                           error={itemErrors[field.path]}
                           value={item[field.path]}
+                          savedValue={savedData[field.path]}
                           onChange={onChange}
                           renderContext="page"
                         />
                       ),
-                      [i, field, itemErrors[field.path], item[field.path]]
+                      [
+                        i,
+                        field,
+                        itemErrors[field.path],
+                        item[field.path],
+                        savedData[field.path],
+                        onChange,
+                      ]
                     );
                   }}
                 </Render>
@@ -296,7 +320,7 @@ const ItemPage = ({ list, itemId, adminPath, getListByKey, toastManager }) => {
             );
           }
 
-          const item = list.deserializeItemData(data[list.gqlNames.itemQueryName]);
+          const item = deserializeItem(list, data);
           const itemErrors = deconstructErrorsToDataShape(error)[list.gqlNames.itemQueryName] || {};
 
           return item ? (
@@ -332,7 +356,9 @@ const ItemPage = ({ list, itemId, adminPath, getListByKey, toastManager }) => {
                         key={itemId}
                         list={list}
                         getListByKey={getListByKey}
-                        onUpdate={refetch}
+                        onUpdate={() =>
+                          refetch().then(refetchedData => deserializeItem(list, refetchedData.data))
+                        }
                         toastManager={toastManager}
                         updateInProgress={updateInProgress}
                         updateErrorMessage={updateError && updateError.message}

--- a/packages/fields/src/types/Relationship/views/CreateItemModal.js
+++ b/packages/fields/src/types/Relationship/views/CreateItemModal.js
@@ -127,6 +127,7 @@ class CreateItemModal extends Component {
                             <Field
                               autoFocus={!i}
                               value={item[field.path]}
+                              savedValue={item[field.path]}
                               field={field}
                               /* TODO: Permission query results */
                               // error={}


### PR DESCRIPTION
An example of usage is the upcoming `OEmbed` field; the embed data is only resolved server-side, so the component must be told about it after saving has succeeded.