### PR TITLE
Fixing field config application for knex field adapters

### DIFF
--- a/.changeset/mighty-tools-worry/changes.json
+++ b/.changeset/mighty-tools-worry/changes.json
@@ -1,0 +1,7 @@
+{
+  "releases": [
+    { "name": "@keystone-alpha/adapter-knex", "type": "patch" },
+    { "name": "@keystone-alpha/fields", "type": "patch" }
+  ],
+  "dependents": []
+}

--- a/.changeset/mighty-tools-worry/changes.md
+++ b/.changeset/mighty-tools-worry/changes.md
@@ -1,0 +1,1 @@
+Fixing application of some field config on knex

--- a/packages/adapter-knex/lib/adapter-knex.js
+++ b/packages/adapter-knex/lib/adapter-knex.js
@@ -625,7 +625,7 @@ class KnexFieldAdapter extends BaseFieldAdapter {
     if (this._isNotNullable) return this._isNotNullable;
 
     return (this._isNotNullable = !!(typeof this.knexOptions.isNotNullable === 'undefined'
-      ? this.field.isRequired
+      ? this.field.isRequired || (typeof this.defaultTo !== 'undefined' && this.defaultTo !== null)
       : this.knexOptions.isNotNullable));
   }
 

--- a/packages/fields/src/types/Checkbox/Implementation.js
+++ b/packages/fields/src/types/Checkbox/Implementation.js
@@ -25,20 +25,16 @@ export class Checkbox extends Implementation {
   }
 }
 
-const CommonCheckboxInterface = superclass =>
-  class extends superclass {
-    getQueryConditions(dbPath) {
-      return this.equalityConditions(dbPath);
-    }
-  };
-
-export class MongoCheckboxInterface extends CommonCheckboxInterface(MongooseFieldAdapter) {
+export class MongoCheckboxInterface extends MongooseFieldAdapter {
   addToMongooseSchema(schema) {
     schema.add({ [this.path]: this.mergeSchemaOptions({ type: Boolean }, this.config) });
   }
+  getQueryConditions(dbPath) {
+    return this.equalityConditions(dbPath);
+  }
 }
 
-export class KnexCheckboxInterface extends CommonCheckboxInterface(KnexFieldAdapter) {
+export class KnexCheckboxInterface extends KnexFieldAdapter {
   constructor() {
     super(...arguments);
 
@@ -48,10 +44,12 @@ export class KnexCheckboxInterface extends CommonCheckboxInterface(KnexFieldAdap
         `Check the config for ${this.path} on the ${this.field.listKey} list`;
     }
   }
-
   addToTableSchema(table) {
     const column = table.boolean(this.path);
     if (this.isNotNullable) column.notNullable();
-    if (this.defaultTo) column.defaultTo(this.defaultTo);
+    if (typeof this.defaultTo !== 'undefined') column.defaultTo(this.defaultTo);
+  }
+  getQueryConditions(dbPath) {
+    return this.equalityConditions(dbPath);
   }
 }

--- a/packages/fields/src/types/Decimal/Implementation.js
+++ b/packages/fields/src/types/Decimal/Implementation.js
@@ -99,7 +99,7 @@ export class KnexDecimalInterface extends KnexFieldAdapter {
     if (this.isUnique) column.unique();
     else if (this.isIndexed) column.index();
     if (this.isNotNullable) column.notNullable();
-    if (this.defaultTo) column.defaultTo(this.defaultTo);
+    if (typeof this.defaultTo !== 'undefined') column.defaultTo(this.defaultTo);
   }
 
   getQueryConditions(dbPath) {

--- a/packages/fields/src/types/Float/Implementation.js
+++ b/packages/fields/src/types/Float/Implementation.js
@@ -58,6 +58,6 @@ export class KnexFloatInterface extends CommonFloatInterface(KnexFieldAdapter) {
     if (this.isUnique) column.unique();
     else if (this.isIndexed) column.index();
     if (this.isNotNullable) column.notNullable();
-    if (this.defaultTo) column.defaultTo(this.defaultTo);
+    if (typeof this.defaultTo !== 'undefined') column.defaultTo(this.defaultTo);
   }
 }

--- a/packages/fields/src/types/Integer/Implementation.js
+++ b/packages/fields/src/types/Integer/Implementation.js
@@ -65,6 +65,6 @@ export class KnexIntegerInterface extends CommonIntegerInterface(KnexFieldAdapte
     if (this.isUnique) column.unique();
     else if (this.isIndexed) column.index();
     if (this.isNotNullable) column.notNullable();
-    if (this.defaultTo) column.defaultTo(this.defaultTo);
+    if (typeof this.defaultTo !== 'undefined') column.defaultTo(this.defaultTo);
   }
 }

--- a/packages/fields/src/types/Relationship/Implementation.js
+++ b/packages/fields/src/types/Relationship/Implementation.js
@@ -495,7 +495,7 @@ export class KnexRelationshipInterface extends KnexFieldAdapter {
         path: this.path,
         isUnique: this.isUnique,
         isIndexed: this.isIndexed,
-        isNotNullable: false, // See validation above
+        isNotNullable: this.isNotNullable,
       };
       refId.adapter.addToForeignTableSchema(table, foreignKeyConfig);
     }

--- a/packages/fields/src/types/Select/Implementation.js
+++ b/packages/fields/src/types/Select/Implementation.js
@@ -85,6 +85,6 @@ export class KnexSelectInterface extends CommonSelectInterface(KnexFieldAdapter)
     if (this.isUnique) column.unique();
     else if (this.isIndexed) column.index();
     if (this.isNotNullable) column.notNullable();
-    if (this.defaultTo) column.defaultTo(this.defaultTo);
+    if (typeof this.defaultTo !== 'undefined') column.defaultTo(this.defaultTo);
   }
 }

--- a/packages/fields/src/types/Text/Implementation.js
+++ b/packages/fields/src/types/Text/Implementation.js
@@ -66,6 +66,6 @@ export class KnexTextInterface extends CommonTextInterface(KnexFieldAdapter) {
     if (this.isUnique) column.unique();
     else if (this.isIndexed) column.index();
     if (this.isNotNullable) column.notNullable();
-    if (this.defaultTo) column.defaultTo(this.defaultTo);
+    if (typeof this.defaultTo !== 'undefined') column.defaultTo(this.defaultTo);
   }
 }


### PR DESCRIPTION
Fixing a few problems around field and field adapter config:

* Falsy defaults weren't being applied to the DB (ie. giving a `Checkbox` a DB-level default of `false`)
* Explicitly setting `isNotNullable` on a singular relationship field was temporarily disabled; forgot to re-enable it after fixing logic around the how the setting was defaulted