### PR TITLE
Respect static field-level access control in the Admin UI

### DIFF
--- a/.changeset/thirty-ladybugs-boil/changes.json
+++ b/.changeset/thirty-ladybugs-boil/changes.json
@@ -1,0 +1,8 @@
+{
+  "releases": [
+    { "name": "@keystone-alpha/app-admin-ui", "type": "minor" },
+    { "name": "@keystone-alpha/fields", "type": "minor" },
+    { "name": "@keystone-alpha/cypress-project-access-control", "type": "patch" }
+  ],
+  "dependents": []
+}

--- a/.changeset/thirty-ladybugs-boil/changes.md
+++ b/.changeset/thirty-ladybugs-boil/changes.md
@@ -1,0 +1,1 @@
+Respect static field-level access control in the Admin UI

--- a/packages/app-admin-ui/client/components/CreateItemModal.js
+++ b/packages/app-admin-ui/client/components/CreateItemModal.js
@@ -48,12 +48,14 @@ class CreateItemModal extends Component {
       return;
     }
 
-    const nonPrimaryKeyFields = fields.filter(({ isPrimaryKey }) => !isPrimaryKey);
+    const creatable = fields
+      .filter(({ isPrimaryKey }) => !isPrimaryKey)
+      .filter(({ maybeAccess }) => !!maybeAccess.create);
 
