### PR TITLE
Add a keystone.extendGraphQLSchema() method for custom types, queries and mutations.

### DIFF
--- a/.changeset/clean-brooms-tap/changes.json
+++ b/.changeset/clean-brooms-tap/changes.json
@@ -1,0 +1,89 @@
+{
+  "releases": [{ "name": "@keystone-alpha/keystone", "type": "major" }],
+  "dependents": [
+    {
+      "name": "@keystone-alpha/api-tests",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-knex",
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/test-utils",
+        "@keystone-alpha/keystone"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-blog",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-meetup",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-todo",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/adapter-knex",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/adapter-mongoose",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/example-projects-blank",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/example-projects-starter",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/example-projects-todo",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/test-utils",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-knex",
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/keystone"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-access-control",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-basic",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-client-validation",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-login",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-social-login",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    }
+  ]
+}

--- a/.changeset/clean-brooms-tap/changes.md
+++ b/.changeset/clean-brooms-tap/changes.md
@@ -1,0 +1,11 @@
+* Added `keystone.extendGraphQLSchema()` as the interface for custom mutations and queries.
+
+```javascript
+keystone.extendGraphQLSchema({
+  types: ['type Foo { foo: Int }', ...],
+  queries: [{ schema: '...', resolver: () => {} }, ...],
+  mutations: [{ schema: '...', resolver: () => {} }, ...],
+});
+```
+
+ * `new List()` and `keystone.createList()` no longer accept `queries` or `mutations` options! Please use `extendGraphQLSchema()` instead.

--- a/api-tests/extend-graphql-schema/extend-graphql-schema.test.js
+++ b/api-tests/extend-graphql-schema/extend-graphql-schema.test.js
@@ -1,0 +1,74 @@
+const { Text } = require('@keystone-alpha/fields');
+const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystone-alpha/test-utils');
+const cuid = require('cuid');
+
+function setupKeystone(adapterName) {
+  return setupServer({
+    adapterName,
+    name: `ks5-testdb-${cuid()}`,
+    createLists: keystone => {
+      keystone.createList('User', {
+        fields: { name: { type: Text } },
+      });
+      keystone.extendGraphQLSchema({
+        queries: [
+          {
+            schema: 'double(x: Int): Int',
+            resolver: (_, { x }) => 2 * x,
+          },
+        ],
+        mutations: [
+          {
+            schema: 'triple(x: Int): Int',
+            resolver: (_, { x }) => 3 * x,
+          },
+        ],
+      });
+    },
+  });
+}
+multiAdapterRunners().map(({ runner, adapterName }) =>
+  describe(`Adapter: ${adapterName}`, () => {
+    describe('keystone.extendGraphQLSchema()', () => {
+      it(
+        'Executes custom queries correctly',
+        runner(setupKeystone, async ({ keystone }) => {
+          const { data, errors } = await graphqlRequest({
+            keystone,
+            query: `
+              query {
+                double(x: 10)
+              }
+            `,
+          });
+
+          if (errors && errors.length) {
+            throw errors;
+          }
+
+          expect(data.double).toEqual(20);
+        })
+      );
+
+      it(
+        'Executes custom mutations correctly',
+        runner(setupKeystone, async ({ keystone }) => {
+          const { data, errors } = await graphqlRequest({
+            keystone,
+            query: `
+              mutation {
+                triple(x: 10)
+              }
+            `,
+          });
+
+          if (errors && errors.length) {
+            throw errors;
+          }
+
+          expect(data.triple).toEqual(30);
+        })
+      );
+    });
+  })
+);

