### PR TITLE
Switching lists to use standard field types for primary keys (instead of weird pseudo-field)

### DIFF
--- a/.changeset/six-pets-dress/changes.json
+++ b/.changeset/six-pets-dress/changes.json
@@ -1,0 +1,130 @@
+{
+  "releases": [
+    { "name": "@keystone-alpha/adapter-knex", "type": "major" },
+    { "name": "@keystone-alpha/adapter-mongoose", "type": "major" },
+    { "name": "@keystone-alpha/fields-auto-increment", "type": "major" },
+    { "name": "@keystone-alpha/fields-mongoId", "type": "major" },
+    { "name": "@keystone-alpha/fields", "type": "major" },
+    { "name": "@keystone-alpha/app-admin-ui", "type": "minor" },
+    { "name": "@keystone-alpha/keystone", "type": "minor" },
+    { "name": "@keystone-alpha/test-utils", "type": "minor" }
+  ],
+  "dependents": [
+    {
+      "name": "@keystone-alpha/api-tests",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/fields",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/test-utils"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-blog",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/fields-markdown",
+        "@keystone-alpha/fields-wysiwyg-tinymce",
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/fields",
+        "@keystone-alpha/app-admin-ui",
+        "@keystone-alpha/keystone"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-meetup",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/fields-wysiwyg-tinymce",
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/fields",
+        "@keystone-alpha/app-admin-ui",
+        "@keystone-alpha/keystone"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-todo",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/fields",
+        "@keystone-alpha/app-admin-ui",
+        "@keystone-alpha/keystone"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-access-control",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/fields",
+        "@keystone-alpha/app-admin-ui",
+        "@keystone-alpha/keystone"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-basic",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/field-content",
+        "@keystone-alpha/fields-markdown",
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/fields",
+        "@keystone-alpha/app-admin-ui",
+        "@keystone-alpha/keystone"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-client-validation",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/fields",
+        "@keystone-alpha/app-admin-ui",
+        "@keystone-alpha/keystone"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-login",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/fields",
+        "@keystone-alpha/app-admin-ui",
+        "@keystone-alpha/keystone"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-social-login",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/passport-auth",
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/fields",
+        "@keystone-alpha/app-admin-ui",
+        "@keystone-alpha/keystone"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/field-content",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields"]
+    },
+    {
+      "name": "@keystone-alpha/fields-markdown",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields"]
+    },
+    {
+      "name": "@keystone-alpha/fields-wysiwyg-tinymce",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields"]
+    },
+    {
+      "name": "@keystone-alpha/passport-auth",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields"]
+    }
+  ]
+}

--- a/.changeset/six-pets-dress/changes.md
+++ b/.changeset/six-pets-dress/changes.md
@@ -1,0 +1,1 @@
+Switching lists to use standard field types for primary keys (instead of weird pseudo-field)

--- a/packages/adapter-knex/lib/adapter-knex.js
+++ b/packages/adapter-knex/lib/adapter-knex.js
@@ -104,7 +104,7 @@ class KnexAdapter extends BaseKeystoneAdapter {
   getDefaultPrimaryKeyConfig() {
     // Required here due to circular refs
     const { AutoIncrement } = require('@keystone-alpha/fields-auto-increment');
-    return AutoIncrement.primaryKeyDefaults[this.name].getConfig();
+    return AutoIncrement.primaryKeyDefaults[this.name].getConfig(this.client);
   }
 }
 

