### PR TITLE
Add @keystone-alpha to package.json 

### DIFF
--- a/packages/create-keystone-app/templates/todo/package.json.ejs
+++ b/packages/create-keystone-app/templates/todo/package.json.ejs
@@ -6,6 +6,7 @@
   },
   "private": true,
   "dependencies": {
+    "@keystone-alpha": "latest",
     "@keystone-alpha/adapter-mongoose": "latest",
     "@keystone-alpha/app-admin-ui": "latest",
     "@keystone-alpha/app-graphql": "latest",


### PR DESCRIPTION
Updates the `package.json` in the template to add `@keystone-alpha` and hopefully fixes: #1377