### PR TITLE
Add support for fallbacks

### DIFF
--- a/.changeset/many-singers-allow/changes.json
+++ b/.changeset/many-singers-allow/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/app-static", "type": "minor" }], "dependents": [] }

--- a/.changeset/many-singers-allow/changes.md
+++ b/.changeset/many-singers-allow/changes.md
@@ -1,0 +1,1 @@
+Added a new fallback option to support client-side routing

--- a/packages/app-static/README.md
+++ b/packages/app-static/README.md
@@ -24,7 +24,7 @@ module.exports = {
     new AdminUIApp(),
     new StaticApp({
       path: '/',
-      src: pathModule.join(__dirname, 'build'),
+      src: 'public',
       fallback: 'index.html',
     }),
   ],

--- a/packages/app-static/README.md
+++ b/packages/app-static/README.md
@@ -43,4 +43,4 @@ The path to the folder containing static files.
 
 #### `fallback` (optional)
 
-The name of the file to serve if none is found.
+The path to the file to serve if none is found. This path is resolved relative to the `src` path.

--- a/packages/app-static/README.md
+++ b/packages/app-static/README.md
@@ -5,6 +5,42 @@ title: KeystoneJS Static File App
 
 # KeystoneJS Static File App
 
-```DOCS_TODO
-TODO
+A Keystone App to serve static files such as images, CSS and JavaScript with support for client side routing.
+
+## Usage
+
+`index.js`
+
+```js
+const { Keystone } = require('@keystone-alpha/keystone');
+const { GraphQLApp } = require('@keystone-alpha/app-graphql');
+const { AdminUIApp } = require('@keystone-alpha/app-admin-ui');
+const { StaticApp } = require('@keystone-alpha/app-static');
+
+module.exports = {
+  new Keystone(),
+  apps: [
+    new GraphQLApp(),
+    new AdminUIApp(),
+    new StaticApp({
+      path: '/',
+      src: pathModule.join(__dirname, 'build'),
+      fallback: 'index.html',
+    }),
+  ],
+};
 ```
+
+## Options
+
+### `path`
+
+The path to serve files from.
+
+### `src`
+
+The path to the folder containing static files.
+
+#### `fallback` (optional)
+
+The name of the file to serve if none is found.

--- a/packages/app-static/index.js
+++ b/packages/app-static/index.js
@@ -1,5 +1,6 @@
 const fs = require('fs-extra');
 const express = require('express');
+const fallback = require('express-history-api-fallback');
 const pathModule = require('path');
 
 const getDistDir = (src, distDir) => {
@@ -8,15 +9,19 @@ const getDistDir = (src, distDir) => {
 };
 
 class StaticApp {
-  constructor({ path, src }) {
+  constructor({ path, src, fallback }) {
     this._path = path;
     this._src = src;
+    this._fallback = fallback;
   }
 
   prepareMiddleware({ dev, distDir }) {
     const app = express();
     const folderToServe = dev ? this._src : getDistDir(this._src, distDir);
     app.use(this._path, express.static(folderToServe));
+    if (this._fallback) {
+      app.use(fallback(this._fallback, { root: folderToServe }));
+    }
     return app;
   }
 

--- a/packages/app-static/package.json
+++ b/packages/app-static/package.json
@@ -11,6 +11,7 @@
     "express": "^4.17.1"
   },
   "dependencies": {
+    "express-history-api-fallback": "^2.2.1",
     "fs-extra": "^7.0.0"
   }
 }


### PR DESCRIPTION
I've added a new option `fallback` to the `app-static` package so it can support client-side routing. I've also updated the docs for this package.
