### PR TITLE
Expose 'originalInput' to access control functions for lists & fields

### DIFF
--- a/.changeset/rare-flies-care/changes.json
+++ b/.changeset/rare-flies-care/changes.json
@@ -1,0 +1,7 @@
+{
+  "releases": [
+    { "name": "@keystone-alpha/access-control", "type": "minor" },
+    { "name": "@keystone-alpha/keystone", "type": "minor" }
+  ],
+  "dependents": []
+}

--- a/.changeset/rare-flies-care/changes.md
+++ b/.changeset/rare-flies-care/changes.md
@@ -1,0 +1,1 @@
+Expose 'originalInput' to access control functions for lists & fields

--- a/docs/api/access-control.md
+++ b/docs/api/access-control.md
@@ -113,6 +113,7 @@ type AccessInput = {
     item?: {},
     listKey?: string,
   },
+  originalInput?: {},
 };
 
 type StaticAccess = boolean;
@@ -141,6 +142,7 @@ ie; for a list `User`, it would match the input type `UserWhereInput`.
 - `authentication` describes the currently authenticated user.
   - `.item` is the details of the current user. Will be `undefined` for anonymous users.
   - `.listKey` is the list key of the currently authenticated user. Will be `undefined` for anonymous users.
+- `originalInput` for `create` & `update` mutations, this is the data as passed in the mutation.
 
 When resolving `StaticAccess`;
 
@@ -333,7 +335,8 @@ type AccessInput = {
     item?: {},
     listKey?: string,
   },
-  existingItem: {},
+  originalInput?: {},
+  existingItem?: {},
 };
 
 type StaticAccess = boolean;
@@ -364,7 +367,8 @@ only to modify it).
 - `authentication` describes the currently authenticated user.
   - `.item` is the details of the current user. Will be `undefined` for anonymous users.
   - `.listKey` is the list key of the currently authenticated user. Will be `undefined` for anonymous users.
-- `existingItem` is the existing item this field belongs to (undefined on create).
+- `originalInput`is the data as passed in the mutation for `create` & `update` mutations (`undefined` for `read`).
+- `existingItem` is the existing item this field belongs to for `update` mutations & `read` queries (`undefined` for `create`).
 
 When defining `StaticAccess`;
 

--- a/packages/access-control/lib/access-control.js
+++ b/packages/access-control/lib/access-control.js
@@ -119,13 +119,16 @@ module.exports = {
     });
   },
 
