### PR TITLE
Reload all columns after insert (knex)

### DIFF
--- a/.changeset/weak-spies-add/changes.json
+++ b/.changeset/weak-spies-add/changes.json
@@ -1,0 +1,7 @@
+{
+  "releases": [
+    { "name": "@keystone-alpha/api-tests", "type": "patch" },
+    { "name": "@keystone-alpha/adapter-knex", "type": "patch" }
+  ],
+  "dependents": []
+}

--- a/.changeset/weak-spies-add/changes.md
+++ b/.changeset/weak-spies-add/changes.md
@@ -1,0 +1,1 @@
+Reload all columns after insert (knex); fixes #1399

--- a/api-tests/relationships/nested-mutations/two-way-backreference/to-one.test.js
+++ b/api-tests/relationships/nested-mutations/two-way-backreference/to-one.test.js
@@ -73,8 +73,9 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             let company = await create('Company', {});
 
             // Sanity check the links don't yet exist
-            expect(company.location).toBe(undefined);
-            expect(location.company).toBe(undefined);
+            // `...not.toBe(expect.anything())` allows null and undefined values
+            expect(company.location).not.toBe(expect.anything());
+            expect(location.company).not.toBe(expect.anything());
 
             const { errors } = await graphqlRequest({
               keystone,

--- a/packages/adapter-knex/lib/adapter-knex.js
+++ b/packages/adapter-knex/lib/adapter-knex.js
@@ -183,7 +183,7 @@ class KnexListAdapter extends BaseListAdapter {
     const item = (await this._query()
       .insert(realData)
       .into(this.key)
-      .returning(['id', ...Object.keys(realData)]))[0];
+      .returning('*'))[0];
 
     // For every many-field, update the many-table
     const manyItem = await resolveAllKeys(


### PR DESCRIPTION
Knex adapter -- reload all columns after insert; we don't know what might be being selected back out and there maybe DB-level defaults in play (fixes #1399).