### PR TITLE
Convert GraphQL SDL to AST before passing to Apollo

### DIFF
--- a/.changeset/quiet-keys-agree/changes.json
+++ b/.changeset/quiet-keys-agree/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/keystone", "type": "patch" }], "dependents": [] }

--- a/.changeset/quiet-keys-agree/changes.md
+++ b/.changeset/quiet-keys-agree/changes.md
@@ -1,0 +1,8 @@
+Convert GraphQL SDL to AST before passing to Apollo
+
+Apollo released a breaking change in a semver-minor which causes it to
+stop understanding the SDL (string) GraphQL typeDefs we were passing it.
+This fix ensures we're converting to an AST to avoid the error being
+thrown.
+
+See https://github.com/keystonejs/keystone-5/issues/1340

--- a/packages/keystone/lib/Keystone/index.js
+++ b/packages/keystone/lib/Keystone/index.js
@@ -332,7 +332,15 @@ module.exports = class Keystone {
       console.log(resolvers);
     }
 
-    return { typeDefs, resolvers };
+    return {
+      typeDefs: typeDefs.map(
+        typeDef =>
+          gql`
+            ${typeDef}
+          `
+      ),
+      resolvers,
+    };
   }
 
   dumpSchema(file) {


### PR DESCRIPTION
Apollo released a breaking change in a semver-minor which causes it to
stop understanding the SDL (string) GraphQL typeDefs we were passing it.
This fix ensures we're converting to an AST to avoid the error being
thrown.

See https://github.com/apollographql/apollo-server/issues/2921

Fixes #1340