### PR TITLE
Adding `precision` and `scale` as `knexOptions` for the `Decimal` field type

### DIFF
--- a/.changeset/green-boats-impress/changes.json
+++ b/.changeset/green-boats-impress/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/fields", "type": "minor" }], "dependents": [] }

--- a/.changeset/green-boats-impress/changes.md
+++ b/.changeset/green-boats-impress/changes.md
@@ -1,0 +1,1 @@
+Adding `precision` and `scale` as `knexOptions` for the `Decimal` field type

--- a/packages/fields/src/types/Decimal/Implementation.js
+++ b/packages/fields/src/types/Decimal/Implementation.js
@@ -79,8 +79,21 @@ export class MongoDecimalInterface extends MongooseFieldAdapter {
 }
 
 export class KnexDecimalInterface extends KnexFieldAdapter {
+  constructor() {
+    super(...arguments);
+
+    // In addition to the standard knexOptions this type supports precision and scale
+    const { precision, scale } = this.knexOptions;
+    this.precision = precision === null ? null : parseInt(precision) || 18;
+    this.scale = scale === null ? null : (this.precision, parseInt(scale) || 4);
+    if (this.scale !== null && this.precision !== null && this.scale > this.precision) {
+      throw `The scale configured for Decimal field '${this.path}' (${this.scale}) ` +
+        `must not be larger than the field's precision (${this.precision})`;
+    }
+  }
+
   addToTableSchema(table) {
-    const column = table.decimal(this.path);
+    const column = table.decimal(this.path, this.precision, this.scale);
     if (this.isUnique) column.unique();
     if (this.isNotNullable) column.notNullable();
     if (this.defaultTo) column.defaultTo(this.defaultTo);

--- a/packages/fields/src/types/Decimal/README.md
+++ b/packages/fields/src/types/Decimal/README.md
@@ -5,6 +5,12 @@ title: Decimal
 
 # Decimal
 
+`Decimal` fields store exact numeric values.
+They're safe for base-10 fractional value like currency.
+
+There are some differences in underlying implementation, depending on your DB adapter.
+See the [Storage section](#storage) for specifics.
+
 ## Usage
 
 ```js
@@ -19,13 +25,96 @@ keystone.createList('Payment', {
 
 ### Config
 
-| Option       | Type      | Default | Description                                                     |
-| ------------ | --------- | ------- | --------------------------------------------------------------- |
-| `isRequired` | `Boolean` | `false` | Does this field require a value?                                |
-| `isUnique`   | `Boolean` | `false` | Adds a unique index that allows only unique values to be stored |
+| Option        | Type      | Default | Description                                                         |
+| ------------- | --------- | ------- | ------------------------------------------------------------------- |
+| `isRequired`  | `Boolean` | `false` | Does this field require a value?                                    |
+| `isUnique`    | `Boolean` | `false` | Adds a unique index that allows only unique values to be stored     |
+| `knexOptions` | `Object`  | `{}`    | Optional; see the [Knex Adaptor](#knex-adaptor) section for details |
 
----
+## GraphQL
 
-```DOCS_TODO
-TODO
+Since `Decimal` values can't be represented in JavaScript (or JSON) they are transmitted using the `String` type.
+
+### Input Fields
+
+| Field name | Type     | Description            |
+| ---------- | -------- | ---------------------- |
+| `${path}`  | `String` | The value to be stored |
+
+### Output Fields
+
+| Field name | Type     | Description      |
+| ---------- | -------- | ---------------- |
+| `${path}`  | `String` | The value stored |
+
+### Filters
+
+Despite being specified as strings, all comparisons are performed on _numerical equivalence_.
+In essence, this means leading and trailing zeros are ignored.
+Eg. `04.53000 === 4.53`.
+
+| Field name       | Type       | Description                                      |
+| ---------------- | ---------- | ------------------------------------------------ |
+| `${path}`        | `String`   | Equivalent to the value provided                 |
+| `${path}_not`    | `String`   | Not equivalent to the value provided             |
+| `${path}_in`     | `[String]` | In the array provided                            |
+| `${path}_not_in` | `[String]` | Not in the array provided                        |
+| `${path}_lt`     | `String`   | Less than the value provided                     |
+| `${path}_lte`    | `String`   | Less than or equivalent to the value provided    |
+| `${path}_gt`     | `String`   | Greater than the value provided                  |
+| `${path}_gte`    | `String`   | Greater than or equivalent to the value provided |
+
+## Storage
+
+Although their intent is the same, the core DB adapters use different underlying implementations of this type.
+
+### Mongoose Adaptor
+
+Values are stored using the [Mongoose `Decimal128` SchemaType](https://mongoosejs.com/docs/api.html#mongoose_Mongoose-Decimal128)
+which in turn uses the underlying [Decimal128 BSON type](https://metacpan.org/pod/BSON::Decimal128).
+
+The `Decimal128` standard is..
+
+> a decimal floating-point computer numbering format that occupies 16 bytes (128 bits) in computer memory.
+> It is intended for applications where it is necessary to emulate decimal rounding exactly, such as financial and tax computations.
+
+\-- [decimal128 floating-point format on Wikipedia](https://en.wikipedia.org/wiki/Decimal128_floating-point_format)
+
+### Knex Adaptor
+
+The Knex adapter uses the [decimal schema type](https://knexjs.org/#Schema-decimal)
+which maps directly to underlying `Decimal` or `Numeric` types in most DB platforms.
+
+Usually, in a relational DB, `Decimal` fields have a fixed precision.
+As such, the Knex field adapter supports two additional config options:
+
+| Option      | Type                | Default | Description                                                                                             |
+| ----------- | ------------------- | ------- | ------------------------------------------------------------------------------------------------------- |
+| `precision` | `Integer` or `null` | `18`    | The number of significant decimal digits stored                                                         |
+| `scale`     | `Integer` or `null` | `4`     | The number of significant fractional decimal digits stored (ie. on the right side of the decimal place) |
+
+If specified `scale` must be greater than `precision`.
+
+#### Non-Fixed Precision
+
+Some DB platforms (Oracle, SQLite and Postgres) support `Decimal` types without a fixed precision.
+This can be configured by passing both the `precision` and `scale` as `null`, eg:
+
+```js
+keystone.createList('Currency', {
+  fields: {
+    name: { type: Text },
+    totalIssued: { type: Decimal, knexOptions: { precision: null, scale: null } },
+  },
+});
+```
+
+Will produce:
+
+```sql
+CREATE TABLE keystone."Currency" (
+    id integer DEFAULT nextval('keystone."Currency_id_seq"'::regclass) PRIMARY KEY,
+    name text,
+    "totalIssued" numeric
+);
 ```

--- a/packages/fields/src/types/Decimal/filterTests.js
+++ b/packages/fields/src/types/Decimal/filterTests.js
@@ -9,7 +9,7 @@ export const exampleValue = '"6.28"';
 export const getTestFields = () => {
   return {
     name: { type: Text },
-    price: { type: Decimal },
+    price: { type: Decimal, knexOptions: { scale: 2 } },
   };
 };
 


### PR DESCRIPTION
Adding `precision` and `scale` as `knexOptions` for the `Decimal` field type and updated type docs to cover these new options and all the standard stuff.

Eg..

```js
const { Keystone } = require('@keystone-alpha/keystone');
const { KnexAdapter } = require('@keystone-alpha/adapter-knex');
const { Text, Decimal } = require('@keystone-alpha/fields');

const keystone = new Keystone({ name: 'Keystone To-Do List', adapter: new KnexAdapter() });

keystone.createList('Product', {
  fields: {
    name: { type: Text },
    price: { type: Decimal, knexOptions: { precision: 10, scale: 2 } },
  },
});
```

Added to `knexOptions` only (rather than top-level config) as the Mongoose type is inherently 128 bit. 

The defaults are `{ precision: 18, scale: 4 }`. Also allows arbitrary precision if your DB supports it.