### PR TITLE
Implemented custom types for mutations

### DIFF
--- a/.changeset/six-kids-think/changes.json
+++ b/.changeset/six-kids-think/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/keystone", "type": "minor" }], "dependents": [] }

--- a/.changeset/six-kids-think/changes.md
+++ b/.changeset/six-kids-think/changes.md
@@ -1,0 +1,1 @@
+Add a `types` property to custom mutations.

--- a/packages/keystone/lib/Keystone/index.js
+++ b/packages/keystone/lib/Keystone/index.js
@@ -155,6 +155,7 @@ module.exports = class Keystone {
     // Deduping here avoids that problem.
     return [
       ...unique(flatten(this.listsArray.map(list => list.getGqlTypes({ skipAccessControl })))),
+      ...unique(flatten(this.listsArray.map(list => list.getGqlMutationTypes()))),
       `"""NOTE: Can be JSON, or a Boolean/Int/String
           Why not a union? GraphQL doesn't support a union including a scalar
           (https://github.com/facebook/graphql/issues/215)"""

--- a/packages/keystone/lib/List/index.js
+++ b/packages/keystone/lib/List/index.js
@@ -690,7 +690,7 @@ module.exports = class List {
   }
 
   getGqlMutationTypes() {
-    return [...flatten(this.mutations.filter(x => x.types).map(x => x.types);
+    return flatten(this.mutations.filter(x => x.types).map(x => x.types));
   }
 
   checkFieldAccess(operation, itemsToUpdate, context, { gqlName, extraData = {} }) {

--- a/packages/keystone/lib/List/index.js
+++ b/packages/keystone/lib/List/index.js
@@ -689,6 +689,13 @@ module.exports = class List {
     return mutations;
   }
 
+  getGqlMutationTypes() {
+    const types = [];
+    types.push(...flatten(this.mutations.filter(({ types }) => types).map(({ types }) => types)));
+
+    return types;
+  }
+
   checkFieldAccess(operation, itemsToUpdate, context, { gqlName, extraData = {} }) {
     const restrictedFields = [];
 

--- a/packages/keystone/lib/List/index.js
+++ b/packages/keystone/lib/List/index.js
@@ -690,10 +690,7 @@ module.exports = class List {
   }
 
   getGqlMutationTypes() {
-    const types = [];
-    types.push(...flatten(this.mutations.filter(({ types }) => types).map(({ types }) => types)));
-
-    return types;
+    return [...flatten(this.mutations.filter(x => x.types).map(x => x.types);
   }
 
   checkFieldAccess(operation, itemsToUpdate, context, { gqlName, extraData = {} }) {


### PR DESCRIPTION
This is a quick solution to adding custom types for mutations. 
Let me know what you think. 

This is how I am thinking we could add types to the custom mutations
```
keystone.createList('Example', {
  fields: {},
  mutations: [
    {
      types: [
        `type ExampleType {
          name: String
	  amount: Int
        }`,
      ],
      schema: 'getExampleType(id: ID!): ExampleType',
      resolver: async (obj, args, context, info, { query }) => {}
    }
  ]
})
```