### PR TITLE
Adding `MongoId` field type for standalone (ie. non-primay key) IDs

### DIFF
--- a/.changeset/breezy-eagles-add/changes.json
+++ b/.changeset/breezy-eagles-add/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/fields-mongoId", "type": "major" }], "dependents": [] }

--- a/.changeset/breezy-eagles-add/changes.md
+++ b/.changeset/breezy-eagles-add/changes.md
@@ -1,0 +1,1 @@
+Initial MongoId field type implementation

--- a/package.json
+++ b/package.json
@@ -306,10 +306,11 @@
   },
   "field-types": {
     "packages": [
-      "packages/fields-wysiwyg-tinymce",
+      "packages/field-content",
       "packages/fields",
       "packages/fields-markdown",
-      "packages/field-content",
+      "packages/fields-mongoId",
+      "packages/fields-wysiwyg-tinymce",
       "packages/oembed-adapters"
     ]
   },

--- a/packages/fields-mongoId/README.md
+++ b/packages/fields-mongoId/README.md
@@ -1,0 +1,107 @@
+<!--[meta]
+section: field-types
+title: MongoId
+[meta]-->
+
+# Keystone 5 `MongoId` Field Type
+
+This field allows arbitary MongoID fields to be added to your lists.
+
+It supports the core Mongoose and Knex adapters:
+
+- On Mongoose the [native Mongo `ObjectId` schema type](https://mongoosejs.com/docs/schematypes.html#objectids) is used.
+- On Knex a 24 charactor [string field](https://knexjs.org/#Schema-string) is added to the schema.
+  This resolves down to `varchar(24)`, `character varying(24)` or similar, depending on the underlying DB platform.
+  Values stored are forced to lowercase on read and write to avoid issues with case-sensitive string comparisons.
+  See the [casing section](#casing) for details.
+
+## Usage
+
+```js
+const { Keystone } = require('@keystone-alpha/keystone');
+const { MongoId } = require('@keystone-alpha/fields-mongoId');
+
+const keystone = new Keystone(/* ... */);
+
+keystone.createList('Product', {
+  fields: {
+    name: { type: Text },
+    oldId: { type: MongoId },
+    // ...
+  },
+});
+```
+
+### Config
+
+| Option       | Type      | Default | Description                                                     |
+| :----------- | :-------- | :------ | :-------------------------------------------------------------- |
+| `isRequired` | `Boolean` | `false` | Does this field require a value?                                |
+| `isUnique`   | `Boolean` | `false` | Adds a unique index that allows only unique values to be stored |
+
+## Admin UI
+
+We reuse the interface implementation from the native `Text` field.
+
+## GraphQL
+
+`MongoId` fields use the `ID` type in GraphQL.
+
+### Input Fields
+
+| Field name | Type | Description                               |
+| :--------- | :--- | :---------------------------------------- |
+| `${path}`  | `ID` | The ID in it's 24 char hex representation |
+
+### Output Fields
+
+| Field name | Type | Description                               |
+| :--------- | :--- | :---------------------------------------- |
+| `${path}`  | `ID` | The ID in it's 24 char hex representation |
+
+### Filters
+
+Since `MongoId` fields encode identifiers, "text" filters (eg. `contains`, `starts_with`, etc) are not supported.
+Note also that hexadecimal encoding, as used here, is case agnostic.
+As such, despite the GraphQL `ID` type being encoded as Strings, all `MongoId` filters are effectively case insensitive.
+See the the [Casing section](#casing).
+
+| Field name       | Type   | Description                           |
+| :--------------- | :----- | :------------------------------------ |
+| `${path}`        | `ID`   | Exact match to the ID provided        |
+| `${path}_not`    | `ID`   | Not an exact match to the ID provided |
+| `${path}_in`     | `[ID]` | In the array of IDs provided          |
+| `${path}_not_in` | `[ID]` | Not in the array of IDs provided      |
+
+## Storage
+
+### Mongoose Adaptor
+
+The Mongoose Adaptor uses the [native Mongo `ObjectId` schema type](https://mongoosejs.com/docs/schematypes.html#objectids).
+Internally, the 12-byte value are stored in a binary format.
+Mongoose automatically and transparently converts to and from the 24 char hexadecimal representation when reading and writing.
+
+### Knex Adaptor
+
+The Knex adaptor adds 24 charactor [string field](https://knexjs.org/#Schema-string) to the schema.
+This resolves down to `varchar(24)`, `character varying(24)` or similar, depending on the underlying DB platform.
+
+Values stored are forced to lowercase on read and write to avoid issues with case-sensitive string comparisons.
+See the [casing section](#casing) for details.
+
+The field adapter supplied for Knex supports
+[the `isNotNullable` and `defaultTo` options](https://github.com/keystonejs/keystone-5/pull/1383#issuecomment-509889242).
+
+## Casing
+
+Mongo ObjectIDs are usually passed around in a hexadecimal string representation.
+Hexadecial itself is case agnostic; the hex value `AF3D` is identical to the hex value `af3d`
+(they encode the same value as decimal `44861` or binary `1010111100111101`).
+However, JavaScript and (depending on your configuration) some DB platforms are case-sensitive;
+in these contexts, the string `'AF3D'` _does not equal_ the string `'af3d'`.
+
+For the `MongoId` type, we mitigate this problem by forcing values to lowercase when using the Knex adapter.
+
+Similar issues are faced by the
+[core `Uuid` field type](https://github.com/keystonejs/keystone-5/tree/master/packages/fields/src/types/Uuid#casing).
+It is also often represented using hexadecimal within a string.

--- a/packages/fields-mongoId/package.json
+++ b/packages/fields-mongoId/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@keystone-alpha/fields-mongoId",
+  "description": "KeystoneJS MongoId Field Type",
+  "version": "1.0.0",
+  "author": "The KeystoneJS Development Team",
+  "license": "MIT",
+  "main": "index.js",
+  "repository": "https://github.com/keystonejs/keystone-5.git",
+  "engines": {
+    "node": ">=8.4.0"
+  },
+  "dependencies": {
+    "@keystone-alpha/adapter-knex": "^2.0.0",
+    "@keystone-alpha/adapter-mongoose": "^2.2.0",
+    "@keystone-alpha/fields": "^9.0.0"
+  },
+  "main": "dist/fields-mongoId.cjs.js",
+  "module": "dist/fields-mongoId.esm.js"
+}

--- a/packages/fields-mongoId/package.json
+++ b/packages/fields-mongoId/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keystone-alpha/fields-mongoId",
   "description": "KeystoneJS MongoId Field Type",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "author": "The KeystoneJS Development Team",
   "license": "MIT",
   "main": "index.js",

--- a/packages/fields-mongoId/src/Implementation.js
+++ b/packages/fields-mongoId/src/Implementation.js
@@ -1,0 +1,82 @@
+import { Implementation } from '@keystone-alpha/fields';
+import { MongooseFieldAdapter } from '@keystone-alpha/adapter-mongoose';
+import { KnexFieldAdapter } from '@keystone-alpha/adapter-knex';
+
+export class MongoIdImplementation extends Implementation {
+  get gqlOutputFields() {
+    return [`${this.path}: ID`];
+  }
+  get gqlOutputFieldResolvers() {
+    return { [`${this.path}`]: item => item[this.path] };
+  }
+  get gqlQueryInputFields() {
+    return [...this.equalityInputFields('ID'), ...this.inInputFields('ID')];
+  }
+  get gqlUpdateInputFields() {
+    return [`${this.path}: ID`];
+  }
+  get gqlCreateInputFields() {
+    return [`${this.path}: ID`];
+  }
+}
+
+const validator = a => (a ? /^[0-9a-fA-F]{24}$/.test(a.toString()) : true);
+const normaliseValue = a => (a ? a.toString().toLowerCase() : null);
+
+export class MongooseMongoIdInterface extends MongooseFieldAdapter {
+  addToMongooseSchema(schema, mongoose) {
+    const schemaOptions = {
+      type: mongoose.Schema.Types.ObjectId,
+      validate: {
+        validator: this.buildValidator(validator),
+        message: '{VALUE} is not a valid Mongo ObjectId',
+      },
+    };
+    schema.add({ [this.path]: this.mergeSchemaOptions(schemaOptions, this.config) });
+  }
+  getQueryConditions(dbPath) {
+    return {
+      ...this.equalityConditions(dbPath),
+      ...this.inConditions(dbPath),
+    };
+  }
+}
+
+export class KnexMongoIdInterface extends KnexFieldAdapter {
+  addToTableSchema(table) {
+    const column = table.string(this.path, 24);
+    if (this.isUnique) column.unique();
+    if (this.isNotNullable) column.notNullable();
+    if (this.defaultTo) column.defaultTo(this.defaultTo);
+  }
+
+  setupHooks({ addPreSaveHook, addPostReadHook }) {
+    addPreSaveHook(item => {
+      const valType = typeof item[this.path];
+
+      if (item[this.path] && valType === 'string') {
+        item[this.path] = normaliseValue(item[this.path]);
+      } else if (!item[this.path] || valType === 'undefined') {
+        delete item[this.path];
+      } else {
+        // Should have been caught by the validator??
+        throw `Invalid value given for '${this.path}'`;
+      }
+
+      return item;
+    });
+    addPostReadHook(item => {
+      if (item[this.path]) {
+        item[this.path] = normaliseValue(item[this.path]);
+      }
+      return item;
+    });
+  }
+
+  getQueryConditions(dbPath) {
+    return {
+      ...this.equalityConditions(dbPath, normaliseValue),
+      ...this.inConditions(dbPath, normaliseValue),
+    };
+  }
+}

--- a/packages/fields-mongoId/src/index.js
+++ b/packages/fields-mongoId/src/index.js
@@ -1,0 +1,20 @@
+import {
+  MongoIdImplementation,
+  MongooseMongoIdInterface,
+  KnexMongoIdInterface,
+} from './Implementation';
+import { Text } from '@keystone-alpha/fields';
+
+export let MongoId = {
+  type: 'MongoId',
+  implementation: MongoIdImplementation,
+  views: {
+    Controller: Text.views.Controller,
+    Field: Text.views.Field,
+    Filter: Text.views.Filter,
+  },
+  adapters: {
+    knex: KnexMongoIdInterface,
+    mongoose: MongooseMongoIdInterface,
+  },
+};


### PR DESCRIPTION
Adding the `MongoId` field type -- a non-core, standalone, Mongo ObjectID type. Supports the Mongoose and Knex adapters.

This type can be used to store arbitrary Mongo ObjectIds in a list (in addition to your primary key, if you're on Mongo).

Relates to #317, follows on from #1372 and lays more of the groundwork for fixing #1384.