### PR TITLE
Prepare release

### DIFF
--- a/.changeset/six-kids-think/changes.json
+++ b/.changeset/six-kids-think/changes.json
@@ -1,1 +1,0 @@
-{ "releases": [{ "name": "@keystone-alpha/keystone", "type": "minor" }], "dependents": [] }

--- a/.changeset/six-kids-think/changes.md
+++ b/.changeset/six-kids-think/changes.md
@@ -1,1 +1,0 @@
-Add a `types` property to custom mutations.

--- a/packages/keystone/CHANGELOG.md
+++ b/packages/keystone/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @keystone-alpha/keystone
 
+## 10.3.0
+
+### Minor Changes
+
+- [759a3c17](https://github.com/keystonejs/keystone-5/commit/759a3c17): Add a `types` property to custom mutations.
+
 ## 10.2.0
 
 ### Minor Changes

--- a/packages/keystone/package.json
+++ b/packages/keystone/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keystone-alpha/keystone",
   "description": "The main @keystone-alpha class & CLI. This is where the magic happens.",
-  "version": "10.2.0",
+  "version": "10.3.0",
   "author": "The KeystoneJS Development Team",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
This is a big one! 😱 

# @keystone-alpha/keystone

## 10.3.0

### Minor Changes

- [759a3c17](https://github.com/keystonejs/keystone-5/commit/759a3c17): Add a `types` property to custom mutations.