### PR TITLE
Prepare release

### DIFF
--- a/.changeset/nice-singers-look/changes.json
+++ b/.changeset/nice-singers-look/changes.json
@@ -1,1 +1,0 @@
-{ "releases": [{ "name": "@keystone-alpha/fields", "type": "patch" }], "dependents": [] }

--- a/.changeset/nice-singers-look/changes.md
+++ b/.changeset/nice-singers-look/changes.md
@@ -1,1 +1,0 @@
-CloudinaryImage & File fields no longer lose their value during update mutations

--- a/packages/fields/CHANGELOG.md
+++ b/packages/fields/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @keystone-alpha/fields
 
+## 10.6.1
+
+### Patch Changes
+
+- [9c1b1886](https://github.com/keystonejs/keystone-5/commit/9c1b1886): CloudinaryImage & File fields no longer lose their value during update mutations
+
 ## 10.6.0
 
 ### Minor Changes

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keystone-alpha/fields",
   "description": "KeystoneJS Field Types including Text, Password, DateTime, Integer, and more.",
-  "version": "10.6.0",
+  "version": "10.6.1",
   "main": "dist/fields.cjs.js",
   "module": "dist/fields.esm.js",
   "author": "The KeystoneJS Development Team",


### PR DESCRIPTION
## `@keystone-alpha/fields@10.6.1`

### Patch Changes

- [9c1b1886](https://github.com/keystonejs/keystone-5/commit/9c1b1886): CloudinaryImage & File fields no longer lose their value during update mutations