### PR TITLE
Expose the incoming Request object as context.req

### DIFF
--- a/.changeset/giant-dogs-learn/changes.json
+++ b/.changeset/giant-dogs-learn/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/app-graphql", "type": "minor" }], "dependents": [] }

--- a/.changeset/giant-dogs-learn/changes.md
+++ b/.changeset/giant-dogs-learn/changes.md
@@ -1,0 +1,1 @@
+Expose the incoming Request object as `context.req` enabling things like logging IPs in custom hooks, etc.

--- a/packages/app-graphql/lib/apolloServer.js
+++ b/packages/app-graphql/lib/apolloServer.js
@@ -152,6 +152,7 @@ function createApolloServer(keystone, apolloConfig, schemaName, dev, cookieSecre
         startAuthedSession(req, { item, list }, audiences, cookieSecret),
       endAuthedSession: endAuthedSession.bind(null, req),
       ...keystone.getAccessContext(schemaName, req),
+      req,
     }),
     ...(process.env.ENGINE_API_KEY
       ? {


### PR DESCRIPTION
For example, enables custom hooks to know things about the triggering request:

```javascript
keystone.createList('User', {
  fields: { ... },
  mutations: [{
    schema: 'startPasswordRecovery(email: String!): ForgottenPasswordToken',
    resolver: async (obj, args, context, info, { query }) => {
      // Can now access context.req.ip to log this request
    }
  }]
});
```