### PR TITLE
Adding a helper script to build/rebuild the KS test Postgres DB

### DIFF
--- a/packages/adapter-knex/README.md
+++ b/packages/adapter-knex/README.md
@@ -13,6 +13,13 @@ At present, the only fully tested backend is `Postgres`, however Knex gives the 
 ## Setting Up Your Database
 
 Before running Keystone, you must set up a database, a schema, and a user.
+Assuming you're on MacOS and have Postgres installed the `build-test-db.sh` does this for you:
+
+```sh
+./packages/adapter-knex/build-test-db.sh
+```
+
+Otherwise, you can run the steps manually:
 
 ```shell
 createdb -U postgres ks5_dev

--- a/packages/adapter-knex/build-test-db.sh
+++ b/packages/adapter-knex/build-test-db.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Create or recreate and setup the Keystone test Postgres DB from scratch
+# Will distroy any existing data, etc.
+# When Keystone starts the knex adapter will recreate the structure
+
+KS_DB_NAME="ks5_dev"
+KS_SCHEMA_NAME="keystone"
+KS_USER_NAME="keystone5"
+KS_USER_PASS="k3yst0n3"
+
+# On MacOS the super use is the current username, no password
+SUPER_USER="${USER}"
+
+# Our queries
+DROP_CONNECTIONS_SQL="
+  SELECT pg_terminate_backend(pg_stat_activity.pid)
+  FROM pg_stat_activity
+  WHERE pg_stat_activity.datname = '${KS_DB_NAME}'
+  AND pid <> pg_backend_pid();
+"
+DROP_DB_SQL="
+  DROP DATABASE IF EXISTS \"${KS_DB_NAME}\";
+"
+CREATE_DB_SQL="
+  CREATE DATABASE \"${KS_DB_NAME}\";
+"
+RECREATE_ROLE_SQL="
+  DROP USER IF EXISTS \"${KS_USER_NAME}\";
+  CREATE USER \"${KS_USER_NAME}\" PASSWORD '${KS_USER_PASS}';
+"
+SETUP_SCHEMA="
+  CREATE SCHEMA \"${KS_SCHEMA_NAME}\";
+  GRANT ALL ON SCHEMA \"${KS_SCHEMA_NAME}\" TO \"${KS_USER_NAME}\";
+"
+# Needed for `gen_random_uuid()` function, used by UUIDs
+SETUP_UUIDS="
+  CREATE EXTENSION IF NOT EXISTS \"pgcrypto\";
+"
+
+# Run outside the KS DB (in template1)
+psql template1 -U "${SUPER_USER}" -c "${DROP_CONNECTIONS_SQL}"
+psql template1 -U "${SUPER_USER}" -c "${DROP_DB_SQL}"
+psql template1 -U "${SUPER_USER}" -c "${CREATE_DB_SQL}"
+psql template1 -U "${SUPER_USER}" -c "${RECREATE_ROLE_SQL}"
+
+# Run in the new DB
+psql "${KS_DB_NAME}" -U "${SUPER_USER}" -c "${SETUP_SCHEMA}"
+psql "${KS_DB_NAME}" -U "${SUPER_USER}" -c "${SETUP_UUIDS}"


### PR DESCRIPTION
Handy if you're testing things around the basic DB initialisation and schema building.

Eg. usage:

```sh
./packages/adapter-knex/build-test-db.sh && bolt dev
```