### PR TITLE
Windows compatibility

### DIFF
--- a/.changeset/dull-cheetahs-appear/changes.json
+++ b/.changeset/dull-cheetahs-appear/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/build-field-types", "type": "patch" }], "dependents": [] }

--- a/.changeset/dull-cheetahs-appear/changes.md
+++ b/.changeset/dull-cheetahs-appear/changes.md
@@ -1,0 +1,1 @@
+support windows paths in development build

--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "pino": "5.11.1",
     "pirates": "^4.0.1",
     "pluralize": "^7.0.0",
-    "preconstruct": "0.0.66",
+    "preconstruct": "0.0.86",
     "pretty-proptypes": "^0.5.0",
     "prop-types": "^15.7.2",
     "query-string": "^6.8.1",

--- a/packages/build-field-types/package.json
+++ b/packages/build-field-types/package.json
@@ -30,7 +30,6 @@
     "chalk": "^2.4.2",
     "dataloader": "^1.4.0",
     "diff": "^4.0.1",
-    "endent": "^1.3.0",
     "fast-deep-equal": "^2.0.1",
     "fs-extra": "^7.0.0",
     "globby": "^9.1.0",

--- a/packages/build-field-types/src/dev.js
+++ b/packages/build-field-types/src/dev.js
@@ -3,7 +3,6 @@ import { Project } from './project';
 import { success, info } from './logger';
 import * as fs from 'fs-extra';
 import path from 'path';
-import endent from 'endent';
 
 export default async function dev(projectDir: string) {
   let project: Project = await Project.create(projectDir);
@@ -23,18 +22,16 @@ export default async function dev(projectDir: string) {
             fs.symlink(entrypoint.source, path.join(entrypoint.directory, entrypoint.module)),
             fs.writeFile(
               path.join(entrypoint.directory, entrypoint.main),
-              endent`
-            'use strict';
+              `"use strict";
 
-            let unregister = require('${require.resolve('@preconstruct/hook')}').___internalHook('${
-                project.directory
-              }');
+let unregister = require(${JSON.stringify(
+                require.resolve('@preconstruct/hook')
+              )}).___internalHook(${JSON.stringify(project.directory)});
 
-            module.exports = require('${entrypoint.source}');
+module.exports = require(${JSON.stringify(entrypoint.source)});
 
-            unregister();
-            
-            `
+unregister();
+`
             ),
           ]);
         })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2547,10 +2547,21 @@
     string-width "^2.0.0"
     strip-ansi "^3"
 
-"@preconstruct/hook@0.0.1", "@preconstruct/hook@^0.0.1":
+"@preconstruct/hook@0.0.1":
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/@preconstruct/hook/-/hook-0.0.1.tgz#79484f9dceabb970319cd03ec1d8eac71ec6eae5"
   integrity sha512-cpr6LzI0OW1lZxmixkGNqC3KM8XzPFLX7bpj0uClt6sN7wXXc93gHK8YvAO7FqXxmBZKPF6e5KTJJtXISr+InA==
+  dependencies:
+    "@babel/core" "^7.1.2"
+    "@babel/plugin-transform-modules-commonjs" "^7.4.4"
+    "@babel/plugin-transform-runtime" "^7.2.0"
+    pirates "^4.0.1"
+    source-map-support "^0.5.12"
+
+"@preconstruct/hook@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@preconstruct/hook/-/hook-0.0.3.tgz#fd5c14d6e4f7b52076973c3dc136218a1913ca3b"
+  integrity sha512-fezJbvdDUnrb94dneEl46XZpBijPRK7k45bhony7tiORcjgUCVALY1BWk4EJbqz0q5as6z++0D/piMlqmtZugA==
   dependencies:
     "@babel/core" "^7.1.2"
     "@babel/plugin-transform-modules-commonjs" "^7.4.4"
@@ -2861,6 +2872,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.18.tgz#1d3ca764718915584fcd9f6344621b7672665c67"
   integrity sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==
 