-    const data = arrayToObject(nonPrimaryKeyFields, 'path', field => field.serialize(item));
+    const data = arrayToObject(creatable, 'path', field => field.serialize(item));
 
     if (!countArrays(validationWarnings)) {
-      const { errors, warnings } = await validateFields(nonPrimaryKeyFields, item, data);
+      const { errors, warnings } = await validateFields(creatable, item, data);
 
       if (countArrays(errors) + countArrays(warnings) > 0) {
         this.setState(() => ({
@@ -131,11 +133,12 @@ class CreateItemModal extends Component {
             <AutocompleteCaptor />
             <Render>
               {() => {
-                const nonPrimaryKeyFields = list.fields.filter(({ isPrimaryKey }) => !isPrimaryKey);
-                captureSuspensePromises(
-                  nonPrimaryKeyFields.map(field => () => field.initFieldView())
-                );
-                return nonPrimaryKeyFields.map((field, i) => (
+                const creatable = list.fields
+                  .filter(({ isPrimaryKey }) => !isPrimaryKey)
+                  .filter(({ maybeAccess }) => !!maybeAccess.create);
+
+                captureSuspensePromises(creatable.map(field => () => field.initFieldView()));
+                return creatable.map((field, i) => (
                   <Render key={field.path}>
                     {() => {
                       let [Field] = field.adminMeta.readViews([field.views.Field]);

--- a/packages/app-admin-ui/client/pages/Item/index.js
+++ b/packages/app-admin-ui/client/pages/Item/index.js
@@ -60,7 +60,12 @@ const ItemDetails = withRouter(
       super(props);
       // memoized function so we can call it multiple times _per component_
       this.getFieldsObject = memoizeOne(() =>
-        arrayToObject(props.list.fields.filter(({ isPrimaryKey }) => !isPrimaryKey), 'path')
+        arrayToObject(
+          props.list.fields
+            .filter(({ isPrimaryKey }) => !isPrimaryKey)
+            .filter(({ maybeAccess }) => !!maybeAccess.update),
+          'path'
+        )
       );
     }
 
@@ -280,6 +285,7 @@ const ItemDetails = withRouter(
               <AutocompleteCaptor />
               {list.fields
                 .filter(({ isPrimaryKey }) => !isPrimaryKey)
+                .filter(({ maybeAccess }) => !!maybeAccess.update)
                 .map((field, i) => (
                   <Render key={field.path}>
                     {() => {
@@ -379,6 +385,7 @@ const ItemPage = ({ list, itemId, adminPath, getListByKey, toastManager }) => {
           captureSuspensePromises(
             list.fields
               .filter(({ isPrimaryKey }) => !isPrimaryKey)
+              .filter(({ maybeAccess }) => !!maybeAccess.update)
               .map(field => () => field.initFieldView())
           );
 

--- a/packages/fields/src/Controller.js
+++ b/packages/fields/src/Controller.js
@@ -6,6 +6,7 @@ export default class FieldController {
     this.label = config.label;
     this.path = config.path;
     this.type = config.type;
+    this.maybeAccess = config.access;
     this.isPrimaryKey = config.isPrimaryKey;
     this.list = list;
     this.adminMeta = adminMeta;

--- a/packages/fields/src/Implementation.js
+++ b/packages/fields/src/Implementation.js
@@ -176,6 +176,15 @@ class Field {
       // functions
       defaultValue: typeof this.defaultValue !== 'function' ? this.defaultValue : undefined,
       isPrimaryKey: this.isPrimaryKey,
+      // NOTE: This data is serialised, so we're unable to pass through any
+      // access control _functions_. But we can still check for the boolean case
+      // and pass that through (we assume that if there is a function, it's a
+      // "maybe" true, so default it to true).
+      access: {
+        create: !!this.access.create,
+        read: !!this.access.read,
+        update: !!this.access.update,
+      },
     });
   }
   extendAdminMeta(meta) {

--- a/packages/fields/src/types/Relationship/views/CreateItemModal.js
+++ b/packages/fields/src/types/Relationship/views/CreateItemModal.js
@@ -60,7 +60,11 @@ class CreateItemModal extends Component {
       return;
     }
 
-    const data = arrayToObject(fields, 'path', field => field.serialize(item));
+    const creatable = fields
+      .filter(({ isPrimaryKey }) => !isPrimaryKey)
+      .filter(({ maybeAccess }) => !!maybeAccess.create);
+
+    const data = arrayToObject(creatable, 'path', field => field.serialize(item));
 
     if (!countArrays(validationWarnings)) {
       const errors = {};
@@ -163,8 +167,12 @@ class CreateItemModal extends Component {
             <AutocompleteCaptor />
             <Render>
               {() => {
-                captureSuspensePromises(list.fields.map(field => () => field.initFieldView()));
-                return list.fields.map((field, i) => {
+                const creatable = list.fields
+                  .filter(({ isPrimaryKey }) => !isPrimaryKey)
+                  .filter(({ maybeAccess }) => !!maybeAccess.create);
+
+                captureSuspensePromises(creatable.map(field => () => field.initFieldView()));
+                return creatable.map((field, i) => {
                   return (
                     <Render key={field.path}>
                       {() => {

--- a/packages/fields/tests/Implementation.test.js
+++ b/packages/fields/tests/Implementation.test.js
@@ -119,6 +119,11 @@ describe('getAdminMeta()', () => {
 
     const value = impl.getAdminMeta();
     expect(value).toEqual({
+      access: {
+        create: true,
+        read: true,
+        update: true,
+      },
       label: 'config label',
       path: 'path',
       type: 'Field',
@@ -133,6 +138,11 @@ describe('getAdminMeta()', () => {
 
     const value = impl.getAdminMeta();
     expect(value).toEqual({
+      access: {
+        create: true,
+        read: true,
+        update: true,
+      },
       label: 'config label',
       path: 'path',
       type: 'Field',

--- a/test-projects/access-control/cypress/integration/field/admin-ui.js
+++ b/test-projects/access-control/cypress/integration/field/admin-ui.js
@@ -32,45 +32,76 @@ describe('Access Control Fields > Admin UI', () => {
   stayLoggedIn('su');
 
   describe('creating', () => {
-    function createTests(listName) {
-      const slug = listSlug(listName);
-
-      before(() => {
-        cy.visit(`/admin/${slug}`);
-        cy.get('#list-page-create-button').click({ force: true });
-        cy.get('form[role="dialog"]').should('exist');
-      });
+    describe(`static on ${staticList}`, () => {
+      const slug = listSlug(staticList);
 
       it('shows creatable inputs', () => {
-        fieldAccessVariations
-          .filter(({ create, read }) => create && read)
-          .forEach(access => {
-            const field = getFieldName(access);
-            cy.get(`label[for="ks-input-${field}"]`)
-              .should('exist')
-              .then(() => cy.get(`#ks-input-${field}`).should('exist'));
-          });
+        const fields = fieldAccessVariations.filter(({ create, read }) => create && read);
+        const fieldNames = fields.map(access => getFieldName(access));
+
+        cy.visit(`/admin/${slug}?fields=${fieldNames.join('%2C')}`);
+        cy.get('#list-page-create-button').click({ force: true });
+        cy.get('form[role="dialog"]').should('exist');
+
+        fields.forEach(access => {
+          const field = getFieldName(access);
+          cy.get(`label[for="ks-input-${field}"]`)
+            .should('exist')
+            .then(() => cy.get(`#ks-input-${field}`).should('exist'));
+        });
       });
 
-      // Skipped until Admin UI is created to exclude these fields
-      it.skip('does not show non-creatable inputs', () => {
-        fieldAccessVariations
-          .filter(({ create, read }) => !create && read)
-          .forEach(access => {
-            const field = getFieldName(access);
-            cy.get(`label[for="ks-input-${field}"]`)
-              .should('exist')
-              .then(() => cy.get(`#ks-input-${field}`).should('not.exist'));
-          });
-      });
-    }
+      it('does not show non-creatable inputs', () => {
+        const fields = fieldAccessVariations.filter(({ create, read }) => !create && read);
+        const fieldNames = fields.map(access => getFieldName(access));
 
-    describe(`static on ${staticList}`, () => {
-      createTests(staticList);
+        cy.visit(`/admin/${slug}?fields=${fieldNames.join('%2C')}`);
+        cy.get('#list-page-create-button').click({ force: true });
+        cy.get('form[role="dialog"]').should('exist');
+
+        fields.forEach(access => {
+          const field = getFieldName(access);
+          cy.get(`label[for="ks-input-${field}"]`)
+            .should('not.exist')
+            .then(() => cy.get(`#ks-input-${field}`).should('not.exist'));
+        });
+      });
     });
 
     describe('imperative', () => {
-      createTests(imperativeList);
+      const slug = listSlug(imperativeList);
+
+      it('shows creatable inputs', () => {
+        const fields = fieldAccessVariations.filter(({ create, read }) => create && read);
+        const fieldNames = fields.map(access => getFieldName(access));
+
+        cy.visit(`/admin/${slug}?fields=${fieldNames.join('%2C')}`);
+        cy.get('#list-page-create-button').click({ force: true });
+        cy.get('form[role="dialog"]').should('exist');
+
+        fields.forEach(access => {
+          const field = getFieldName(access);
+          cy.get(`label[for="ks-input-${field}"]`)
+            .should('exist')
+            .then(() => cy.get(`#ks-input-${field}`).should('exist'));
+        });
+      });
+
+      it.skip('does not show non-creatable inputs', () => {
+        const fields = fieldAccessVariations.filter(({ create, read }) => !create && read);
+        const fieldNames = fields.map(access => getFieldName(access));
+
+        cy.visit(`/admin/${slug}?fields=${fieldNames.join('%2C')}`);
+        cy.get('#list-page-create-button').click({ force: true });
+        cy.get('form[role="dialog"]').should('exist');
+
+        fields.forEach(access => {
+          const field = getFieldName(access);
+          cy.get(`label[for="ks-input-${field}"]`)
+            .should('not.exist')
+            .then(() => cy.get(`#ks-input-${field}`).should('not.exist'));
+        });
+      });
     });
   });
 
@@ -90,47 +121,67 @@ describe('Access Control Fields > Admin UI', () => {
     describe(`static on ${staticList}`, () => {
       const slug = listSlug(staticList);
 
-      // Skipped until we can force the Admin UI to show all the columns we need
-      it.skip('shows readable field values on list view', () => {
-        cy.visit(`/admin/${slug}`);
-        fieldAccessVariations
-          .filter(({ read }) => read)
-          .forEach(access => {
-            cy.get(`[data-field="${getFieldName(access)}"]`).should('exist');
-            // TODO: Test value is displayed and correct
-          });
+      it('shows readable field values on list view', () => {
+        const fields = fieldAccessVariations.filter(({ read }) => read);
+        const fieldNames = fields.map(access => getFieldName(access));
+
+        cy.visit(`/admin/${slug}?fields=${fieldNames.join('%2C')}`);
+
+        fields.forEach(access => {
+          cy.get(`[data-field="${getFieldName(access)}"]`).should('exist');
+          // TODO: Test value is displayed and correct
+        });
       });
     });
 
     describe('imperative', () => {
       const slug = listSlug(imperativeList);
 
-      // Skipped until we can force the Admin UI to show all the columns we need
-      it.skip('shows readable field values on list view', () => {
-        cy.visit(`/admin/${slug}`);
-        fieldAccessVariations
-          .filter(({ read }) => read)
-          .forEach(access => {
-            cy.get(`[data-field="${getFieldName(access)}"]`).should('exist');
-            // TODO: Test value is displayed and correct
-          });
+      it('shows readable field values on list view', () => {
+        const fields = fieldAccessVariations.filter(({ read }) => read);
+        const fieldNames = fields.map(access => getFieldName(access));
+
+        cy.visit(`/admin/${slug}?fields=${fieldNames.join('%2C')}`);
+
+        fields.forEach(access => {
+          cy.get(`[data-field="${getFieldName(access)}"]`).should('exist');
+          // TODO: Test value is displayed and correct
+        });
       });
 
-      // Skipped until Admin UI is updated to exclude these fields
       it.skip('does not show item value of non-readable fields', () => {
-        fieldAccessVariations
-          .filter(({ read }) => !read)
-          .forEach(access => {
-            cy.get(`[data-field="${getFieldName(access)}"]`).should('exist');
-          });
+        const fields = fieldAccessVariations.filter(({ read }) => !read);
+        const fieldNames = fields.map(access => getFieldName(access));
+
+        cy.visit(`/admin/${slug}?fields=${fieldNames.join('%2C')}`);
+
+        fields.forEach(access => {
+          cy.get(`[data-field="${getFieldName(access)}"]`).should('not.exist');
+        });
       });
     });
   });
 
   describe('updating', () => {
-    function updateTests(listName) {
-      const slug = listSlug(listName);
-      const queryName = `all${listName}s`;
+    function updateFromListViewTests(listName) {
+      describe(`list view multi-update on list ${listName}`, () => {
+        it.skip('shows only the fields commonly updatable across all selected items', () => {
+          // TODO: Setup access control so that it's something like this:
+          //
+          // | Is Updatable | foo | bar | zip |
+          // |--------------|-----|-----|-----|
+          // | Item 1       |  ✓  |     |  ✓  |
+          // | Item 2       |     |  ✓  |  ✓  |
+          //
+          // And check that the updatable fields are the intersection (ie; only
+          // 'zip' in this case)
+        });
+      });
+    }
+
+    describe(`static on ${staticList}`, () => {
+      const slug = listSlug(staticList);
+      const queryName = `all${staticList}s`;
 
       before(() => {
         cy.graphql_query('/admin/api', `query { ${queryName}(first: 1) { id } }`).then(
@@ -152,42 +203,55 @@ describe('Access Control Fields > Admin UI', () => {
           });
       });
 
-      // Skipped until Admin UI hides these fields
+      it('does not show non-updatable inputs', () => {
+        fieldAccessVariations
+          .filter(({ update, read }) => !update && read)
+          .forEach(access => {
+            const field = getFieldName(access);
+            cy.get(`label[for="ks-input-${field}"]`)
+              .should('not.exist')
+              .then(() => cy.get(`#ks-input-${field}`).should('not.exist'));
+          });
+      });
+
+      updateFromListViewTests(staticList);
+    });
+
+    describe(`imperative on ${imperativeList}`, () => {
+      const slug = listSlug(imperativeList);
+      const queryName = `all${imperativeList}s`;
+
+      before(() => {
+        cy.graphql_query('/admin/api', `query { ${queryName}(first: 1) { id } }`).then(
+          ({ data }) => {
+            cy.visit(`/admin/${slug}/${data[queryName][0].id}`);
+            cy.get('form').should('exist');
+          }
+        );
+      });
+
+      it('shows updatable inputs', () => {
+        fieldAccessVariations
+          .filter(({ update, read }) => update && read)
+          .forEach(access => {
+            const field = getFieldName(access);
+            cy.get(`label[for="ks-input-${field}"]`)
+              .should('exist')
+              .then(() => cy.get(`#ks-input-${field}`).should('exist'));
+          });
+      });
+
       it.skip('does not show non-updatable inputs', () => {
         fieldAccessVariations
           .filter(({ update, read }) => !update && read)
           .forEach(access => {
             const field = getFieldName(access);
             cy.get(`label[for="ks-input-${field}"]`)
-              .should('exist')
+              .should('not.exist')
               .then(() => cy.get(`#ks-input-${field}`).should('not.exist'));
           });
       });
-    }
 
-    function updateFromListViewTests() {
-      describe('list view multi-update', () => {
-        it.skip('shows only the fields commonly updatable across all selected items', () => {
-          // TODO: Setup access control so that it's something like this:
-          //
-          // | Is Updatable | foo | bar | zip |
-          // |--------------|-----|-----|-----|
-          // | Item 1       |  ✓  |     |  ✓  |
-          // | Item 2       |     |  ✓  |  ✓  |
-          //
-          // And check that the updatable fields are the intersection (ie; only
-          // 'zip' in this case)
-        });
-      });
-    }
-
-    describe(`static on ${staticList}`, () => {
-      updateTests(staticList);
-      updateFromListViewTests(staticList);
-    });
-
-    describe(`imperative on ${imperativeList}`, () => {
-      updateTests(imperativeList);
       updateFromListViewTests(imperativeList);
     });
   });


### PR DESCRIPTION
For example;

```javascript
keystone.createList('Post', {
  fields: {
    name:  { type: Text },
    slug: { type: Slug, from: 'name' },
    createdAt: {
      type: DateTime,
      defaultValue: () => new Date().toISOString(),
      access: {
        create: false,
        read: true,
        update: false,
      }
    }
  }
});
```

Will show the `createdAt` field in the list view as a column, but will not show the field in either the create modals or the item details form.

NOTE: As a future enhancement, we should show the field in the item details form, but with a "read only" view.

<img width="1074" alt="Screen Shot 2019-08-23 at 9 11 29 am" src="https://user-images.githubusercontent.com/612020/63555877-07e13500-c586-11e9-998d-192afa21acb4.png">
<img width="628" alt="Screen Shot 2019-08-23 at 9 10 49 am" src="https://user-images.githubusercontent.com/612020/63555880-0c0d5280-c586-11e9-9b79-60945f50409f.png">
<img width="727" alt="Screen Shot 2019-08-23 at 9 16 49 am" src="https://user-images.githubusercontent.com/612020/63556081-c604be80-c586-11e9-820a-3d9185515414.png">
