### PR TITLE
Prefill nested creates for Relationship fields with back references

### DIFF
--- a/.changeset/soft-snails-remember/changes.json
+++ b/.changeset/soft-snails-remember/changes.json
@@ -1,0 +1,7 @@
+{
+  "releases": [
+    { "name": "@keystone-alpha/app-admin-ui", "type": "minor" },
+    { "name": "@keystone-alpha/fields", "type": "minor" }
+  ],
+  "dependents": []
+}

--- a/.changeset/soft-snails-remember/changes.md
+++ b/.changeset/soft-snails-remember/changes.md
@@ -1,0 +1,1 @@
+Prefill nested creates for Relationship fields with back referennces

--- a/packages/app-admin-ui/client/classes/List.js
+++ b/packages/app-admin-ui/client/classes/List.js
@@ -115,13 +115,13 @@ export default class List {
     return `${this.gqlNames.listQueryMetaName}${metaQueryArgs} { count }`;
   }
 
-  getInitialItemData({ originalInput = {} } = {}) {
+  getInitialItemData({ originalInput = {}, prefill = {} } = {}) {
     return this.fields
       .filter(({ isPrimaryKey }) => !isPrimaryKey)
       .reduce(
         (memo, field) => ({
           ...memo,
-          [field.path]: field.getDefaultValue({ originalInput }),
+          [field.path]: field.getDefaultValue({ originalInput, prefill }),
         }),
         {}
       );

--- a/packages/app-admin-ui/client/components/CreateItemModal.js
+++ b/packages/app-admin-ui/client/components/CreateItemModal.js
@@ -17,8 +17,8 @@ let Render = ({ children }) => children();
 class CreateItemModal extends Component {
   constructor(props) {
     super(props);
-    const { list } = props;
-    const item = list.getInitialItemData();
+    const { list, prefillData } = props;
+    const item = list.getInitialItemData({ prefill: prefillData });
     const validationErrors = {};
     const validationWarnings = {};
 

--- a/packages/app-admin-ui/client/pages/Item/index.js
+++ b/packages/app-admin-ui/client/pages/Item/index.js
@@ -311,13 +311,14 @@ const ItemDetails = withRouter(
                           <Field
                             autoFocus={!i}
                             field={field}
+                            list={list}
+                            item={item}
                             errors={[
                               ...(itemErrors[field.path] ? [itemErrors[field.path]] : []),
                               ...(validationErrors[field.path] || []),
                             ]}
                             warnings={validationWarnings[field.path] || []}
                             value={item[field.path]}
-                            itemId={item.id}
                             savedValue={savedData[field.path]}
                             onChange={onChange}
                             renderContext="page"
@@ -326,6 +327,7 @@ const ItemDetails = withRouter(
                         [
                           i,
                           field,
+                          list,
                           itemErrors[field.path],
                           item[field.path],
                           item.id,

--- a/packages/fields/src/Controller.js
+++ b/packages/fields/src/Controller.js
@@ -14,13 +14,13 @@ export default class FieldController {
 
     if ('defaultValue' in config) {
       if (typeof config.defaultValue !== 'function') {
-        this._getDefaultValue = () => config.defaultValue;
+        this._getDefaultValue = ({ prefill }) => prefill[this.path] || config.defaultValue;
       } else {
         this._getDefaultValue = config.defaultValue;
       }
     } else {
       // By default, the default value is undefined
-      this._getDefaultValue = () => undefined;
+      this._getDefaultValue = ({ prefill }) => prefill[this.path] || undefined;
     }
   }
 
@@ -92,8 +92,8 @@ export default class FieldController {
     !isEqual(initialData[this.path], currentData[this.path]);
 
   // eslint-disable-next-line no-unused-vars
-  getDefaultValue = ({ originalInput = {} } = {}) => {
-    return this._getDefaultValue({ originalInput });
+  getDefaultValue = ({ originalInput = {}, prefill = {} } = {}) => {
+    return this._getDefaultValue({ originalInput, prefill });
   };
 
   initCellView = () => {

--- a/packages/fields/src/types/Relationship/views/CreateItemModal.js
+++ b/packages/fields/src/types/Relationship/views/CreateItemModal.js
@@ -29,8 +29,8 @@ let Render = ({ children }) => children();
 class CreateItemModal extends Component {
   constructor(props) {
     super(props);
-    const { list } = props;
-    const item = list.getInitialItemData();
+    const { list, prefillData = {} } = props;
+    const item = list.getInitialItemData({ prefill: prefillData });
     const validationErrors = {};
     const validationWarnings = {};
 

--- a/packages/fields/tests/Controller.test.js
+++ b/packages/fields/tests/Controller.test.js
@@ -102,10 +102,11 @@ describe('getDefaultValue()', () => {
 
     test('receives expected paramaters', () => {
       const originalInput = {};
+      const prefill = {};
       const defaultValue = jest.fn(() => 'default');
       const controller = new FieldController({ ...config, defaultValue }, 'list', 'adminMeta');
-      controller.getDefaultValue({ originalInput });
-      expect(defaultValue).toHaveBeenCalledWith({ originalInput });
+      controller.getDefaultValue({ originalInput, prefill });
+      expect(defaultValue).toHaveBeenCalledWith({ originalInput, prefill });
     });
   });
 });


### PR DESCRIPTION
Let's say you've got two lists:

```javascript
keystone.createList('Post', {
  fields: {
    title: { type: Text },
    slug: { type: Slug, from: 'title' },
    categories: {
      type: Relationship,
      ref: 'PostCategory',
      many: true,
    },
  },
});

keystone.createList('PostCategory', {
  fields: {
    name: { type: Text },
    slug: { type: Slug, from: 'name' },
    posts: {
      type: Relationship,
      ref: 'Post.categories',
      many: true,
    },
  },
});
```

Notice that `PostCategory.posts` has a back reference to `Post.categories`.

Now if we go to the `Post` list, and click the `+` next to `Post.categories`, when the create modal appears, it will have its `posts` field prefilled with a back reference to the current `Post` we're on.

![auto-back-links](https://user-images.githubusercontent.com/612020/63564781-cbbfcb80-c5a9-11e9-92f2-77d0cf77c779.gif)