### PR TITLE
Ensure searchUnsplash mutation returns results with a non-null id

### DIFF
--- a/.changeset/yellow-owls-pump/changes.json
+++ b/.changeset/yellow-owls-pump/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/fields", "type": "patch" }], "dependents": [] }

--- a/.changeset/yellow-owls-pump/changes.md
+++ b/.changeset/yellow-owls-pump/changes.md
@@ -1,0 +1,1 @@
+Ensure searchUnsplash mutation returns results with a non-null id

--- a/packages/fields/src/types/Unsplash/Implementation.js
+++ b/packages/fields/src/types/Unsplash/Implementation.js
@@ -14,8 +14,9 @@ const defaultTransforms = {
   fit: 'max',
 };
 
-function transformUserFromApiToKs5(user) {
+function transformUserFromApiToKs5(user, { includeId = false } = {}) {
   return {
+    ...(includeId && { id: user.id }),
     unsplpashId: user.id,
     username: user.username,
     name: user.name,
@@ -26,8 +27,9 @@ function transformUserFromApiToKs5(user) {
   };
 }
 
-function transformImageFromApiToKs5(image) {
+function transformImageFromApiToKs5(image, { includeId = false } = {}) {
   return {
+    ...(includeId && { id: image.id }),
     unsplashId: image.id,
     width: image.width,
     height: image.height,
@@ -35,7 +37,7 @@ function transformImageFromApiToKs5(image) {
     description: image.description || null,
     alt: image.alt_description || null,
     publicUrl: image.urls.raw,
-    user: transformUserFromApiToKs5(image.user),
+    user: transformUserFromApiToKs5(image.user, { includeId }),
   };
 }
 
@@ -173,7 +175,7 @@ export class Unsplash extends Implementation {
           total,
           totalPages: total_pages,
           results: results.map(result =>
-            this.injectPublicUrlFields(transformImageFromApiToKs5(result))
+            this.injectPublicUrlFields(transformImageFromApiToKs5(result, { includeId: true }))
           ),
         };
       },

--- a/packages/fields/src/types/Unsplash/Implementation.js
+++ b/packages/fields/src/types/Unsplash/Implementation.js
@@ -17,7 +17,7 @@ const defaultTransforms = {
 function transformUserFromApiToKs5(user, { includeId = false } = {}) {
   return {
     ...(includeId && { id: user.id }),
-    unsplpashId: user.id,
+    unsplashId: user.id,
     username: user.username,
     name: user.name,
     url: user.links.html,


### PR DESCRIPTION
Previously, this was returning `id: null`, which would confuse Apollo's cache who expected `id`s to always have a value if included in the results. Ultimately, apollo would key the cache by the `id`, but that `id` is `null`, so it would only store a single item 5 times (for example).

This fix ensures that the `searchUnsplash` query always injects an id.