### PR TITLE
Removed drop database from knex adapter

### DIFF
--- a/packages/adapter-knex/lib/adapter-knex.js
+++ b/packages/adapter-knex/lib/adapter-knex.js
@@ -41,7 +41,14 @@ class KnexAdapter extends BaseKeystoneAdapter {
   }
 
   async postConnect() {
-    await this.dropDatabase();
+    const isSetup = await this.schema().hasTable(Object.keys(this.listAdapters)[0]);
+
+    if (this.config.dropDatabase || !isSetup) {
+      console.log('Knex adapter: Dropping database');
+      await this.dropDatabase();
+    } else {
+      return [];
+    }
 
     const createResult = await pSettle(
       Object.values(this.listAdapters).map(listAdapter => listAdapter.createTable())

--- a/packages/test-utils/lib/test-utils.js
+++ b/packages/test-utils/lib/test-utils.js
@@ -40,7 +40,10 @@ async function getMongoMemoryServerConfig() {
   // Passing `true` here generates a new, random DB name for us
   const mongoUri = await mongoServer.getConnectionString(true);
   // In theory the dbName can contain query params so lets parse it then extract the db name
-  const dbName = url.parse(mongoUri)``.pathname.split('/').pop();
+  const dbName = url
+    .parse(mongoUri)
+    .pathname.split('/')
+    .pop();
 
   return { mongoUri, dbName };
 }

--- a/packages/test-utils/lib/test-utils.js
+++ b/packages/test-utils/lib/test-utils.js
@@ -10,9 +10,10 @@ const SCHEMA_NAME = 'testing';
 
 function setupServer({ name, adapterName, createLists = () => {} }) {
   const Adapter = { mongoose: MongooseAdapter, knex: KnexAdapter }[adapterName];
+  const args = { mongoose: {}, knex: { dropDatabase: true } }[adapterName];
   const keystone = new Keystone({
     name,
-    adapter: new Adapter(),
+    adapter: new Adapter(args),
     defaultAccess: { list: true, field: true },
   });
 
@@ -39,10 +40,7 @@ async function getMongoMemoryServerConfig() {
   // Passing `true` here generates a new, random DB name for us
   const mongoUri = await mongoServer.getConnectionString(true);
   // In theory the dbName can contain query params so lets parse it then extract the db name
-  const dbName = url
-    .parse(mongoUri)
-    .pathname.split('/')
-    .pop();
+  const dbName = url.parse(mongoUri)``.pathname.split('/').pop();
 
   return { mongoUri, dbName };
 }

--- a/test-projects/basic/index.js
+++ b/test-projects/basic/index.js
@@ -167,7 +167,7 @@ keystone.createList('Post', {
       `;
       const variables = { authorId: item.author.toString() };
       const { data } = await graphql(schema, query, null, context, variables);
-      return `${item.name} (by ${data.User.name})`;
+      return `${item.name}${data.User && `(by ${data.User.name})`}`;
     } else {
       return item.name;
     }


### PR DESCRIPTION
This is a simple solution to the `await this.dropDatabase();` line in the knex adpater. Let me know your thoughts.

The dropDatabase option can be given to the adpater by 
```
const keystone = new Keystone({
  name: 'Keystone',
  adapter: new KnexAdapter({ dropDatabase: true }),
  onConnect: initialiseData
})
```