### PR TITLE
Adding non-core `DateTimeUtc` field type

### DIFF
--- a/.changeset/two-pets-doubt/changes.json
+++ b/.changeset/two-pets-doubt/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "@keystone-alpha/fields-datetime-utc", "type": "major" }],
+  "dependents": []
+}

--- a/.changeset/two-pets-doubt/changes.md
+++ b/.changeset/two-pets-doubt/changes.md
@@ -1,0 +1,1 @@
+Adding non-core DateTimeUtc type

--- a/package.json
+++ b/package.json
@@ -309,6 +309,7 @@
       "packages/field-content",
       "packages/fields",
       "packages/fields-auto-increment",
+      "packages/fields-datetime-utc",
       "packages/fields-markdown",
       "packages/fields-mongoId",
       "packages/fields-wysiwyg-tinymce",

--- a/packages/fields-datetime-utc/README.md
+++ b/packages/fields-datetime-utc/README.md
@@ -1,0 +1,24 @@
+<!--[meta]
+section: field-types
+title: DateTimeUtc
+[meta]-->
+
+# DateTimeUtc
+
+`DateTimeUtc` fields represent points in time.
+
+Accepts only values that include an offset, explicitly or implicity (as in JS `Date` objects).
+Produces JS `Date` objects and ISO 8601 strings.
+
+Unlike the core `DateTime` field type only the UTC value is stored.
+
+## Usage
+
+```js
+keystone.createList('User', {
+  fields: {
+    email: { type: Text },
+    lastOnline: { type: DateTimeUtc },
+  },
+});
+```

--- a/packages/fields-datetime-utc/package.json
+++ b/packages/fields-datetime-utc/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@keystone-alpha/fields-datetime-utc",
+  "description": "KeystoneJS DatetimeUtc Field Type",
+  "version": "0.0.0",
+  "author": "The KeystoneJS Development Team",
+  "license": "MIT",
+  "repository": "https://github.com/keystonejs/keystone-5.git",
+  "engines": {
+    "node": ">=8.4.0"
+  },
+  "dependencies": {
+    "@keystone-alpha/adapter-knex": "^2.1.0",
+    "@keystone-alpha/adapter-mongoose": "^2.2.1",
+    "@keystone-alpha/fields": "^9.1.0",
+    "luxon": "^1.11.4"
+  },
+  "main": "dist/fields-datetime-utc.cjs.js",
+  "module": "dist/fields-datetime-utc.esm.js"
+}

--- a/packages/fields-datetime-utc/src/Implementation.js
+++ b/packages/fields-datetime-utc/src/Implementation.js
@@ -1,0 +1,79 @@
+import { DateTime } from 'luxon';
+import { Implementation } from '@keystone-alpha/fields';
+import { KnexFieldAdapter } from '@keystone-alpha/adapter-knex';
+import { MongooseFieldAdapter } from '@keystone-alpha/adapter-mongoose';
+
+export class DateTimeUtcImplementation extends Implementation {
+  get gqlOutputFields() {
+    return [`${this.path}: String`];
+  }
+  get gqlOutputFieldResolvers() {
+    return { [`${this.path}`]: item => item[this.path] && item[this.path].toISOString() };
+  }
+  get gqlQueryInputFields() {
+    return [
+      ...this.equalityInputFields('String'),
+      ...this.orderingInputFields('String'),
+      ...this.inInputFields('String'),
+    ];
+  }
+  get gqlUpdateInputFields() {
+    return [`${this.path}: String`];
+  }
+  get gqlCreateInputFields() {
+    return [`${this.path}: String`];
+  }
+  getGqlAuxTypes() {
+    return [`scalar String`];
+  }
+
+  extendAdminMeta(meta) {
+    return { ...meta, format: 'YYYY-MM-DD[T]HH:mm:ss.SSSZZ' };
+  }
+}
+
+// All values must have an offset
+const toDate = str => {
+  if (!str.match(/([zZ]|[\+\-][0-9]+(\:[0-9]+)?)$/)) {
+    throw `Value supplied (${str}) is not a valid date time with offset.`;
+  }
+  return DateTime.fromISO(str).toJSDate();
+};
+
+export class MongoDateTimeUtcInterface extends MongooseFieldAdapter {
+  addToMongooseSchema(schema) {
+    schema.add({ [this.path]: this.mergeSchemaOptions({ type: Date }, this.config) });
+  }
+  getQueryConditions(dbPath) {
+    return {
+      ...this.equalityConditions(dbPath, toDate),
+      ...this.orderingConditions(dbPath, toDate),
+      ...this.inConditions(dbPath, toDate),
+    };
+  }
+}
+
+export class KnexDateTimeUtcInterface extends KnexFieldAdapter {
+  constructor() {
+    super(...arguments);
+    this.isUnique = !!this.config.isUnique;
+    this.isIndexed = !!this.config.isIndexed && !this.config.isUnique;
+  }
+  addToTableSchema(table) {
+    // It's important we don't exceed the precision of native Date
+    // objects (ms) or JS will silently round values down.
+    const column = table.timestamp(this.path, { useTz: true, precision: 3 });
+
+    if (this.isUnique) column.unique();
+    else if (this.isIndexed) column.index();
+    if (this.isNotNullable) column.notNullable();
+    if (this.defaultTo) column.defaultTo(this.defaultTo);
+  }
+  getQueryConditions(dbPath) {
+    return {
+      ...this.equalityConditions(dbPath, toDate),
+      ...this.orderingConditions(dbPath, toDate),
+      ...this.inConditions(dbPath, toDate),
+    };
+  }
+}

--- a/packages/fields-datetime-utc/src/index.js
+++ b/packages/fields-datetime-utc/src/index.js
@@ -1,0 +1,21 @@
+import {
+  DateTimeUtcImplementation,
+  MongoDateTimeUtcInterface,
+  KnexDateTimeUtcInterface,
+} from './Implementation';
+import { DateTime } from '@keystone-alpha/fields';
+
+export const DateTimeUtc = {
+  type: 'DateTimeUtc',
+  implementation: DateTimeUtcImplementation,
+  views: {
+    Controller: DateTime.views.Controller,
+    Field: DateTime.views.Field,
+    Filter: DateTime.views.Filter,
+    Cell: DateTime.views.Cell,
+  },
+  adapters: {
+    mongoose: MongoDateTimeUtcInterface,
+    knex: KnexDateTimeUtcInterface,
+  },
+};


### PR DESCRIPTION
Like the core type but simpler and, most of the time, what we actually want. 

Insists on being given offsets anytime it ingests a value but stores only UTC so contributes a single field to the schema:

* A `timestamp` on Knex (`timestamptz` on Postgres)
   - Precision limited to match JS (milliseconds); avoids silent rounding in JS world
* A `Date` on Mongoose

Supports:

* Field config `isIndexed`, `isUnique` and `defaultValue`
* Knex options `defaultTo` and `isNotNullable`
* The same filtering as the core `DateTime` type (in, equality, "ordering")
* Ordering

Values are exposed as `Date` objects in JS and plain `String` scalars in GraphQL. 

I'd argue this should actually be the default/core implementation (but not today!).