+"@types/node@^12.6.9":
+  version "12.6.9"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.9.tgz#ffeee23afdc19ab16e979338e7b536fdebbbaeaf"
+  integrity sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw==
+
 "@types/node@^7.0.11":
   version "7.10.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-7.10.2.tgz#a98845168012d7a63a84d50e738829da43bdb0de"
@@ -2909,6 +2925,13 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
+
+"@types/resolve@0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"
+  integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
+  dependencies:
+    "@types/node" "*"
 
 "@types/semver@^5.5.0":
   version "5.5.0"
@@ -3381,6 +3404,11 @@ acorn@^6.0.7:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
   integrity sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==
+
+acorn@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.2.1.tgz#3ed8422d6dec09e6121cc7a843ca86a330a86b51"
+  integrity sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==
 
 address@1.0.3, address@^1.0.1:
   version "1.0.3"
@@ -5397,6 +5425,11 @@ builtin-modules@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.0.0.tgz#1e587d44b006620d90286cc7a9238bbc6129cab1"
   integrity sha512-hMIeU4K2ilbXV6Uv93ZZ0Avg/M91RaKXucQ+4me2Do1txxBDyDZWCBa5bJSLqoNTRpXTLwEzIk1KmloenDDjhg==
+
+builtin-modules@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.1.0.tgz#aad97c15131eb76b65b50ef208e7584cd76a7484"
+  integrity sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==
 
 builtin-status-codes@^3.0.0:
   version "3.0.0"
@@ -8628,6 +8661,11 @@ estree-walker@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.0.tgz#5d865327c44a618dde5699f763891ae31f257dae"
   integrity sha512-peq1RfVAVzr3PU/jL31RaOjUKLoZJpObQWJJ+LgfcxDUifyLZ1RjPQZTl0pzj2uJ45b7A7XpyppXvxdEqzo4rw==
+
+estree-walker@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
+  integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
 
 esutils@^2.0.0, esutils@^2.0.2:
   version "2.0.2"
@@ -12541,6 +12579,13 @@ is-redirect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
   integrity sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=
+
+is-reference@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-1.1.3.tgz#e99059204b66fdbe09305cfca715a29caa5c8a51"
+  integrity sha512-W1iHHv/oyBb2pPxkBxtaewxa1BC58Pn5J0hogyCdefwUIvb6R+TGbAcIa4qPNYLqLhb3EnOgUf2MQkkF76BcKw==
+  dependencies:
+    "@types/estree" "0.0.39"
 
 is-regex@^1.0.3, is-regex@^1.0.4:
   version "1.0.4"
@@ -17666,15 +17711,15 @@ prebuild-install@^5.3.0:
     tunnel-agent "^0.6.0"
     which-pm-runs "^1.0.0"
 
-preconstruct@0.0.66:
-  version "0.0.66"
-  resolved "https://registry.yarnpkg.com/preconstruct/-/preconstruct-0.0.66.tgz#86833194ee634d139b3e139b52340d9be7088e9f"
-  integrity sha512-wjg4P36VQVavtSdCe+JBl94xoK6JIBZSibKFrlu4c3m5Bu58jQJ1dwA8JDoyAHQq2dd0rBpQdy2Dt2pzvKm+Zg==
+preconstruct@0.0.86:
+  version "0.0.86"
+  resolved "https://registry.yarnpkg.com/preconstruct/-/preconstruct-0.0.86.tgz#8c296a57f1c5031de532352a17eac306b671effe"
+  integrity sha512-XKCdJJgCWMvnzyLz5Sx4o8NaieIILYD17zPdCfF7FW19PJDwZu0GOCwe0T8Ao1dZoQB1ynACZK8mbRrJom4u0g==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@babel/core" "^7.1.2"
     "@babel/plugin-transform-runtime" "^7.2.0"