-  validateListAccessControl({ access, listKey, operation, authentication }) {
+  validateListAccessControl({ access, listKey, operation, authentication = {}, originalInput }) {
     // Either a boolean or an object describing a where clause
     let result;
     if (typeof access[operation] !== 'function') {
       result = access[operation];
     } else {
-      result = access[operation]({ authentication: authentication.item ? authentication : {} });
+      result = access[operation]({
+        authentication: authentication.item ? authentication : {},
+        originalInput,
+      });
     }
 
     const type = getType(result);
@@ -150,9 +153,10 @@ module.exports = {
     access,
     listKey,
     fieldKey,
+    originalInput,
     existingItem,
     operation,
-    authentication,
+    authentication = {},
   }) {
     let result;
     if (typeof access[operation] !== 'function') {
@@ -160,6 +164,7 @@ module.exports = {
     } else {
       result = access[operation]({
         authentication: authentication.item ? authentication : {},
+        originalInput,
         existingItem,
       });
     }

--- a/packages/access-control/tests/access-control.test.js
+++ b/packages/access-control/tests/access-control.test.js
@@ -151,6 +151,18 @@ describe('Access control package tests', () => {
       Error
     );
 
+    const originalInput = {};
+    const accessFn = jest.fn(() => true);
+
+    validateListAccessControl({ access: { [operation]: accessFn }, operation, originalInput });
+
+    expect(accessFn).toHaveBeenCalledTimes(1);
+    expect(accessFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        originalInput,
+      })
+    );
+
     [{}, { item: {} }].forEach(authentication => {
       operation = 'read';
 
@@ -203,6 +215,25 @@ describe('Access control package tests', () => {
     expect(validateFieldAccessControl({ access: { [operation]: false }, operation })).toBe(false);
     expect(() => validateFieldAccessControl({ access: { [operation]: 10 }, operation })).toThrow(
       Error
+    );
+
+    const originalInput = {};
+    const existingItem = {};
+    const accessFn = jest.fn(() => true);
+
+    validateFieldAccessControl({
+      access: { [operation]: accessFn },
+      operation,
+      originalInput,
+      existingItem,
+    });
+
+    expect(accessFn).toHaveBeenCalledTimes(1);
+    expect(accessFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        originalInput,
+        existingItem,
+      })
     );
 
     [{}, { item: {} }].forEach(authentication => {

--- a/packages/keystone/lib/Keystone/index.js
+++ b/packages/keystone/lib/Keystone/index.js
@@ -355,9 +355,10 @@ module.exports = class Keystone {
     // memoizing to avoid requests that hit the same type multiple times.
     // We do it within the request callback so we can resolve it based on the
     // request info ( like who's logged in right now, etc)
-    const getListAccessControlForUser = fastMemoize((listKey, operation) => {
+    const getListAccessControlForUser = fastMemoize((listKey, originalInput, operation) => {
       return validateListAccessControl({
         access: this.lists[listKey].access,
+        originalInput,
         operation,
         authentication: { item: user, listKey: authedListKey },
         listKey,
@@ -365,9 +366,10 @@ module.exports = class Keystone {
     });
 
     const getFieldAccessControlForUser = fastMemoize(
-      (listKey, fieldKey, existingItem, operation) => {
+      (listKey, fieldKey, originalInput, existingItem, operation) => {
         return validateFieldAccessControl({
           access: this.lists[listKey].fieldsByPath[fieldKey].access,
+          originalInput,
           existingItem,
           operation,
           authentication: { item: user, listKey: authedListKey },

--- a/packages/keystone/lib/List/index.js
+++ b/packages/keystone/lib/List/index.js
@@ -537,7 +537,13 @@ module.exports = class List {
     return (item, args, context, ...rest) => {
       // If not allowed access
       const operation = 'read';
-      const access = context.getFieldAccessControlForUser(this.key, field.path, item, operation);
+      const access = context.getFieldAccessControlForUser(
+        this.key,
+        field.path,
+        undefined,
+        item,
+        operation
+      );
       if (!access) {
         // If the client handles errors correctly, it should be able to
         // receive partial data (for the fields the user has access to),
@@ -693,6 +699,7 @@ module.exports = class List {
           const access = context.getFieldAccessControlForUser(
             this.key,
             field.path,
+            data,
             existingItem,
             operation
           );
@@ -706,8 +713,8 @@ module.exports = class List {
     }
   }
 
-  checkListAccess(context, operation, { gqlName, ...extraInternalData }) {
-    const access = context.getListAccessControlForUser(this.key, operation);
+  checkListAccess(context, originalInput, operation, { gqlName, ...extraInternalData }) {
+    const access = context.getListAccessControlForUser(this.key, originalInput, operation);
     if (!access) {
       graphqlLogger.debug(
         { operation, access, gqlName, ...extraInternalData },
@@ -868,7 +875,7 @@ module.exports = class List {
   }
 
   async listQuery(args, context, queryName) {
-    const access = this.checkListAccess(context, 'read', { queryName });
+    const access = this.checkListAccess(context, undefined, 'read', { queryName });
 
     return this.adapter.itemsQuery(mergeWhereClause(args, access));
   }
@@ -879,7 +886,7 @@ module.exports = class List {
       // on what the user requested
       // Evalutation takes place in ../Keystone/index.js
       getCount: () => {
-        const access = this.checkListAccess(context, 'read', { queryName });
+        const access = this.checkListAccess(context, undefined, 'read', { queryName });
 
         return this.adapter
           .itemsQueryMeta(mergeWhereClause(args, access))
@@ -897,10 +904,10 @@ module.exports = class List {
       // NOTE: These could return a Boolean or a JSON object (if using the
       // declarative syntax)
       getAccess: () => ({
-        getCreate: () => context.getListAccessControlForUser(this.key, 'create'),
-        getRead: () => context.getListAccessControlForUser(this.key, 'read'),
-        getUpdate: () => context.getListAccessControlForUser(this.key, 'update'),
-        getDelete: () => context.getListAccessControlForUser(this.key, 'delete'),
+        getCreate: () => context.getListAccessControlForUser(this.key, undefined, 'create'),
+        getRead: () => context.getListAccessControlForUser(this.key, undefined, 'read'),
+        getUpdate: () => context.getListAccessControlForUser(this.key, undefined, 'update'),
+        getDelete: () => context.getListAccessControlForUser(this.key, undefined, 'delete'),
       }),
       getSchema: () => {
         const queries = [
@@ -933,7 +940,7 @@ module.exports = class List {
     const operation = 'read';
     graphqlLogger.debug({ id, operation, type: opToType[operation], gqlName }, 'Start query');
 
-    const access = this.checkListAccess(context, operation, { gqlName, itemId: id });
+    const access = this.checkListAccess(context, undefined, operation, { gqlName, itemId: id });
 
     const result = await this.getAccessControlledItem(id, access, { context, operation, gqlName });
 
@@ -1314,7 +1321,7 @@ module.exports = class List {
     const operation = 'create';
     const gqlName = this.gqlNames.createMutationName;
 
-    this.checkListAccess(context, operation, { gqlName });
+    this.checkListAccess(context, data, operation, { gqlName });
 
     const existingItem = undefined;
 
@@ -1329,7 +1336,7 @@ module.exports = class List {
     const operation = 'create';
     const gqlName = this.gqlNames.createManyMutationName;
 
-    this.checkListAccess(context, operation, { gqlName });
+    this.checkListAccess(context, data, operation, { gqlName });
 
     const itemsToUpdate = data.map(d => ({ existingItem: undefined, data: d.data }));
 
@@ -1399,7 +1406,7 @@ module.exports = class List {
     const gqlName = this.gqlNames.updateMutationName;
     const extraData = { itemId: id };
 
-    const access = this.checkListAccess(context, operation, { gqlName, ...extraData });
+    const access = this.checkListAccess(context, data, operation, { gqlName, ...extraData });
 
     const existingItem = await this.getAccessControlledItem(id, access, {
       context,
@@ -1420,7 +1427,7 @@ module.exports = class List {
     const ids = data.map(d => d.id);
     const extraData = { itemId: ids };
 
-    const access = this.checkListAccess(context, operation, { gqlName, ...extraData });
+    const access = this.checkListAccess(context, data, operation, { gqlName, ...extraData });
 
     const existingItems = await this.getAccessControlledItems(ids, access);
 
@@ -1470,7 +1477,7 @@ module.exports = class List {
     const operation = 'delete';
     const gqlName = this.gqlNames.deleteMutationName;
 
-    const access = this.checkListAccess(context, operation, { gqlName, itemId: id });
+    const access = this.checkListAccess(context, undefined, operation, { gqlName, itemId: id });
 
     const existingItem = await this.getAccessControlledItem(id, access, {
       context,
@@ -1485,7 +1492,7 @@ module.exports = class List {
     const operation = 'delete';
     const gqlName = this.gqlNames.deleteManyMutationName;
 
-    const access = this.checkListAccess(context, operation, { gqlName, itemIds: ids });
+    const access = this.checkListAccess(context, undefined, operation, { gqlName, itemIds: ids });
 
     const existingItems = await this.getAccessControlledItems(ids, access);
 

--- a/packages/keystone/tests/List.test.js
+++ b/packages/keystone/tests/List.test.js
@@ -140,7 +140,7 @@ Relationship.adapters['mock'] = {};
 
 const context = {
   getListAccessControlForUser: () => true,
-  getFieldAccessControlForUser: (listKey, fieldPath, existingItem) =>
+  getFieldAccessControlForUser: (listKey, fieldPath, originalInput, existingItem) =>
     !(existingItem && existingItem.makeFalse && fieldPath === 'name'),
   authedItem: {
     id: 1,
@@ -1013,16 +1013,21 @@ test('checkFieldAccess', () => {
 
 test('checkListAccess', () => {
   const list = setup();
-  expect(list.checkListAccess(context, 'read', { gqlName: 'testing' })).toEqual(true);
+  const originalInput = {};
+  expect(list.checkListAccess(context, originalInput, 'read', { gqlName: 'testing' })).toEqual(
+    true
+  );
 
   const newContext = {
     ...context,
-    getListAccessControlForUser: (listKey, operation) => operation === 'update',
+    getListAccessControlForUser: (listKey, originalInput, operation) => operation === 'update',
   };
-  expect(list.checkListAccess(newContext, 'update', { gqlName: 'testing' })).toEqual(true);
-  expect(() => list.checkListAccess(newContext, 'read', { gqlName: 'testing' })).toThrow(
-    AccessDeniedError
+  expect(list.checkListAccess(newContext, originalInput, 'update', { gqlName: 'testing' })).toEqual(
+    true
   );
+  expect(() =>
+    list.checkListAccess(newContext, originalInput, 'read', { gqlName: 'testing' })
+  ).toThrow(AccessDeniedError);
 });
 
 test('getAccessControlledItem', async () => {


### PR DESCRIPTION
Let's say I've got a "publishing workflow" where a `Post`, once published, can't be edited except by admins, or if the author first marks it as draft.

I've got two options for setting access control, but neither seem ideal:

**Option 1: access per field**

```javascript
keystone.createList('Post', {
  fields: {
    content: {
      type: Text,
      access: {
        read: true,
        create: true,
        update: ({ authentication: { item }, existingItem }) => {
          if (!item) {
            return false;
          }

          if (item.isAdmin) {
            return true;
          }

          // Allow updating when in draft
          // NOTE: This check is now required on _every_ field
          return existingItem.publishStatus !== 'published';
        },
      }
    },
    publishStatus: {
      type: Select,
      options: ['draft', 'published'],
      defaultValue: 'draft',
      access: {
        read: true,
        create: true,
        update: ({ authentication: { item }, existingItem }) => {
          if (!item) {
            return false;
          }

          // Admins or authors can adjust the published status
          if (item.isAdmin || existingItem.author === item.id) {
            return true;
          }
        },
      }
    },
  },
});
```

This isn't great because it would be easy to accidentally forget to add that access control on every field.

**Option 2: List-level access**

```javascript
keystone.createList('Post', {
  fields: {
    content: { type: Text },
    author: { type: Relationship, ref: 'User' },
    publishStatus: {
      type: Select,
      options: ['draft', 'published'],
      defaultValue: 'draft',
    },
  },
  access: {
    create: true,
    read: true,
    update: ({ authentication: { item } }) => {
      if (!item) {
        return false;
      }

      if (item.isAdmin) {
        return true;
      }

      // How do I allow the author to set a 'published' post back to 'draft'?
      return {
        publishStatus_not: 'published'
        author: { id: item.id },
      }
    }
  },
});
```

This seems like the best bet, but I can't access the incoming changes so I can first check to see what the author is trying to change, and if it involves changing the publishedStatus to draft, then it's ok, otherwise, don't allow it.

---

So, this PR introduces the `originalInput`, which allows it to come out like this:

```javascript
keystone.createList('Post', {
  fields: {
    content: { type: Text },
    author: { type: Relationship, ref: 'User' },
    publishStatus: {
      type: Select,
      options: ['draft', 'published'],
      defaultValue: 'draft',
    },
  },
  access: {
    create: true,
    read: true,
    update: ({ authentication: { item }, originalInput }) => {
      if (!item) {
        return false;
      }

      if (item.isAdmin) {
        return true;
      }

      // The only valid edit an author can make to publishStatus is to move it
      // from 'published' -> 'draft'.
      if (originalInput.publishStatus && originalInput.publishStatus !== 'draft') {
        return false;
      }

      // Otherwise, the author must be trying to edit a post that's already got
      // publishStatus in draft
      return {
        author: { id: item.id },
        publishStatus_not: 'published',
      };
    }
  },
});
```