### PR TITLE
Prepare release

### DIFF
--- a/.changeset/clever-readers-sniff/changes.json
+++ b/.changeset/clever-readers-sniff/changes.json
@@ -1,1 +1,0 @@
-{ "releases": [{ "name": "@keystone-alpha/fields", "type": "minor" }], "dependents": [] }

--- a/.changeset/clever-readers-sniff/changes.md
+++ b/.changeset/clever-readers-sniff/changes.md
@@ -1,2 +1,0 @@
-- Add `Slug.alwaysMakeUnique` option to force calling `makeUnique` even when initially generated slug may already be unique to prevent accidental data leak.
-- Fix a bug where items restricted via access control weren't considered when testing a `Slug` for uniqueness.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,17 +6,19 @@ During the alpha stage of development we are focussing on getting the core syste
 Contributions which improve the documention and test coverage are particularly welcomed.
 
 ### Community Ecosystem
-Keystone makes no assumptions about type of applications it powers. It achieves flexibility through small, highly composable parts that allow you to build a foundation for any type of application.  
+
+Keystone makes no assumptions about type of applications it powers. It achieves flexibility through small, highly composable parts that allow you to build a foundation for any type of application.
 
 For this reason we might not add features to Keystone if they are prescriptive about:
-  - Data structures
-  - Workflows
-  - Access controls
-  - Front-end application UI
+
+- Data structures
+- Workflows
+- Access controls
+- Front-end application UI
 
 But we want your contributions! We recognise many types of applications share common features and prescriptive patterns can sometimes be helpful, even at the expense of flexibility.
 
-If you develop custom fields, adapters, apps or any other Keystone feature, (or have an idea) join us on the [Keystone Slack channel](https://launchpass.com/keystonejs) or make a pull request to [KeystoneJS-Contrib](https://github.com/keystonejs-contrib/keystonejs-contrib) and we will add it to our list of community libraries. 
+If you develop custom fields, adapters, apps or any other Keystone feature, (or have an idea) join us on the [Keystone Slack channel](https://launchpass.com/keystonejs) or make a pull request to [KeystoneJS-Contrib](https://github.com/keystonejs-contrib/keystonejs-contrib) and we will add it to our list of community libraries.
 
 ## Code of Conduct
 

--- a/packages/fields/CHANGELOG.md
+++ b/packages/fields/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @keystone-alpha/fields
 
+## 10.3.0
+
+### Minor Changes
+
+- [a640471a](https://github.com/keystonejs/keystone-5/commit/a640471a): - Add `Slug.alwaysMakeUnique` option to force calling `makeUnique` even when initially generated slug may already be unique to prevent accidental data leak.
+  - Fix a bug where items restricted via access control weren't considered when testing a `Slug` for uniqueness.
+
 ## 10.2.0
 
 ### Minor Changes

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keystone-alpha/fields",
   "description": "KeystoneJS Field Types including Text, Password, DateTime, Integer, and more.",
-  "version": "10.2.0",
+  "version": "10.3.0",
   "main": "dist/fields.cjs.js",
   "module": "dist/fields.esm.js",
   "author": "The KeystoneJS Development Team",


### PR DESCRIPTION
# @keystone-alpha/fields

## 10.3.0

### Minor Changes

- [a640471a](https://github.com/keystonejs/keystone-5/commit/a640471a): - Add `Slug.alwaysMakeUnique` option to force calling `makeUnique` even when initially generated slug may already be unique to prevent accidental data leak.
  - Fix a bug where items restricted via access control weren't considered when testing a `Slug` for uniqueness.