-    "@preconstruct/hook" "^0.0.1"
+    "@preconstruct/hook" "^0.0.3"
     builtin-modules "^3.0.0"
     chalk "^2.3.2"
     dataloader "^1.4.0"
@@ -17696,12 +17741,13 @@ preconstruct@0.0.66:
     quick-lru "^4.0.0"
     resolve "^1.10.0"
     resolve-from "^4.0.0"
-    rollup "^1.0.0"
-    rollup-plugin-alias "^1.4.0"
-    rollup-plugin-commonjs "^9.3.4"
-    rollup-plugin-node-resolve "^4.0.0"
-    rollup-plugin-replace "^2.0.0"
-    rollup-pluginutils "^2.6.0"
+    rollup "^1.12.2"
+    rollup-plugin-alias "^1.5.1"
+    rollup-plugin-commonjs "^10.0.0"
+    rollup-plugin-json "^4.0.0"
+    rollup-plugin-node-resolve "^5.0.0"
+    rollup-plugin-replace "^2.2.0"
+    rollup-pluginutils "^2.7.1"
     sarcastic "^1.5.0"
     terser "^3.14.1"
     xxhash-wasm "^0.3.1"
@@ -19681,6 +19727,13 @@ resolve@^1.10.1, resolve@^1.11.0:
   dependencies:
     path-parse "^1.0.6"
 
+resolve@^1.11.1:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
+  integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
+  dependencies:
+    path-parse "^1.0.6"
+
 resolve@^1.3.2, resolve@^1.5.0, resolve@^1.6.0:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
@@ -19802,15 +19855,30 @@ rollup-plugin-alias@^1.4.0:
   dependencies:
     slash "^2.0.0"
 
-rollup-plugin-commonjs@^9.3.4:
-  version "9.3.4"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.3.4.tgz#2b3dddbbbded83d45c36ff101cdd29e924fd23bc"
-  integrity sha512-DTZOvRoiVIHHLFBCL4pFxOaJt8pagxsVldEXBOn6wl3/V21wVaj17HFfyzTsQUuou3sZL3lEJZVWKPFblJfI6w==
+rollup-plugin-alias@^1.5.1:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-alias/-/rollup-plugin-alias-1.5.2.tgz#f15a1cc8ee0debf74ab5c2bb68a944a66b568411"
+  integrity sha512-ODeZXhTxpD48sfcYLAFc1BGrsXKDj7o1CSNH3uYbdK3o0NxyMmaQPTNgW+ko+am92DLC8QSTe4kyxTuEkI5S5w==
   dependencies:
-    estree-walker "^0.6.0"
+    slash "^3.0.0"
+
+rollup-plugin-commonjs@^10.0.0:
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-10.0.2.tgz#61328f3a29945e2c35f2b2e824c18944fd88a54d"
+  integrity sha512-DxeR4QXTgTOFseYls1V7vgKbrSJmPYNdEMOs0OvH+7+89C3GiIonU9gFrE0u39Vv1KWm3wepq8KAvKugtoM2Zw==
+  dependencies:
+    estree-walker "^0.6.1"
+    is-reference "^1.1.2"
     magic-string "^0.25.2"
-    resolve "^1.10.0"
-    rollup-pluginutils "^2.6.0"
+    resolve "^1.11.0"
+    rollup-pluginutils "^2.8.1"
+
+rollup-plugin-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-json/-/rollup-plugin-json-4.0.0.tgz#a18da0a4b30bf5ca1ee76ddb1422afbb84ae2b9e"
+  integrity sha512-hgb8N7Cgfw5SZAkb3jf0QXii6QX/FOkiIq2M7BAQIEydjHvTyxXHQiIzZaTFgx1GK0cRCHOCBHIyEkkLdWKxow==
+  dependencies:
+    rollup-pluginutils "^2.5.0"
 
 rollup-plugin-node-resolve@^4.0.0:
   version "4.0.0"
@@ -19821,6 +19889,17 @@ rollup-plugin-node-resolve@^4.0.0:
     is-module "^1.0.0"
     resolve "^1.8.1"
 
