### PR TITLE
Fix bug with OEmbed not building at release time due to FIELD_TYPES file

### DIFF
--- a/.changeset/little-yaks-tell/changes.json
+++ b/.changeset/little-yaks-tell/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/fields", "type": "minor" }], "dependents": [] }

--- a/.changeset/little-yaks-tell/changes.md
+++ b/.changeset/little-yaks-tell/changes.md
@@ -1,0 +1,1 @@
+Expose `options.adminMeta` to Content Blocks.

--- a/.changeset/lovely-spies-cry/changes.json
+++ b/.changeset/lovely-spies-cry/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/fields", "type": "patch" }], "dependents": [] }

--- a/.changeset/lovely-spies-cry/changes.md
+++ b/.changeset/lovely-spies-cry/changes.md
@@ -1,0 +1,1 @@
+Correctly use `options.adminMeta.readViews()` to load OEmbed Block views.

--- a/packages/fields/src/types/Content/views/Controller.js
+++ b/packages/fields/src/types/Content/views/Controller.js
@@ -56,7 +56,10 @@ export default class ContentController extends TextController {
 
       const customBlocks = blocksModules.map(block => ({
         ...block,
-        options: this.config.blockOptions[block.type],
+        options: {
+          ...this.config.blockOptions[block.type],
+          adminMeta: this.adminMeta,
+        },
         // This block exists because it was passed into the Content field
         // directly.
         // Depdencies are not allowed to show UI chrome (toolbar/sidebar) unless

--- a/packages/fields/src/types/OEmbed/views/blocks/FIELD_TYPES
+++ b/packages/fields/src/types/OEmbed/views/blocks/FIELD_TYPES
@@ -1,1 +1,0 @@
-/* Placeholder file which will be picked up by the Admin UI's bundler */

--- a/packages/fields/src/types/OEmbed/views/blocks/o-embed.js
+++ b/packages/fields/src/types/OEmbed/views/blocks/o-embed.js
@@ -2,7 +2,6 @@
 import { jsx } from '@emotion/core';
 import { Suspense, Fragment, useState, createContext, useContext } from 'react';
 import { Button } from '@arch-ui/button';
-import { readViews } from './FIELD_TYPES';
 import PreviewPlaceholder from '../preview';
 import pluralize from 'pluralize';
 
@@ -21,7 +20,7 @@ const Embed = ({ url, oembedData }) => {
 
   if (options.previewComponent) {
     // The adapter should implement this option
-    const [Preview] = readViews([options.previewComponent]);
+    const [Preview] = options.adminMeta.readViews([options.previewComponent]);
     return <Preview url={url} options={options} />;
   } else {
     // This is a fallback so we can at least try to render _something_


### PR DESCRIPTION
- Expose `options.adminMeta` to Content Blocks.
- Correctly use `options.adminMeta.readViews()` to load OEmbed Block views.