### PR TITLE
Prepare release

### DIFF
--- a/.changeset/many-needles-breathe/changes.json
+++ b/.changeset/many-needles-breathe/changes.json
@@ -1,1 +1,0 @@
-{ "releases": [{ "name": "@keystone-alpha/auth-passport", "type": "minor" }], "dependents": [] }

--- a/.changeset/many-needles-breathe/changes.md
+++ b/.changeset/many-needles-breathe/changes.md
@@ -1,1 +1,0 @@
-`auth-passport`'s `onAuthenticated` method now receives an `isNewItem` flag to indicate if the user is logging for the first time or not.

--- a/.changeset/tame-tigers-call/changes.json
+++ b/.changeset/tame-tigers-call/changes.json
@@ -1,1 +1,0 @@
-{ "releases": [{ "name": "@keystone-alpha/adapter-knex", "type": "patch" }], "dependents": [] }

--- a/.changeset/tame-tigers-call/changes.md
+++ b/.changeset/tame-tigers-call/changes.md
@@ -1,1 +1,0 @@
-Updates warning message when knex cannot find a database

--- a/packages/adapter-knex/CHANGELOG.md
+++ b/packages/adapter-knex/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @keystone-alpha/adapter-knex
 
+## 4.0.6
+
+### Patch Changes
+
+- [7e280f57](https://github.com/keystonejs/keystone-5/commit/7e280f57): Updates warning message when knex cannot find a database
+
 ## 4.0.5
 
 - Updated dependencies [33001656](https://github.com/keystonejs/keystone-5/commit/33001656):

--- a/packages/adapter-knex/package.json
+++ b/packages/adapter-knex/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keystone-alpha/adapter-knex",
   "description": "KeystoneJS Knex Database Adapter",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "author": "The KeystoneJS Development Team",
   "license": "MIT",
   "engines": {

--- a/packages/auth-passport/CHANGELOG.md
+++ b/packages/auth-passport/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @keystone-alpha/auth-passport
 
+## 3.1.0
+
+### Minor Changes
+
+- [b301fd0f](https://github.com/keystonejs/keystone-5/commit/b301fd0f): `auth-passport`'s `onAuthenticated` method now receives an `isNewItem` flag to indicate if the user is logging for the first time or not.
+
 ## 3.0.0
 
 ### Major Changes

--- a/packages/auth-passport/package.json
+++ b/packages/auth-passport/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keystone-alpha/auth-passport",
   "description": "Provides Social Authentication Strategies based on PassportJS.",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "author": "The KeystoneJS Development Team",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
# @keystone-alpha/adapter-knex

## 4.0.6

### Patch Changes

- [7e280f57](https://github.com/keystonejs/keystone-5/commit/7e280f57): Updates warning message when knex cannot find a database

# @keystone-alpha/auth-passport

## 3.1.0

### Minor Changes

- [b301fd0f](https://github.com/keystonejs/keystone-5/commit/b301fd0f): `auth-passport`'s `onAuthenticated` method now receives an `isNewItem` flag to indicate if the user is logging for the first time or not.