+rollup-plugin-node-resolve@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.2.0.tgz#730f93d10ed202473b1fb54a5997a7db8c6d8523"
+  integrity sha512-jUlyaDXts7TW2CqQ4GaO5VJ4PwwaV8VUGA7+km3n6k6xtOEacf61u0VXwN80phY/evMcaS+9eIeJ9MOyDxt5Zw==
+  dependencies:
+    "@types/resolve" "0.0.8"
+    builtin-modules "^3.1.0"
+    is-module "^1.0.0"
+    resolve "^1.11.1"
+    rollup-pluginutils "^2.8.1"
+
 rollup-plugin-replace@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-replace/-/rollup-plugin-replace-2.1.0.tgz#f9c07a4a89a2f8be912ee54b3f0f68d91e9ed0ae"
@@ -19830,6 +19909,14 @@ rollup-plugin-replace@^2.0.0:
     minimatch "^3.0.2"
     rollup-pluginutils "^2.0.1"
 
+rollup-plugin-replace@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-replace/-/rollup-plugin-replace-2.2.0.tgz#f41ae5372e11e7a217cde349c8b5d5fd115e70e3"
+  integrity sha512-/5bxtUPkDHyBJAKketb4NfaeZjL5yLZdeUihSfbF2PQMz+rSTEb8ARKoOl3UBT4m7/X+QOXJo3sLTcq+yMMYTA==
+  dependencies:
+    magic-string "^0.25.2"
+    rollup-pluginutils "^2.6.0"
+
 rollup-pluginutils@^2.0.1:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.3.3.tgz#3aad9b1eb3e7fe8262820818840bf091e5ae6794"
@@ -19837,6 +19924,13 @@ rollup-pluginutils@^2.0.1:
   dependencies:
     estree-walker "^0.5.2"
     micromatch "^2.3.11"
+
+rollup-pluginutils@^2.5.0, rollup-pluginutils@^2.7.1, rollup-pluginutils@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.1.tgz#8fa6dd0697344938ef26c2c09d2488ce9e33ce97"
+  integrity sha512-J5oAoysWar6GuZo0s+3bZ6sVZAC0pfqKz68De7ZgDi5z63jOVZn1uJL/+z1jeKHNbGII8kAyHF5q8LnxSX5lQg==
+  dependencies:
+    estree-walker "^0.6.1"
 
 rollup-pluginutils@^2.6.0:
   version "2.6.0"
@@ -19854,6 +19948,15 @@ rollup@^1.0.0:
     "@types/estree" "0.0.39"
     "@types/node" "*"
     acorn "^6.0.5"
+
+rollup@^1.12.2:
+  version "1.19.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.19.2.tgz#64f74ef9b743cbc31e5aa226c7bce0a767cd9a33"
+  integrity sha512-nH8Sr5MMhdq+Se4w9RsJiwIFJ7eHNt+UyqR8a1WKlP36+ruJnzRoXMeSXicdRScAyDhrdQQR7GUX6W41qHlp+A==
+  dependencies:
+    "@types/estree" "0.0.39"
+    "@types/node" "^12.6.9"
+    acorn "^6.2.1"
 
 rsvp@^3.3.3:
   version "3.6.2"
@@ -20400,6 +20503,11 @@ slash@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
   integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
+
+slash@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
+  integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
 slate-base64-serializer@^0.2.107:
   version "0.2.107"


### PR DESCRIPTION
Finalise
* #1262 "windows compatibility: project does not install"
* #1263 "windows compatible npm scripts"

Updates have been merged to preconstruct per [PR #77](https://github.com/preconstruct/preconstruct/pull/77). This PR makes the same changes here.

Root cause
* Forward slashes needed to be escaped.
* The `endent` package [doesn't support escape sequences](https://github.com/dmnd/dedent/issues/24). It isn't used in preconstruct.

Tested myself on MacOs and by @MadeByMike on windows 10.