### PR TITLE
 Add `searchUnsplash` GraphQL query when using the `Unsplash` field type

### DIFF
--- a/.changeset/nasty-buses-develop/changes.json
+++ b/.changeset/nasty-buses-develop/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/fields", "type": "minor" }], "dependents": [] }

--- a/.changeset/nasty-buses-develop/changes.md
+++ b/.changeset/nasty-buses-develop/changes.md
@@ -1,0 +1,1 @@
+Add `searchUnsplash` GraphQL query when using the `Unsplash` field type

--- a/packages/fields/src/types/Unsplash/README.md
+++ b/packages/fields/src/types/Unsplash/README.md
@@ -81,6 +81,22 @@ type Post {
   heroImage: UnsplashImage
 }
 
+type UnsplashSearchResults {
+  total: Int
+  totalPages: Int
+  results: [UnsplashImage]
+}
+
+enum UnsplashOrientation {
+  landscape
+  portrait
+  squarish
+}
+
+type Query {
+  searchUnsplash(query: String!, page: Int, perPage: Int, orientation: UnsplashOrientation, collections: [String]): UnsplashSearchResults
+}
+
 type Mutation {
   createPost(data: PostCreateInput): Post
 }


### PR DESCRIPTION
For example:

```graphql
query searchImages {
  searchUnsplash(query: "computer", perPage: 4) {
    total
    totalPages
    results {
      unsplashId
      publicUrl
      description
    }
  }
}
```

Results in:

```json
{
  "data": {
    "searchUnsplash": {
      "total": 26138,
      "totalPages": 2614,
      "results": [
        {
          "unsplashId": "95YRwf6CNw8",
          "publicUrl": "https://images.unsplash.com/photo-1517694712202-14dd9538aa97?fit=max&fm=jpg&ixid=eyJhcHBfaWQiOjc3Nzg0fQ&ixlib=rb-1.2.1&q=75",
          "description": "JavaScript in progress"
        },
        {
          "unsplashId": "WiONHd_zYI4",
          "publicUrl": "https://images.unsplash.com/photo-1537498425277-c283d32ef9db?fit=max&fm=jpg&ixid=eyJhcHBfaWQiOjc3Nzg0fQ&ixlib=rb-1.2.1&q=75",
          "description": "MacBook Pro on white surface"
        },
        {
          "unsplashId": "bJjsKbToY34",
          "publicUrl": "https://images.unsplash.com/photo-1516542076529-1ea3854896f2?fit=max&fm=jpg&ixid=eyJhcHBfaWQiOjc3Nzg0fQ&ixlib=rb-1.2.1&q=75",
          "description": "Instagram, Twitter & Facebook Designs > https://creativemarket.com/NordWood"
        },
        {
          "unsplashId": "FlPc9_VocJ4",
          "publicUrl": "https://images.unsplash.com/photo-1516321318423-f06f85e504b3?fit=max&fm=jpg&ixid=eyJhcHBfaWQiOjc3Nzg0fQ&ixlib=rb-1.2.1&q=75",
          "description": "what’s going on here"
        }
      ]
    }
  },
  "extensions": {}
}
```