### PR TITLE
Fixing knex schema for select options

### DIFF
--- a/.changeset/flat-dolphins-repair/changes.json
+++ b/.changeset/flat-dolphins-repair/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/fields", "type": "patch" }], "dependents": [] }

--- a/.changeset/flat-dolphins-repair/changes.md
+++ b/.changeset/flat-dolphins-repair/changes.md
@@ -1,0 +1,1 @@
+Fixing issue with the Select fields on Knex; options not being applied correctly

--- a/packages/fields/src/types/Select/Implementation.js
+++ b/packages/fields/src/types/Select/Implementation.js
@@ -75,7 +75,7 @@ export class MongoSelectInterface extends CommonSelectInterface(MongooseFieldAda
 
 export class KnexSelectInterface extends CommonSelectInterface(KnexFieldAdapter) {
   addToTableSchema(table) {
-    const column = table.enu(this.path, this.config.options.map(({ value }) => value));
+    const column = table.enu(this.path, this.field.options.map(({ value }) => value));
     if (this.isUnique) column.unique();
     if (this.isNotNullable) column.notNullable();
     if (this.defaultTo) column.defaultTo(this.defaultTo);


### PR DESCRIPTION
Fixing issue with the Select fields on Knex. The Knex fields adapter was looking at the options supplied _before_ they'd been run though the `initOptions()` function.