### PR TITLE
Admin UI signout bug fixes

### DIFF
--- a/.changeset/pink-queens-look/changes.json
+++ b/.changeset/pink-queens-look/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/app-admin-ui", "type": "patch" }], "dependents": [] }

--- a/.changeset/pink-queens-look/changes.md
+++ b/.changeset/pink-queens-look/changes.md
@@ -1,0 +1,1 @@
+Correctly send user to Admin UI after logging in (under some circumstances, it would just show the word "Error")

--- a/.changeset/silly-lamps-agree/changes.json
+++ b/.changeset/silly-lamps-agree/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/app-admin-ui", "type": "patch" }], "dependents": [] }

--- a/.changeset/silly-lamps-agree/changes.md
+++ b/.changeset/silly-lamps-agree/changes.md
@@ -1,0 +1,1 @@
+Correctly sign the user out when clicking the icon in the Admin UI

--- a/packages/app-admin-ui/client/index.js
+++ b/packages/app-admin-ui/client/index.js
@@ -22,6 +22,7 @@ import ListNotFoundPage from './pages/ListNotFound';
 import ItemPage from './pages/Item';
 import InvalidRoutePage from './pages/InvalidRoute';
 import StyleGuidePage from './pages/StyleGuide';
+import SignoutPage from './pages/Signout';
 
 const findCustomPages = (pages, allPages = []) => {
   if (!Array.isArray(pages)) return allPages;
@@ -34,7 +35,7 @@ const findCustomPages = (pages, allPages = []) => {
 
 const Keystone = () => {
   let adminMeta = useAdminMeta();
-  let { adminPath, apiPath, pages, pageViews, readViews } = adminMeta;
+  let { adminPath, signoutPath, apiPath, pages, pageViews, readViews } = adminMeta;
   const apolloClient = useMemo(() => new ApolloClient({ uri: apiPath }), [apiPath]);
 
   return (
@@ -45,77 +46,89 @@ const Keystone = () => {
             <ConnectivityListener />
             <Global styles={globalStyles} />
             <BrowserRouter>
-              <ScrollToTop>
-                <Nav>
-                  <Suspense fallback={<PageLoading />}>
-                    <Switch>
-                      <Route
-                        path={`${adminPath}/style-guide/:page?`}
-                        render={() => <StyleGuidePage {...adminMeta} />}
-                      />
-                      {findCustomPages(pages).map(page => (
-                        <Route
-                          exact
-                          key={page.path}
-                          path={`${adminPath}/${page.path}`}
-                          render={() => {
-                            const [Page] = readViews([pageViews[page.path]]);
-                            return <Page />;
-                          }}
-                        />
-                      ))}
-                      <Route exact path={adminPath} render={() => <HomePage {...adminMeta} />} />
-                      <Route
-                        path={`${adminPath}/:listKey`}
-                        render={({
-                          match: {
-                            params: { listKey },
-                          },
-                        }) => {
-                          // TODO: Permission query to show/hide a list from the
-                          // menu
-                          const list = adminMeta.getListByPath(listKey);
-                          return list ? (
-                            <Switch>
+              <Route exact path={signoutPath}>
+                {({ match }) =>
+                  match ? (
+                    <SignoutPage {...adminMeta} />
+                  ) : (
+                    <ScrollToTop>
+                      <Nav>
+                        <Suspense fallback={<PageLoading />}>
+                          <Switch>
+                            <Route
+                              path={`${adminPath}/style-guide/:page?`}
+                              render={() => <StyleGuidePage {...adminMeta} />}
+                            />
+                            {findCustomPages(pages).map(page => (
                               <Route
                                 exact
-                                path={`${adminPath}/:list`}
-                                render={routeProps => (
-                                  <ListPage
-                                    key={listKey}
-                                    list={list}
-                                    adminMeta={adminMeta}
-                                    routeProps={routeProps}
-                                  />
-                                )}
+                                key={page.path}
+                                path={`${adminPath}/${page.path}`}
+                                render={() => {
+                                  const [Page] = readViews([pageViews[page.path]]);
+                                  return <Page />;
+                                }}
                               />
-                              <Route
-                                exact
-                                path={`${adminPath}/:list/:itemId`}
-                                render={({
-                                  match: {
-                                    params: { itemId },
-                                  },
-                                }) => (
-                                  <ItemPage
-                                    key={`${listKey}-${itemId}`}
-                                    list={list}
-                                    itemId={itemId}
-                                    {...adminMeta}
-                                  />
-                                )}
-                              />
-                              <Route render={() => <InvalidRoutePage {...adminMeta} />} />
-                            </Switch>
-                          ) : (
-                            <ListNotFoundPage listKey={listKey} {...adminMeta} />
-                          );
-                        }}
-                      />
-                    </Switch>
-                  </Suspense>
-                </Nav>
-              </ScrollToTop>
+                            ))}
+                            <Route
+                              exact
+                              path={adminPath}
+                              render={() => <HomePage {...adminMeta} />}
+                            />
+                            <Route
+                              path={`${adminPath}/:listKey`}
+                              render={({
+                                match: {
+                                  params: { listKey },
+                                },
+                              }) => {
+                                // TODO: Permission query to show/hide a list from the
+                                // menu
+                                const list = adminMeta.getListByPath(listKey);
+                                return list ? (
+                                  <Switch>
+                                    <Route
+                                      exact
+                                      path={`${adminPath}/:list`}
+                                      render={routeProps => (
+                                        <ListPage
+                                          key={listKey}
+                                          list={list}
+                                          adminMeta={adminMeta}
+                                          routeProps={routeProps}
+                                        />
+                                      )}
+                                    />
+                                    <Route
+                                      exact
+                                      path={`${adminPath}/:list/:itemId`}
+                                      render={({
+                                        match: {
+                                          params: { itemId },
+                                        },
+                                      }) => (
+                                        <ItemPage
+                                          key={`${listKey}-${itemId}`}
+                                          list={list}
+                                          itemId={itemId}
+                                          {...adminMeta}
+                                        />
+                                      )}
+                                    />
+                                    <Route render={() => <InvalidRoutePage {...adminMeta} />} />
+                                  </Switch>
+                                ) : (
+                                  <ListNotFoundPage listKey={listKey} {...adminMeta} />
+                                );
+                              }}
+                            />
+                          </Switch>
+                        </Suspense>
+                      </Nav>
+                    </ScrollToTop>
+                  )
+                }
+              </Route>
             </BrowserRouter>
           </ToastProvider>
         </KeyboardShortcuts>

--- a/packages/app-admin-ui/client/pages/Signout.js
+++ b/packages/app-admin-ui/client/pages/Signout.js
@@ -1,5 +1,4 @@
 import React, { Fragment } from 'react';
-import { Link } from 'react-router-dom';
 import styled from '@emotion/styled';
 
 import SessionProvider from '../providers/Session';
@@ -69,7 +68,7 @@ const SignedOutPage = ({ isLoading, isSignedIn, signinPath, signOut }) => {
             <Fragment>
               <p>You have been signed out.</p>
               <p>
-                <Link to={signinPath}>Sign In</Link>
+                <a href={signinPath}>Sign In</a>
               </p>
             </Fragment>
           )}

--- a/packages/app-admin-ui/index.js
+++ b/packages/app-admin-ui/index.js
@@ -62,7 +62,7 @@ class AdminUIApp {
     app.get(signinPath, (req, res, next) =>
       // This session is currently authenticated as part of the 'admin'
       // audience.
-      req.user && req.session.audiences && req.session.audiences.contains('admin')
+      req.user && req.session.audiences && req.session.audiences.includes('admin')
         ? res.redirect(this.adminPath)
         : next()
     );


### PR DESCRIPTION
- Correctly send user to Admin UI after logging in (under some circumstances, it would just show the word "Error")
- Correctly sign the user out when clicking the icon in the Admin UI

mostly whitespace changes. see: https://github.com/keystonejs/keystone-5/pull/1317/files?w=1