### PR TITLE
Remove sizeByPixelDensity option in gatsby-remark-images

### DIFF
--- a/.changeset/tall-rats-complain/changes.json
+++ b/.changeset/tall-rats-complain/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/website", "type": "minor" }], "dependents": [] }

--- a/.changeset/tall-rats-complain/changes.md
+++ b/.changeset/tall-rats-complain/changes.md
@@ -1,0 +1,1 @@
+Remove sizeByPixelDensity option in gatsby-remark-images

--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -80,7 +80,6 @@ async function getGatsbyConfig() {
               resolve: 'gatsby-remark-images',
               options: {
                 maxWidth: 848, // TODO: remove magic number -- width of main col
-                sizeByPixelDensity: true,
               },
             },
             // This is needed to resolve svgs


### PR DESCRIPTION
Fixes #1408 

[This option has been deprecated](https://www.gatsbyjs.org/packages/gatsby-plugin-sharp/#parameters-2)