--- a/docs/api/create-list.md
+++ b/docs/api/create-list.md
@@ -74,12 +74,6 @@ keystone.createList('User',
 })
 ```
 
-### `mutations`
-
-An Array of custom mutations in the form of: `{ schema, resolver }`.
-
-_Note:_ These mutation don't necessarily need to be associated with the list. As a result this API may change in the future.
-
 ### `label`
 
 Overrides label for the list in the AdminUI. Default is `listName`.

--- a/docs/api/keystone.md
+++ b/docs/api/keystone.md
@@ -46,6 +46,26 @@ Registers a new list with Keystone and returns a Keystone list object.
 | listKey | A string representing the name of a list. This should be singular, E.g. 'User' not 'Users' |
 | config  | The list config. See: Creating lists                                                       |
 
+## keystone.extendGraphQLSchema({ types, queries, mutations })
+
+Extends keystones generated schema with custom types, queries, and mutations.
+
+|           |                                                     |
+| --------- | --------------------------------------------------- |
+| types     | A list of strings defining graphQL types.           |
+| queries   | A list of objects of the form { schema, resolver }. |
+| mutations | A list of objects of the form { schema, resolver }. |
+
+The `schema` for both queries and mutations should be a string defining the graphQL schema element for the query/mutation, e.g.
+
+```javascript
+{
+  schema: 'getBestPosts(author: ID!): [Post]';
+}
+```
+
+The `resolver` for both queries and mutations should be a resolver function with the signature `(obj, args, context, info)`. See the [Apollo docs](https://www.apollographql.com/docs/graphql-tools/resolvers/#resolver-function-signature) for more details.
+
 ## keystone.connect()
 
 Manually connect Keystone to the adapters. See Custom Servers.

--- a/packages/keystone/tests/Keystone.test.js
+++ b/packages/keystone/tests/Keystone.test.js
@@ -178,6 +178,78 @@ describe('Keystone.createList()', () => {
   });
 });
 
+describe('Keystone.extendGraphQLSchema()', () => {
+  test('types', () => {
+    const config = {
+      adapter: new MockAdapter(),
+      name: 'Jest Test',
+    };
+    const keystone = new Keystone(config);
+    keystone.createList('User', {
+      fields: {
+        name: { type: MockFieldType },
+        email: { type: MockFieldType },
+      },
+    });
+
+    keystone.extendGraphQLSchema({ types: ['type FooBar { foo: Int, bar: Float }'] });
+    const schema = keystone.getTypeDefs().join('\n');
+    expect(schema.match(/type FooBar {\s*foo: Int\s*bar: Float\s*}/g) || []).toHaveLength(1);
+  });
+
+  test('queries', () => {
+    const config = {
+      adapter: new MockAdapter(),
+      name: 'Jest Test',
+    };
+    const keystone = new Keystone(config);
+    keystone.createList('User', {
+      fields: {
+        name: { type: MockFieldType },
+        email: { type: MockFieldType },
+      },
+    });
+
+    keystone.extendGraphQLSchema({
+      queries: [
+        {
+          schema: 'double(x: Int): Int',
+          resolver: (_, { x }) => 2 * x,
+        },
+      ],
+    });
+    const schema = keystone.getTypeDefs().join('\n');
+    expect(schema.match(/double\(x: Int\): Int/g) || []).toHaveLength(1);
+    expect(keystone._extendedQueries).toHaveLength(1);
+  });
+
+  test('mutations', () => {
+    const config = {
+      adapter: new MockAdapter(),
+      name: 'Jest Test',
+    };
+    const keystone = new Keystone(config);
+    keystone.createList('User', {
+      fields: {
+        name: { type: MockFieldType },
+        email: { type: MockFieldType },
+      },
+    });
+
+    keystone.extendGraphQLSchema({
+      mutations: [
+        {
+          schema: 'double(x: Int): Int',
+          resolver: (_, { x }) => 2 * x,
+        },
+      ],
+    });
+    const schema = keystone.getTypeDefs().join('\n');
+    expect(schema.match(/double\(x: Int\): Int/g) || []).toHaveLength(1);
+    expect(keystone._extendedMutations).toHaveLength(1);
+  });
+});
+
 describe('Keystone.createItems()', () => {
   const lists = {
     User: {


### PR DESCRIPTION
This PR adds a new method for adding custom types, queries and mutations to the graphQL schema.

```javascript
keystone.extendGraphQLSchema({
  types: ['type Foo { foo: Int }', ...],
  queries: [{ schema: '...', resolver: () => {} }, ...],
  mutations: [{ schema: '...', resolver: () => {} }, ...],
});
```

It also removes the `queries` and `mutations` options from the `createList()` API.