--- a/packages/adapter-knex/package.json
+++ b/packages/adapter-knex/package.json
@@ -8,6 +8,7 @@
     "node": ">=8.4.0"
   },
   "dependencies": {
+    "@keystone-alpha/fields-auto-increment": "^0.0.0",
     "@keystone-alpha/keystone": "^8.0.0",
     "@keystone-alpha/utils": "^3.0.1",
     "knex": "^0.16.5",

--- a/packages/adapter-mongoose/lib/adapter-mongoose.js
+++ b/packages/adapter-mongoose/lib/adapter-mongoose.js
@@ -116,6 +116,12 @@ class MongooseAdapter extends BaseKeystoneAdapter {
   dropDatabase() {
     return this.mongoose.connection.dropDatabase();
   }
+
+  getDefaultPrimaryKeyConfig() {
+    // Required here due to circular refs
+    const { MongoId } = require('@keystone-alpha/fields-mongoId');
+    return MongoId.primaryKeyDefaults[this.name].getConfig();
+  }
 }
 
 const DEFAULT_MODEL_SCHEMA_OPTIONS = {

--- a/packages/adapter-mongoose/lib/tokenizers/simple.js
+++ b/packages/adapter-mongoose/lib/tokenizers/simple.js
@@ -1,4 +1,3 @@
-const mongoose = require('mongoose');
 const { objMerge } = require('@keystone-alpha/utils');
 
 module.exports = ({ getRelatedListAdapterFromQueryPath, modifierConditions }) => (
@@ -13,12 +12,6 @@ module.exports = ({ getRelatedListAdapterFromQueryPath, modifierConditions }) =>
   // ['posts', 'comments', 'author']
   const refListAdapter = getRelatedListAdapterFromQueryPath(path.slice(0, -1));
   const simpleQueryConditions = {
-    // id is how it looks in the schema
-    // _id is how it looks in the MongoDB
-    id: value => ({ _id: { $eq: mongoose.Types.ObjectId(value) } }),
-    id_not: value => ({ _id: { $ne: mongoose.Types.ObjectId(value) } }),
-    id_in: value => ({ _id: { $in: value.map(id => mongoose.Types.ObjectId(id)) } }),
-    id_not_in: value => ({ _id: { $not: { $in: value.map(id => mongoose.Types.ObjectId(id)) } } }),
     ...objMerge(
       refListAdapter.fieldAdapters.map(fieldAdapter =>
         fieldAdapter.getQueryConditions(fieldAdapter.dbPath)

--- a/packages/adapter-mongoose/package.json
+++ b/packages/adapter-mongoose/package.json
@@ -8,6 +8,7 @@
     "node": ">=8.4.0"
   },
   "dependencies": {
+    "@keystone-alpha/fields-mongoId": "^0.0.0",
     "@keystone-alpha/keystone": "^8.0.0",
     "@keystone-alpha/logger": "^2.0.1",
     "@keystone-alpha/mongo-join-builder": "^2.0.2",

--- a/packages/adapter-mongoose/tests/simple.test.js
+++ b/packages/adapter-mongoose/tests/simple.test.js
@@ -1,4 +1,3 @@
-const mongoose = require('mongoose');
 const tokenizerFactory = require('../lib/tokenizers/simple');
 
 describe('Simple tokenizer', () => {
@@ -64,29 +63,5 @@ describe('Simple tokenizer', () => {
     expect(getQueryConditions).toHaveBeenCalledTimes(1);
     expect(nameConditions).toHaveBeenCalledTimes(1);
     expect(nameConditions).toHaveBeenCalledWith('hi', { name: 'hi' });
-  });
-
-  test('Correctly handles id query keys', () => {
-    const nameConditions = jest.fn(() => ({ foo: 'bar' }));
-    const simpleConditions = { name: nameConditions };
-    const getQueryConditions = jest.fn(() => simpleConditions);
-    const getRelatedListAdapterFromQueryPath = jest.fn(() => ({
-      fieldAdapters: [{ getQueryConditions }],
-    }));
-
-    const simple = tokenizerFactory({ getRelatedListAdapterFromQueryPath });
-
-    expect(simple({ id: '123412341234' }, 'id', ['name'])).toMatchObject({
-      matchTerm: { _id: { $eq: mongoose.Types.ObjectId('123412341234') } },
-    });
-    expect(simple({ id_not: '123412341234' }, 'id_not', ['name'])).toMatchObject({
-      matchTerm: { _id: { $ne: mongoose.Types.ObjectId('123412341234') } },
-    });
-    expect(simple({ id_in: ['123412341234'] }, 'id_in', ['name'])).toMatchObject({
-      matchTerm: { _id: { $in: [mongoose.Types.ObjectId('123412341234')] } },
-    });
-    expect(simple({ id_not_in: ['123412341234'] }, 'id_not_in', ['name'])).toMatchObject({
-      matchTerm: { _id: { $not: { $in: [mongoose.Types.ObjectId('123412341234')] } } },
-    });
   });
 });

--- a/packages/app-admin-ui/client/classes/List.js
+++ b/packages/app-admin-ui/client/classes/List.js
@@ -14,10 +14,12 @@ export default class List {
     // TODO: undo this
     Object.assign(this, config);
 
-    this.fields = config.fields.map(fieldConfig => {
-      const [Controller] = adminMeta.readViews([views[fieldConfig.path].Controller]);
-      return new Controller(fieldConfig, this, adminMeta, views[fieldConfig.path]);
-    });
+    this.fields = config.fields
+      .filter(field => !field.isPrimaryKey)
+      .map(fieldConfig => {
+        const [Controller] = adminMeta.readViews([views[fieldConfig.path].Controller]);
+        return new Controller(fieldConfig, this, adminMeta, views[fieldConfig.path]);
+      });
 
     this.fieldsByPath = arrayToObject(this.fields, 'path');
 

--- a/packages/fields-auto-increment/README.md
+++ b/packages/fields-auto-increment/README.md
@@ -6,12 +6,12 @@ title: AutoIncrement
 # Keystone 5 `AutoIncrement` Field Type
 
 An automatically incrementing integer with support for the Knex adapter.
-Currently, outside it's use as a primary key, this field type will only work on PostgreSQL.
-
 It's important to note, this type..
 
 - Has [important limitations](#limitations) due to varying support from the underlying DB platform
 - Has [non-standard defaults](#non-standard-defaults) for much of it's configuration
+
+**Currently, outside it's use as a primary key, this field type will only work on PostgreSQL.**
 
 ## Limitations
 
@@ -59,7 +59,7 @@ const keystone = new Keystone(/* ... */);
 keystone.createList('Order', {
   fields: {
     name: { type: Text },
-    orderNumber: { type: AutoIncrement, knexOptions: { isPrimaryKey: false } },
+    orderNumber: { type: AutoIncrement },
     // ...
   },
 });
@@ -71,18 +71,6 @@ keystone.createList('Order', {
 | :------------ | :-------- | :---------- | :-------------------------------------------------------------- |
 | `isRequired`  | `Boolean` | `false`     | Does this field require a value?                                |
 | `isUnique`    | `Boolean` | `true`      | Adds a unique index that allows only unique values to be stored |
-| `knexOptions` | `Object`  | (see below) | (see below)                                                     |
-
-### `knexOptions`
-
-| Option         | Type      | Default | Description                                           |
-| :------------- | :-------- | :------ | :---------------------------------------------------- |
-| `isPrimaryKey` | `Boolean` | `true`  | Should Knex set this as the primary key for the table |
-
-The setting `isPrimaryKey` to `false` prevents Knex from setting the columns as the primary key.
-This is current only supported on PostgreSQL.
-It works by substituting the generic `increments()` call for an explicitly build `serial` column.
-See the [Limitations section](#limitations) more about auto inc and their usage as primary keys.
 
 ## Admin UI
 
@@ -130,9 +118,10 @@ The underlying implementation varies in significant ways depending on the DB pla
 
 One implication of `increments()` is that Knex will
 [always make it the primary key](https://github.com/tgriesser/knex/issues/385) of the table.
-To work around this we've implemented the `knexOptions.isPrimaryKey` flag (see [`knexOptions`](#knexoptions)).
-Passing this as `false` replaces the generic `increments()` call with an explicitly build `serial` column.
-This is only supported on PostgreSQL.
+To work around this, if this type is not being used as the lists primary key,
+we replace the generic `increments()` call with an explicitly build `serial` column.
+This work around only supports PostgreSQL; on other DB platforms, this type can only be used for the `id` field.
+See the [Limitations section](#limitations) more about auto inc and their usage as primary keys.
 
 ### Mongoose Adapter
 

--- a/packages/fields-auto-increment/README.md
+++ b/packages/fields-auto-increment/README.md
@@ -59,7 +59,7 @@ const keystone = new Keystone(/* ... */);
 keystone.createList('Order', {
   fields: {
     name: { type: Text },
-    orderNumber: { type: AutoIncrement },
+    orderNumber: { type: AutoIncrement, gqlType: 'Int' },
     // ...
   },
 });
@@ -67,10 +67,11 @@ keystone.createList('Order', {
 
 ### Config
 
-| Option        | Type      | Default     | Description                                                     |
-| :------------ | :-------- | :---------- | :-------------------------------------------------------------- |
-| `isRequired`  | `Boolean` | `false`     | Does this field require a value?                                |
-| `isUnique`    | `Boolean` | `true`      | Adds a unique index that allows only unique values to be stored |
+| Option       | Type      | Default       | Description                                                                                |
+| :----------- | :-------- | :------------ | :----------------------------------------------------------------------------------------- |
+| `isRequired` | `Boolean` | `false`       | Does this field require a value?                                                           |
+| `isUnique`   | `Boolean` | `true`        | Adds a unique index that allows only unique values to be stored                            |
+| `gqlType`    | `String`  | `Int` or `ID` | The GraphQL to be used by this field. Defaults to `ID` for primay keys or `Int` otherwise. |
 
 ## Admin UI
 
@@ -78,7 +79,9 @@ keystone.createList('Order', {
 
 ## GraphQL
 
-`AutoIncrement` fields use the `Int` type in GraphQL.
+`AutoIncrement` fields can use the `Int` or `ID` GraphQL types.
+This can be specified using the `gqlType` config option if needed.
+The default is `ID` for primay key fields and `Int` otherwise.
 
 ### Input Fields
 
@@ -86,28 +89,28 @@ keystone.createList('Order', {
 As such, input fields and types may not be added to the GraphQL schema.
 See the [non-standard defaults section](#non-standard-defaults) for details.
 
-| Field name | Type  | Description               |
-| :--------- | :---- | :------------------------ |
-| `${path}`  | `Int` | The integer value to save |
+| Field name | Type          | Description               |
+| :--------- | :------------ | :------------------------ |
+| `${path}`  | `Int` or `ID` | The integer value to save |
 
 ### Output Fields
 
-| Field name | Type  | Description              |
-| :--------- | :---- | :----------------------- |
-| `${path}`  | `Int` | The integer value stored |
+| Field name | Type          | Description              |
+| :--------- | :------------ | :----------------------- |
+| `${path}`  | `Int` or `ID` | The integer value stored |
 
 ### Filters
 
-| Field name       | Type    | Description                                 |
-| :--------------- | :------ | :------------------------------------------ |
-| `${path}`        | `Int`   | Exact match to the value provided           |
-| `${path}_not`    | `Int`   | Not an exact match to the value provided    |
-| `${path}_lt`     | `Int`   | Less than the value provided                |
-| `${path}_lte`    | `Int`   | Less than or equal to the value provided    |
-| `${path}_gt`     | `Int`   | Greater than the value provided             |
-| `${path}_gte`    | `Int`   | Greater or equal to than the value provided |
-| `${path}_in`     | `[Int]` | In the array of integers provided           |
-| `${path}_not_in` | `[Int]` | Not in the array of integers provided       |
+| Field name       | Type              | Description                                 |
+| :--------------- | :---------------- | :------------------------------------------ |
+| `${path}`        | `Int` or `ID`     | Exact match to the value provided           |
+| `${path}_not`    | `Int` or `ID`     | Not an exact match to the value provided    |
+| `${path}_lt`     | `Int` or `ID`     | Less than the value provided                |
+| `${path}_lte`    | `Int` or `ID`     | Less than or equal to the value provided    |
+| `${path}_gt`     | `Int` or `ID`     | Greater than the value provided             |
+| `${path}_gte`    | `Int` or `ID`     | Greater or equal to than the value provided |
+| `${path}_in`     | `[Int]` or `[ID]` | In the array of integers provided           |
+| `${path}_not_in` | `[Int]` or `[ID]` | Not in the array of integers provided       |
 
 ## Storage
 

--- a/packages/fields-auto-increment/src/Implementation.js
+++ b/packages/fields-auto-increment/src/Implementation.js
@@ -34,17 +34,16 @@ export class KnexAutoIncrementInterface extends KnexFieldAdapter {
     // Apply some field type defaults before we hand off to super; see README.md
     knexOptions.isNotNullable =
       typeof knexOptions.isNotNullable === 'undefined' ? true : knexOptions.isNotNullable;
-    knexOptions.isPrimaryKey =
-      typeof knexOptions.isPrimaryKey === 'undefined' ? true : knexOptions.isPrimaryKey;
 
     // The base implementation takes care of everything else
     super(...arguments);
   }
 
   addToTableSchema(table) {
+    // The knex `increments()` schema building function always uses the column as the primary key
     // If not isPrimaryKey use a raw `serial` instead
     // This will only work on PostgreSQL; see README.md
-    const column = this.knexOptions.isPrimaryKey
+    const column = this.field.isPrimaryKey
       ? table.increments(this.path)
       : table.specificType(this.path, 'serial');
 

--- a/packages/fields-auto-increment/src/index.js
+++ b/packages/fields-auto-increment/src/index.js
@@ -15,12 +15,8 @@ export const AutoIncrement = {
 
   primaryKeyDefaults: {
     knex: {
-      getConfig: () => ({
-        type: AutoIncrement,
-        gqlType: 'ID',
-        isUnique: true,
-        knexOptions: { isNotNullable: true },
-      }),
+      // Uniqueness, non-nullability and GraphQL type are implied
+      getConfig: () => ({ type: AutoIncrement }),
     },
   },
 };

--- a/packages/fields-auto-increment/src/index.js
+++ b/packages/fields-auto-increment/src/index.js
@@ -1,7 +1,7 @@
 import { AutoIncrementImplementation, KnexAutoIncrementInterface } from './Implementation';
 import { Integer } from '@keystone-alpha/fields';
 
-export let AutoIncrement = {
+export const AutoIncrement = {
   type: 'AutoIncrement',
   implementation: AutoIncrementImplementation,
   views: {
@@ -11,5 +11,16 @@ export let AutoIncrement = {
   },
   adapters: {
     knex: KnexAutoIncrementInterface,
+  },
+
+  primaryKeyDefaults: {
+    knex: {
+      getConfig: () => ({
+        type: AutoIncrement,
+        gqlType: 'ID',
+        isUnique: true,
+        knexOptions: { isNotNullable: true },
+      }),
+    },
   },
 };

--- a/packages/fields-mongoId/src/Implementation.js
+++ b/packages/fields-mongoId/src/Implementation.js
@@ -25,6 +25,9 @@ const normaliseValue = a => (a ? a.toString().toLowerCase() : null);
 
 export class MongooseMongoIdInterface extends MongooseFieldAdapter {
   addToMongooseSchema(schema, mongoose) {
+    // If this field is the primary key we actually don't have to add it; it's implicit
+    if (this.field.isPrimaryKey) return;
+
     const schemaOptions = {
       type: mongoose.Schema.Types.ObjectId,
       validate: {
@@ -32,12 +35,42 @@ export class MongooseMongoIdInterface extends MongooseFieldAdapter {
         message: '{VALUE} is not a valid Mongo ObjectId',
       },
     };
-    schema.add({ [this.path]: this.mergeSchemaOptions(schemaOptions, this.config) });
+    schema.add({
+      [this.field.isPrimaryKey ? '_id' : this.path]: this.mergeSchemaOptions(
+        schemaOptions,
+        this.config
+      ),
+    });
   }
+
+  setupHooks({ addPreSaveHook, addPostReadHook }) {
+    if (!this.field.isPrimaryKey) return;
+
+    addPreSaveHook(item => {
+      if (item.id) {
+        item._id = item.id;
+        delete item.id;
+      }
+      return item;
+    });
+    addPostReadHook(itemOrModel => {
+      // Sometimes this is called with a mongoose model, sometimes with an object and sometimes with null
+      // I do no know why
+      const item = itemOrModel && itemOrModel.toObject ? itemOrModel.toObject() : itemOrModel;
+
+      if (item && item._id) {
+        item.id = item._id.toString();
+        delete item._id;
+      }
+      return item;
+    });
+  }
+
   getQueryConditions(dbPath) {
+    const mongoose = this.listAdapter.parentAdapter.mongoose;
     return {
-      ...this.equalityConditions(dbPath),
-      ...this.inConditions(dbPath),
+      ...this.equalityConditions(this.field.isPrimaryKey ? '_id' : dbPath, mongoose.Types.ObjectId),
+      ...this.inConditions(this.field.isPrimaryKey ? '_id' : dbPath, mongoose.Types.ObjectId),
     };
   }
 }

--- a/packages/fields-mongoId/src/index.js
+++ b/packages/fields-mongoId/src/index.js
@@ -5,7 +5,7 @@ import {
 } from './Implementation';
 import { Text } from '@keystone-alpha/fields';
 
-export let MongoId = {
+export const MongoId = {
   type: 'MongoId',
   implementation: MongoIdImplementation,
   views: {
@@ -16,5 +16,18 @@ export let MongoId = {
   adapters: {
     knex: KnexMongoIdInterface,
     mongoose: MongooseMongoIdInterface,
+  },
+
+  primaryKeyDefaults: {
+    knex: {
+      getConfig: () => {
+        throw `The Uuid field type doesn't provide a default primary key field configuration for knex. ` +
+          `You'll need to supply your own 'id' field for each list or use a different field type for your ` +
+          `ids (eg '@keystone-alpha/fields-auto-increment').`;
+      },
+    },
+    mongoose: {
+      getConfig: () => ({ type: MongoId }),
+    },
   },
 };

--- a/packages/fields/src/Implementation.js
+++ b/packages/fields/src/Implementation.js
@@ -8,6 +8,7 @@ class Field {
     { getListByKey, listKey, listAdapter, fieldAdapterClass, defaultAccess }
   ) {
     this.path = path;
+    this.isPrimaryKey = path === 'id';
     this.schemaDoc = schemaDoc;
     this.config = config;
     this.isRequired = isRequired;
@@ -163,6 +164,7 @@ class Field {
       type: this.constructor.name,
       isRequired: this.isRequired,
       defaultValue: this.getDefaultValue(),
+      isPrimaryKey: this.isPrimaryKey,
     });
   }
   extendAdminMeta(meta) {

--- a/packages/fields/src/types/Uuid/Implementation.js
+++ b/packages/fields/src/types/Uuid/Implementation.js
@@ -2,7 +2,7 @@ import { Implementation } from '../../Implementation';
 import { MongooseFieldAdapter } from '@keystone-alpha/adapter-mongoose';
 import { KnexFieldAdapter } from '@keystone-alpha/adapter-knex';
 
-export class Uuid extends Implementation {
+export class UuidImplementation extends Implementation {
   constructor(path, { caseTo = 'lower' }) {
     super(...arguments);
 

--- a/packages/fields/src/types/Uuid/Implementation.js
+++ b/packages/fields/src/types/Uuid/Implementation.js
@@ -83,9 +83,26 @@ export class MongoUuidInterface extends MongooseFieldAdapter {
 export class KnexUuidInterface extends KnexFieldAdapter {
   addToTableSchema(table) {
     const column = table.uuid(this.path);
-    if (this.isUnique) column.unique();
-    if (this.isNotNullable) column.notNullable();
+    // Fair to say primary keys are always non-nullable and uniqueness is implied by primary()
+    if (this.field.isPrimaryKey) {
+      column.primary().notNullable();
+    } else {
+      if (this.isUnique) column.unique();
+      if (this.isNotNullable) column.notNullable();
+    }
     if (this.defaultTo) column.defaultTo(this.defaultTo);
+  }
+
+  addToForeignTableSchema(table, { path, isUnique, isIndexed, isNotNullable }) {
+    if (!this.field.isPrimaryKey) {
+      throw `Can't create foreign key '${path}' on table "${table._tableName}"; ` +
+        `'${this.path}' on list '${this.field.listKey}' as is not the primary key.`;
+    }
+
+    const column = table.uuid(path);
+    if (isUnique) column.unique();
+    else if (isIndexed) column.index();
+    if (isNotNullable) column.notNullable();
   }
 
   getQueryConditions(dbPath) {

--- a/packages/fields/src/types/Uuid/index.js
+++ b/packages/fields/src/types/Uuid/index.js
@@ -20,8 +20,7 @@ const Uuid = {
         if (client === 'postgres') {
           return {
             type: Uuid,
-            isUnique: true,
-            knexOptions: { isNotNullable: true, defaultTo: knex => knex.raw('gen_random_uuid()') },
+            knexOptions: { defaultTo: knex => knex.raw('gen_random_uuid()') },
           };
         }
         throw `The Uuid field type doesn't provide a default primary key field configuration for the ` +

--- a/packages/fields/src/types/Uuid/index.js
+++ b/packages/fields/src/types/Uuid/index.js
@@ -1,9 +1,9 @@
-import { Uuid, MongoUuidInterface, KnexUuidInterface } from './Implementation';
+import { UuidImplementation, MongoUuidInterface, KnexUuidInterface } from './Implementation';
 import { importView } from '@keystone-alpha/build-field-types';
 
-export default {
+const Uuid = {
   type: 'Uuid',
-  implementation: Uuid,
+  implementation: UuidImplementation,
   views: {
     Controller: importView('./views/Controller'),
     Field: importView('./views/Field'),
@@ -13,4 +13,29 @@ export default {
     knex: KnexUuidInterface,
     mongoose: MongoUuidInterface,
   },
+
+  primaryKeyDefaults: {
+    knex: {
+      getConfig: client => {
+        if (client === 'postgres') {
+          return {
+            type: Uuid,
+            knexOptions: { defaultTo: knex => knex.raw('gen_random_uuid()') },
+          };
+        }
+        throw `The Uuid field type doesn't provide a default primary key field configuration for the ` +
+          `'${client}' knex client. You'll need to supply your own 'id' field for each list or use a ` +
+          `different field type for your ids (eg '@keystone-alpha/fields-auto-increment').`;
+      },
+    },
+    mongoose: {
+      getConfig: () => {
+        throw `The Uuid field type doesn't provide a default primary key field configuration for mongoose. ` +
+          `You'll need to supply your own 'id' field for each list or use a different field type for your ` +
+          `ids (eg '@keystone-alpha/fields-mongoId').`;
+      },
+    },
+  },
 };
+
+export default Uuid;

--- a/packages/fields/src/types/Uuid/index.js
+++ b/packages/fields/src/types/Uuid/index.js
@@ -20,7 +20,8 @@ const Uuid = {
         if (client === 'postgres') {
           return {
             type: Uuid,
-            knexOptions: { defaultTo: knex => knex.raw('gen_random_uuid()') },
+            isUnique: true,
+            knexOptions: { isNotNullable: true, defaultTo: knex => knex.raw('gen_random_uuid()') },
           };
         }
         throw `The Uuid field type doesn't provide a default primary key field configuration for the ` +

--- a/packages/fields/tests/Implementation.test.js
+++ b/packages/fields/tests/Implementation.test.js
@@ -127,6 +127,7 @@ test('getAdminMeta()', () => {
     path: 'path',
     type: 'Field',
     defaultValue: 'default',
+    isPrimaryKey: false,
   });
 });
 

--- a/packages/keystone/lib/List/index.js
+++ b/packages/keystone/lib/List/index.js
@@ -1480,4 +1480,7 @@ module.exports = class List {
   getFieldByPath(path) {
     return this.fieldsByPath[path];
   }
+  getPrimaryKey() {
+    return this.fieldsByPath['id'];
+  }
 };

--- a/packages/keystone/lib/List/index.js
+++ b/packages/keystone/lib/List/index.js
@@ -144,16 +144,17 @@ module.exports = class List {
     this.hooks = hooks;
     this.mutations = mutations;
     this.schemaDoc = schemaDoc;
-    // 180814 JM TODO: Since there's no access control specified, this implicitly makes name, id or {labelField} readable by all (probably bad?)
+
+    // Assuming the id column shouldn't be included in default columns or sort
+    const nonIdFieldNames = Object.keys(fields).filter(k => k !== 'id');
     this.adminConfig = {
       defaultPageSize: 50,
-      defaultColumns: Object.keys(fields)
-        .slice(0, 2)
-        .join(','),
-      defaultSort: Object.keys(fields)[0],
+      defaultColumns: nonIdFieldNames.slice(0, 2).join(','),
+      defaultSort: nonIdFieldNames[0],
       maximumPageSize: 1000,
       ...adminConfig,
     };
+
     this.labelResolver = labelResolver || getDefautlLabelResolver(labelField);
     this.isAuxList = isAuxList;
     this.getListByKey = getListByKey;
@@ -259,16 +260,27 @@ module.exports = class List {
   }
 
   initFields() {
-    if (this.fieldsInitialised) {
-      return;
-    }
-
+    if (this.fieldsInitialised) return;
     this.fieldsInitialised = true;
 
-    const sanitisedFieldsConfig = mapKeys(this._fields, (fieldConfig, path) => ({
+    let sanitisedFieldsConfig = mapKeys(this._fields, (fieldConfig, path) => ({
       ...fieldConfig,
       type: mapNativeTypeToKeystoneType(fieldConfig.type, this.key, path),
     }));
+
+    // Add an 'id' field if none supplied
+    if (!sanitisedFieldsConfig.id) {
+      if (typeof this.adapter.parentAdapter.getDefaultPrimaryKeyConfig !== 'function') {
+        throw `No 'id' field given for the '${this.key}' list and the list adapter ` +
+          `in used (${this.adapter.key}) doesn't supply a default primary key config ` +
+          `(no 'getDefaultPrimaryKeyConfig()' function)`;
+      }
+      // Rebuild the object so id is "first"
+      sanitisedFieldsConfig = {
+        id: this.adapter.parentAdapter.getDefaultPrimaryKeyConfig(),
+        ...sanitisedFieldsConfig,
+      };
+    }
 
     // Helpful errors for misconfigured lists
     Object.entries(sanitisedFieldsConfig).forEach(([fieldKey, fieldConfig]) => {
@@ -346,7 +358,6 @@ module.exports = class List {
         `
         """ ${this.schemaDoc || 'A keystone list'} """
         type ${this.gqlNames.outputTypeName} {
-          id: ID
           """
           This virtual field will be resolved in one of the following ways (in this order):
            1. Execution of 'labelResolver' set on the ${this.key} List config, or
@@ -368,11 +379,6 @@ module.exports = class List {
       `,
         `
         input ${this.gqlNames.whereInputName} {
-          id: ID
-          id_not: ID
-          id_in: [ID!]
-          id_not_in: [ID!]
-
           AND: [${this.gqlNames.whereInputName}]
           OR: [${this.gqlNames.whereInputName}]
 
@@ -395,6 +401,7 @@ module.exports = class List {
         input ${this.gqlNames.updateInputName} {
           ${flatten(
             this.fields
+              .filter(({ path }) => path !== 'id') // Exclude the id fields update types
               .filter(field => skipAccessControl || field.access.update) // If it's globally set to false, makes sense to never let it be updated
               .map(field => field.gqlUpdateInputFields)
           ).join('\n')}
@@ -413,6 +420,7 @@ module.exports = class List {
         input ${this.gqlNames.createInputName} {
           ${flatten(
             this.fields
+              .filter(({ path }) => path !== 'id') // Exclude the id fields create types
               .filter(field => skipAccessControl || field.access.create) // If it's globally set to false, makes sense to never let it be created
               .map(field => field.gqlCreateInputFields)
           ).join('\n')}

--- a/packages/keystone/lib/adapters/index.js
+++ b/packages/keystone/lib/adapters/index.js
@@ -28,7 +28,8 @@ class BaseKeystoneAdapter {
       const errors = taskResults.filter(({ isRejected }) => isRejected);
 
       if (errors.length) {
-        const error = new Error('Post connection error');
+        if (errors.length === 1) throw errors[0];
+        const error = new Error('Multiple errors in BaseKeystoneAdapter.postConnect():');
         error.errors = errors.map(({ reason }) => reason);
         throw error;
       }
@@ -144,6 +145,13 @@ class BaseListAdapter {
     return this.fieldAdapters
       .filter(adapter => adapter.isRelationship)
       .find(adapter => adapter.supportsRelationshipQuery(segment));
+  }
+
+  getFieldAdapterByPath(path) {
+    return this.fieldAdaptersByPath[path];
+  }
+  getPrimaryKeyAdapter() {
+    return this.fieldAdaptersByPath['id'];
   }
 }
 

--- a/packages/test-utils/lib/test-utils.js
+++ b/packages/test-utils/lib/test-utils.js
@@ -82,7 +82,7 @@ function getUpdate(keystone) {
   return (list, id, data) => keystone.getListByKey(list).adapter.update(id, data);
 }
 
-function keystoneMongoTest(setupKeystoneFn, testFn) {
+function keystoneMongoRunner(setupKeystoneFn, testFn) {
   return async function() {
     const setup = await setupKeystoneFn('mongoose');
     const { keystone } = setup;
@@ -104,7 +104,7 @@ function keystoneMongoTest(setupKeystoneFn, testFn) {
   };
 }
 
-function keystoneKnexTest(setupKeystoneFn, testFn) {
+function keystoneKnexRunner(setupKeystoneFn, testFn) {
   return async function() {
     const setup = await setupKeystoneFn('knex');
     const { keystone } = setup;
@@ -124,11 +124,11 @@ function keystoneKnexTest(setupKeystoneFn, testFn) {
   };
 }
 
-function multiAdapterRunners() {
+function multiAdapterRunners(only) {
   return [
-    { runner: keystoneMongoTest, adapterName: 'mongoose' },
-    { runner: keystoneKnexTest, adapterName: 'knex' },
-  ];
+    { runner: keystoneMongoRunner, adapterName: 'mongoose' },
+    { runner: keystoneKnexRunner, adapterName: 'knex' },
+  ].filter(a => typeof only === 'undefined' || a.adapterName === only);
 }
 
 const sorted = (arr, keyFn) => {


### PR DESCRIPTION
Until now list adapters automatically added a semi-magical pseudo-field that surfaced in Keystone as `id`. Fields and filters for this pseudo-field were added to the GraphQL types and filters as exceptional cases. This PR replaces that approach by leveraging the existent functionality in of generic field types.

Database adapters can now (optionally) provide a `getDefaultPrimaryKeyConfig()` function that returns a their suggested config for the `id` field. (The Knex and Mongoose adapters defer this responsibility decision to the types themselves.)

The intention is to give solution builders sensible defaults but with multiple opportunities to intervene:

```js
const { Keystone } = require('@keystone-alpha/keystone');
const { MongooseAdapter } = require('@keystone-alpha/adapter-mongoose');
const { MongoId } = require('@keystone-alpha/fields-mongoId');
const { Text } = require('@keystone-alpha/fields');

const adapter = new MongooseAdapter();
const keystone = new Keystone({ name: 'Keystone To-Do List', adapter });

// Let Keystone add a default id field automatically
keystone.createList('Todo', {
  fields: { name: { type: Text } },
});

// Ask the adapter for it's default primary key config
keystone.createList('Todo', {
  fields: {
    id: adapter.getDefaultPrimaryKeyConfig(),
    name: { type: Text },
  },
});

// Pick the field type yourself and use the types recommended primary key config
keystone.createList('Todo', {
  fields: {
    id: MongoId.primaryKeyDefaults[adapter.name].getConfig(),
    name: { type: Text },
  },
});

// Build the field config manually using whatever field type and config you want
keystone.createList('Todo', {
  fields: {
    id: { type: MongoId },
    name: { type: Text },
  },
});
```

These ^^^ configs result in identical lists.