### PR TITLE
Prepare release

### DIFF
--- a/.changeset/heavy-dogs-breathe/changes.json
+++ b/.changeset/heavy-dogs-breathe/changes.json
@@ -1,1 +1,0 @@
-{ "releases": [{ "name": "@keystone-alpha/fields", "type": "patch" }], "dependents": [] }

--- a/.changeset/heavy-dogs-breathe/changes.md
+++ b/.changeset/heavy-dogs-breathe/changes.md
@@ -1,1 +1,0 @@
-OEmbed & Unsplash types no longer lose their value on update.

--- a/packages/fields/CHANGELOG.md
+++ b/packages/fields/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @keystone-alpha/fields
 
+## 10.6.2
+
+### Patch Changes
+
+- [4ab3cc38](https://github.com/keystonejs/keystone-5/commit/4ab3cc38): OEmbed & Unsplash types no longer lose their value on update.
+
 ## 10.6.1
 
 ### Patch Changes

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keystone-alpha/fields",
   "description": "KeystoneJS Field Types including Text, Password, DateTime, Integer, and more.",
-  "version": "10.6.1",
+  "version": "10.6.2",
   "main": "dist/fields.cjs.js",
   "module": "dist/fields.esm.js",
   "author": "The KeystoneJS Development Team",


### PR DESCRIPTION
# @keystone-alpha/fields

## 10.6.2

### Patch Changes

- [4ab3cc38](https://github.com/keystonejs/keystone-5/commit/4ab3cc38): OEmbed & Unsplash types no longer lose their value on update.