### PR TITLE
Fixing DeepScan use callback 2nd arg missing

### DIFF
--- a/.changeset/sour-poets-grow/changes.json
+++ b/.changeset/sour-poets-grow/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/app-admin-ui", "type": "patch" }], "dependents": [] }

--- a/.changeset/sour-poets-grow/changes.md
+++ b/.changeset/sour-poets-grow/changes.md
@@ -1,0 +1,1 @@
+Fixing minor potential perf issue, flagged by DeepCheck

--- a/packages/app-admin-ui/client/components/UpdateManyItemsModal.js
+++ b/packages/app-admin-ui/client/components/UpdateManyItemsModal.js
@@ -150,16 +150,19 @@ class UpdateManyModal extends Component {
               <Render>
                 {() => {
                   let [Field] = field.adminMeta.readViews([field.views.Field]);
-                  let onChange = useCallback(value => {
-                    this.setState(({ item }) => ({
-                      item: {
-                        ...item,
-                        [field.path]: value,
-                      },
-                      validationErrors: {},
-                      validationWarnings: {},
-                    }));
-                  });
+                  let onChange = useCallback(
+                    value => {
+                      this.setState(({ item }) => ({
+                        item: {
+                          ...item,
+                          [field.path]: value,
+                        },
+                        validationErrors: {},
+                        validationWarnings: {},
+                      }));
+                    },
+                    [field]
+                  );
                   return useMemo(
                     () => (
                       <Field


### PR DESCRIPTION
DeepCheck started complaining about our use of `useCallback()`:

> The second argument should not be missing at 'useCallback()' call because the memoized value is always recomputed without it.

I believe this is the correct fix? See.. https://reactjs.org/docs/hooks-reference.html#usecallback