### PR TITLE
Adding a `field` reference to field adapter instances

### DIFF
--- a/.changeset/tame-poems-swim/changes.json
+++ b/.changeset/tame-poems-swim/changes.json
@@ -1,0 +1,109 @@
+{
+  "releases": [
+    { "name": "@keystone-alpha/keystone", "type": "major" },
+    { "name": "@keystone-alpha/fields", "type": "patch" }
+  ],
+  "dependents": [
+    {
+      "name": "@keystone-alpha/api-tests",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/test-utils",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-blog",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-meetup",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-todo",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/adapter-knex",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/adapter-mongoose",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/test-utils",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-knex",
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/keystone"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-access-control",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-basic",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-client-validation",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-login",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-social-login",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/fields"
+      ]
+    }
+  ]
+}

--- a/.changeset/tame-poems-swim/changes.md
+++ b/.changeset/tame-poems-swim/changes.md
@@ -1,0 +1,1 @@
+Adding field instance to the BaseFieldAdapter constructor arguments

--- a/packages/fields/src/Implementation.js
+++ b/packages/fields/src/Implementation.js
@@ -20,6 +20,7 @@ class Field {
       fieldAdapterClass,
       this.constructor.name,
       path,
+      this,
       getListByKey,
       { isRequired, ...config }
     );

--- a/packages/fields/src/types/Password/Implementation.js
+++ b/packages/fields/src/types/Password/Implementation.js
@@ -94,18 +94,17 @@ const CommonPasswordInterface = superclass =>
     setupHooks({ addPreSaveHook }) {
       // Updates the relevant value in the item provided (by referrence)
       addPreSaveHook(async item => {
-        const list = this.getListByKey(this.listAdapter.key);
-        const field = list.fieldsByPath[this.path];
-        const plaintext = item[field.path];
+        const path = this.field.path;
+        const plaintext = item[path];
 
         if (typeof plaintext === 'undefined') {
           return item;
         }
 
         if (String(plaintext) === plaintext && plaintext !== '') {
-          item[field.path] = await field.generateHash(plaintext);
+          item[path] = await this.field.generateHash(plaintext);
         } else {
-          item[field.path] = null;
+          item[path] = null;
         }
         return item;
       });

--- a/packages/fields/src/types/Uuid/Implementation.js
+++ b/packages/fields/src/types/Uuid/Implementation.js
@@ -54,10 +54,7 @@ export class MongoUuidInterface extends MongooseFieldAdapter {
       const valType = typeof item[this.path];
 
       if (item[this.path] && valType === 'string') {
-        const list = this.getListByKey(this.listAdapter.key);
-        const field = list.fieldsByPath[this.path];
-
-        item[this.path] = field.normaliseValue(item[this.path]);
+        item[this.path] = this.field.normaliseValue(item[this.path]);
       } else if (!item[this.path] || valType === 'undefined') {
         delete item[this.path];
       } else {
@@ -69,22 +66,16 @@ export class MongoUuidInterface extends MongooseFieldAdapter {
     });
     addPostReadHook(item => {
       if (item[this.path]) {
-        const list = this.getListByKey(this.listAdapter.key);
-        const field = list.fieldsByPath[this.path];
-
-        item[this.path] = field.normaliseValue(item[this.path]);
+        item[this.path] = this.field.normaliseValue(item[this.path]);
       }
       return item;
     });
   }
 
   getQueryConditions(dbPath) {
-    const list = this.getListByKey(this.listAdapter.key);
-    const field = list.fieldsByPath[this.path];
-
     return {
-      ...this.equalityConditions(dbPath, field.normaliseValue),
-      ...this.inConditions(dbPath, field.normaliseValue),
+      ...this.equalityConditions(dbPath, this.field.normaliseValue),
+      ...this.inConditions(dbPath, this.field.normaliseValue),
     };
   }
 }
@@ -97,12 +88,9 @@ export class KnexUuidInterface extends KnexFieldAdapter {
   }
 
   getQueryConditions(dbPath) {
-    const list = this.getListByKey(this.listAdapter.key);
-    const field = list.fieldsByPath[this.path];
-
     return {
-      ...this.equalityConditions(dbPath, field.normaliseValue),
-      ...this.inConditions(dbPath, field.normaliseValue),
+      ...this.equalityConditions(dbPath, this.field.normaliseValue),
+      ...this.inConditions(dbPath, this.field.normaliseValue),
     };
   }
 }

--- a/packages/keystone/lib/adapters/index.js
+++ b/packages/keystone/lib/adapters/index.js
@@ -69,8 +69,8 @@ class BaseListAdapter {
     ];
   }
 
-  newFieldAdapter(fieldAdapterClass, name, path, getListByKey, config) {
-    const adapter = new fieldAdapterClass(name, path, this, getListByKey, config);
+  newFieldAdapter(fieldAdapterClass, name, path, field, getListByKey, config) {
+    const adapter = new fieldAdapterClass(name, path, field, this, getListByKey, config);
     this.prepareFieldAdapter(adapter);
     adapter.setupHooks({
       addPreSaveHook: this.addPreSaveHook.bind(this),
@@ -148,9 +148,17 @@ class BaseListAdapter {
 }
 
 class BaseFieldAdapter {
-  constructor(fieldName, path, listAdapter, getListByKey, { isRequired, isUnique, ...config }) {
+  constructor(
+    fieldName,
+    path,
+    field,
+    listAdapter,
+    getListByKey,
+    { isRequired, isUnique, ...config }
+  ) {
     this.fieldName = fieldName;
     this.path = path;
+    this.field = field;
     this.listAdapter = listAdapter;
     this.config = config;
     this.getListByKey = getListByKey;


### PR DESCRIPTION
This tries to solve the same problem as #1370 but, rather than getters that dereference the field at run time, we just pass the `field` instance in to the `fieldAdapter` constructor.

Easiest to see what's going on if you look at the commits in series.