### PR TITLE
Adding db level config for knex adapter

### DIFF
--- a/.changeset/early-tools-help/changes.json
+++ b/.changeset/early-tools-help/changes.json
@@ -1,0 +1,8 @@
+{
+  "releases": [
+    { "name": "@keystone-alpha/adapter-knex", "type": "minor" },
+    { "name": "@keystone-alpha/fields", "type": "minor" },
+    { "name": "@keystone-alpha/keystone", "type": "patch" }
+  ],
+  "dependents": []
+}

--- a/.changeset/early-tools-help/changes.md
+++ b/.changeset/early-tools-help/changes.md
@@ -1,0 +1,1 @@
+Adding `knexOptions` to the KnexFieldAdapter to support DB-level config for nullability (`isNotNullable`) and defaults (`defaultTo`)

--- a/packages/fields/src/types/CalendarDay/Implementation.js
+++ b/packages/fields/src/types/CalendarDay/Implementation.js
@@ -69,7 +69,8 @@ export class KnexCalendarDayInterface extends CommonCalendarInterface(KnexFieldA
   addToTableSchema(table) {
     const column = table.date(this.path);
     if (this.isUnique) column.unique();
-    if (this.isRequired) column.notNullable();
+    if (this.isNotNullable) column.notNullable();
+    if (this.defaultTo) column.defaultTo(this.defaultTo);
   }
 
   setupHooks({ addPostReadHook }) {

--- a/packages/fields/src/types/Checkbox/Implementation.js
+++ b/packages/fields/src/types/Checkbox/Implementation.js
@@ -41,6 +41,7 @@ export class MongoCheckboxInterface extends CommonCheckboxInterface(MongooseFiel
 export class KnexCheckboxInterface extends CommonCheckboxInterface(KnexFieldAdapter) {
   addToTableSchema(table) {
     const column = table.boolean(this.path);
-    if (this.isRequired) column.notNullable();
+    if (this.isNotNullable) column.notNullable();
+    if (this.defaultTo) column.defaultTo(this.defaultTo);
   }
 }

--- a/packages/fields/src/types/Decimal/Implementation.js
+++ b/packages/fields/src/types/Decimal/Implementation.js
@@ -82,7 +82,8 @@ export class KnexDecimalInterface extends KnexFieldAdapter {
   addToTableSchema(table) {
     const column = table.decimal(this.path);
     if (this.isUnique) column.unique();
-    if (this.isRequired) column.notNullable();
+    if (this.isNotNullable) column.notNullable();
+    if (this.defaultTo) column.defaultTo(this.defaultTo);
   }
 
   getQueryConditions(dbPath) {

--- a/packages/fields/src/types/File/Implementation.js
+++ b/packages/fields/src/types/File/Implementation.js
@@ -143,6 +143,7 @@ export class MongoFileInterface extends CommonFileInterface(MongooseFieldAdapter
 export class KnexFileInterface extends CommonFileInterface(KnexFieldAdapter) {
   addToTableSchema(table) {
     const column = table.jsonb(this.path);
-    if (this.isRequired) column.notNullable();
+    if (this.isNotNullable) column.notNullable();
+    if (this.defaultTo) column.defaultTo(this.defaultTo);
   }
 }

--- a/packages/fields/src/types/Float/Implementation.js
+++ b/packages/fields/src/types/Float/Implementation.js
@@ -50,6 +50,7 @@ export class KnexFloatInterface extends CommonFloatInterface(KnexFieldAdapter) {
   addToTableSchema(table) {
     const column = table.float(this.path);
     if (this.isUnique) column.unique();
-    if (this.isRequired) column.notNullable();
+    if (this.isNotNullable) column.notNullable();
+    if (this.defaultTo) column.defaultTo(this.defaultTo);
   }
 }

--- a/packages/fields/src/types/Integer/Implementation.js
+++ b/packages/fields/src/types/Integer/Implementation.js
@@ -57,6 +57,7 @@ export class KnexIntegerInterface extends CommonIntegerInterface(KnexFieldAdapte
   addToTableSchema(table) {
     const column = table.integer(this.path);
     if (this.isUnique) column.unique();
-    if (this.isRequired) column.notNullable();
+    if (this.isNotNullable) column.notNullable();
+    if (this.defaultTo) column.defaultTo(this.defaultTo);
   }
 }

--- a/packages/fields/src/types/OEmbed/Implementation.js
+++ b/packages/fields/src/types/OEmbed/Implementation.js
@@ -270,6 +270,7 @@ export class MongoOEmbedInterface extends CommonOEmbedInterface(MongooseFieldAda
 export class KnexOEmbedInterface extends CommonOEmbedInterface(KnexFieldAdapter) {
   addToTableSchema(table) {
     const column = table.jsonb(this.path);
-    if (this.isRequired) column.notNullable();
+    if (this.isNotNullable) column.notNullable();
+    if (this.defaultTo) column.defaultTo(this.defaultTo);
   }
 }

--- a/packages/fields/src/types/Password/Implementation.js
+++ b/packages/fields/src/types/Password/Implementation.js
@@ -128,7 +128,8 @@ export class MongoPasswordInterface extends CommonPasswordInterface(MongooseFiel
 export class KnexPasswordInterface extends CommonPasswordInterface(KnexFieldAdapter) {
   addToTableSchema(table) {
     const column = table.string(this.path, 60);
-    if (this.isRequired) column.notNullable();
+    if (this.isNotNullable) column.notNullable();
+    // Defaulting or unique constraints here would create vulnerabilities
   }
 
   getQueryConditions(dbPath) {

--- a/packages/fields/src/types/Relationship/README.md
+++ b/packages/fields/src/types/Relationship/README.md
@@ -31,9 +31,9 @@ keystone.createList('Org', {
 
 ### Config
 
-| Option       | Type      | Default | Description                                                     |
-| ------------ | --------- | ------- | --------------------------------------------------------------- |
-| `isUnique`   | `Boolean` | `false` | Adds a unique index that allows only unique values to be stored |
+| Option     | Type      | Default | Description                                                     |
+| ---------- | --------- | ------- | --------------------------------------------------------------- |
+| `isUnique` | `Boolean` | `false` | Adds a unique index that allows only unique values to be stored |
 
 ```DOCS_TODO
 TODO: Missing config options

--- a/packages/fields/src/types/Select/Implementation.js
+++ b/packages/fields/src/types/Select/Implementation.js
@@ -77,6 +77,7 @@ export class KnexSelectInterface extends CommonSelectInterface(KnexFieldAdapter)
   addToTableSchema(table) {
     const column = table.enu(this.path, this.config.options.map(({ value }) => value));
     if (this.isUnique) column.unique();
-    if (this.isRequired) column.notNullable();
+    if (this.isNotNullable) column.notNullable();
+    if (this.defaultTo) column.defaultTo(this.defaultTo);
   }
 }

--- a/packages/fields/src/types/Text/Implementation.js
+++ b/packages/fields/src/types/Text/Implementation.js
@@ -58,6 +58,7 @@ export class KnexTextInterface extends CommonTextInterface(KnexFieldAdapter) {
   addToTableSchema(table) {
     const column = table.text(this.path);
     if (this.isUnique) column.unique();
-    if (this.isRequired) column.notNullable();
+    if (this.isNotNullable) column.notNullable();
+    if (this.defaultTo) column.defaultTo(this.defaultTo);
   }
 }

--- a/packages/fields/src/types/Unsplash/Implementation.js
+++ b/packages/fields/src/types/Unsplash/Implementation.js
@@ -262,6 +262,7 @@ export class MongoUnsplashInterface extends CommonUnsplashInterface(MongooseFiel
 export class KnexUnsplashInterface extends CommonUnsplashInterface(KnexFieldAdapter) {
   addToTableSchema(table) {
     const column = table.jsonb(this.path);
-    if (this.isRequired) column.notNullable();
+    if (this.isNotNullable) column.notNullable();
+    if (this.defaultTo) column.defaultTo(this.defaultTo);
   }
 }

--- a/packages/fields/src/types/Uuid/Implementation.js
+++ b/packages/fields/src/types/Uuid/Implementation.js
@@ -84,7 +84,8 @@ export class KnexUuidInterface extends KnexFieldAdapter {
   addToTableSchema(table) {
     const column = table.uuid(this.path);
     if (this.isUnique) column.unique();
-    if (this.isRequired) column.notNullable();
+    if (this.isNotNullable) column.notNullable();
+    if (this.defaultTo) column.defaultTo(this.defaultTo);
   }
 
   getQueryConditions(dbPath) {


### PR DESCRIPTION
Adding `knexOptions` to the KnexFieldAdapter to support DB-level config for nullability (`isNotNullable`) and defaults (`defaultTo`). These are defaulted based on their KS-level equivalents (`isRequired` and `defaultValue`).

Also updated existing Knex field adapters to use new db-level config options. This switches `isRequired` flag for `isNotNullable` and adds db-level defaulting to all fields (for which it makes sense).

I'm expecting some of the naming to be a little spicy for some 🌶