### PR TITLE
CloudinaryImage & File fields no longer lose their value during update mutations

### DIFF
--- a/.changeset/nice-singers-look/changes.json
+++ b/.changeset/nice-singers-look/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/fields", "type": "patch" }], "dependents": [] }

--- a/.changeset/nice-singers-look/changes.md
+++ b/.changeset/nice-singers-look/changes.md
@@ -1,0 +1,1 @@
+CloudinaryImage & File fields no longer lose their value during update mutations

--- a/packages/fields/src/types/File/Implementation.js
+++ b/packages/fields/src/types/File/Implementation.js
@@ -78,9 +78,19 @@ export class File extends Implementation {
   async resolveInput({ resolvedData, existingItem }) {
     const previousData = existingItem && existingItem[this.path];
     const uploadData = resolvedData[this.path];
-    // TODO: FIXME: Handle when uploadData is null. Can happen when:
-    // Deleting the file
-    if (!uploadData) {
+
+    // NOTE: The following two conditions could easily be combined into a
+    // single `if (!uploadData) return uploadData`, but that would lose the
+    // nuance of returning `undefined` vs `null`.
+    // Premature Optimisers; be ware!
+    if (typeof uploadData === 'undefined') {
+      // Nothing was passed in, so we can bail early.
+      return undefined;
+    }
+
+    if (uploadData === null) {
+      // `null` was specifically uploaded, and we should set the field value to
+      // null. To do that we... return `null`
       return null;
     }
 


### PR DESCRIPTION
A recent change to ensure `resolveInput()` is run on every field every mutation surfaced a known bug where the `File` (and hence the `CloudinaryImage`) type would incorrectly return `null` instead of `undefined`.

ie; Save a cloudinary image, then updating any other fields would cause the cloudinary image to be reset to `null`.

This PR fixes that bug.

**Before**
![image-upload-bug](https://user-images.githubusercontent.com/612020/63587931-938bad80-c5e8-11e9-941a-ebdfc1506909.gif)

**After**
![image-upload-fixed](https://user-images.githubusercontent.com/612020/63587941-99818e80-c5e8-11e9-984b-13e17fc16efb.gif)
