### PR TITLE
 First pass at a Programatic keystone.executeQuery method

### DIFF
--- a/.changeset/odd-days-tie/changes.json
+++ b/.changeset/odd-days-tie/changes.json
@@ -1,0 +1,8 @@
+{
+  "releases": [
+    { "name": "@keystone-alpha/api-tests", "type": "minor" },
+    { "name": "@keystone-alpha/keystone", "type": "minor" },
+    { "name": "@keystone-alpha/test-utils", "type": "minor" }
+  ],
+  "dependents": []
+}

--- a/.changeset/odd-days-tie/changes.md
+++ b/.changeset/odd-days-tie/changes.md
@@ -1,0 +1,1 @@
+Add a `keystone.executeQuery()` method to run GraphQL queries and mutations directly against a Keystone instance. NOTE: These queries are executed without any Access Control checks by default.

--- a/api-tests/queries-access-control/meta.test.js
+++ b/api-tests/queries-access-control/meta.test.js
@@ -10,7 +10,12 @@ function setupKeystone(adapterName) {
       keystone.createList('User', {
         fields: {
           company: { type: Relationship, ref: 'Company' },
-          workHistory: { type: Relationship, ref: 'Company', many: true, access: { read: false } },
+          workHistory: {
+            type: Relationship,
+            ref: 'Company',
+            many: true,
+            access: { read: false },
+          },
           posts: { type: Relationship, ref: 'Post', many: true },
         },
       });

--- a/api-tests/relationships/nested-mutations/create-and-connect-singular.test.js
+++ b/api-tests/relationships/nested-mutations/create-and-connect-singular.test.js
@@ -19,38 +19,6 @@ function setupKeystone(adapterName) {
           group: { type: Relationship, ref: 'Group' },
         },
       });
-
-      keystone.createList('GroupNoRead', {
-        fields: {
-          name: { type: Text },
-        },
-        access: {
-          read: () => false,
-        },
-      });
-
-      keystone.createList('EventToGroupNoRead', {
-        fields: {
-          title: { type: Text },
-          group: { type: Relationship, ref: 'GroupNoRead' },
-        },
-      });
-
-      keystone.createList('GroupNoCreate', {
-        fields: {
-          name: { type: Text },
-        },
-        access: {
-          create: () => false,
-        },
-      });
-
-      keystone.createList('EventToGroupNoCreate', {
-        fields: {
-          title: { type: Text },
-          group: { type: Relationship, ref: 'GroupNoCreate' },
-        },
-      });
     },
   });
 }

--- a/api-tests/relationships/nested-mutations/disconnect-all-many.test.js
+++ b/api-tests/relationships/nested-mutations/disconnect-all-many.test.js
@@ -1,7 +1,12 @@
 const { gen, sampleOne } = require('testcheck');
 const { Text, Relationship } = require('@keystone-alpha/fields');
 const cuid = require('cuid');
-const { setupServer, graphqlRequest, multiAdapterRunners } = require('@keystone-alpha/test-utils');
+const {
+  setupServer,
+  graphqlRequest,
+  multiAdapterRunners,
+  networkedGraphqlRequest,
+} = require('@keystone-alpha/test-utils');
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
@@ -144,7 +149,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       describe('read: false on related list', () => {
         test(
           'has no effect when specifying disconnectAll',
-          runner(setupKeystone, async ({ keystone, create, findById }) => {
+          runner(setupKeystone, async ({ app, create, findById }) => {
             const noteContent = sampleOne(alphanumGenerator);
 
             // Create an item to link against
@@ -157,21 +162,21 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             });
 
             // Update the item and link the relationship field
-            const { errors } = await graphqlRequest({
-              keystone,
+            const { errors } = await networkedGraphqlRequest({
+              app,
               query: `
-            mutation {
-              updateUserToNotesNoRead(
-                id: "${createUser.id}"
-                data: {
-                  username: "A thing",
-                  notes: { disconnectAll: true }
+                mutation {
+                  updateUserToNotesNoRead(
+                    id: "${createUser.id}"
+                    data: {
+                      username: "A thing",
+                      notes: { disconnectAll: true }
+                    }
+                  ) {
+                    id
+                  }
                 }
-              ) {
-                id
-              }
-            }
-        `,
+              `,
             });
 
             expect(errors).toBe(undefined);

--- a/api-tests/relationships/nested-mutations/disconnect-all-singular.test.js
+++ b/api-tests/relationships/nested-mutations/disconnect-all-singular.test.js
@@ -1,7 +1,12 @@
 const { gen, sampleOne } = require('testcheck');
 const { Text, Relationship } = require('@keystone-alpha/fields');
 const cuid = require('cuid');
-const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystone-alpha/test-utils');
+const {
+  multiAdapterRunners,
+  setupServer,
+  graphqlRequest,
+  networkedGraphqlRequest,
+} = require('@keystone-alpha/test-utils');
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
@@ -167,7 +172,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       describe('read: false on related list', () => {
         test(
           'has no effect when using disconnectAll',
-          runner(setupKeystone, async ({ keystone, create, findById }) => {
+          runner(setupKeystone, async ({ app, create, findById }) => {
             const groupName = sampleOne(alphanumGenerator);
 
             // Create an item to link against
@@ -183,20 +188,20 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(createEvent.group.toString()).toBe(createGroup.id);
 
             // Update the item and link the relationship field
-            const { errors } = await graphqlRequest({
-              keystone,
+            const { errors } = await networkedGraphqlRequest({
+              app,
               query: `
-          mutation {
-            updateEventToGroupNoRead(
-              id: "${createEvent.id}"
-              data: {
-                group: { disconnectAll: true }
-              }
-            ) {
-              id
-            }
-          }
-      `,
+                mutation {
+                  updateEventToGroupNoRead(
+                    id: "${createEvent.id}"
+                    data: {
+                      group: { disconnectAll: true }
+                    }
+                  ) {
+                    id
+                  }
+                }
+              `,
             });
 
             expect(errors).toBe(undefined);

--- a/api-tests/relationships/nested-mutations/disconnect-many.test.js
+++ b/api-tests/relationships/nested-mutations/disconnect-many.test.js
@@ -1,7 +1,12 @@
 const { gen, sampleOne } = require('testcheck');
 const { Text, Relationship } = require('@keystone-alpha/fields');
 const cuid = require('cuid');
-const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystone-alpha/test-utils');
+const {
+  multiAdapterRunners,
+  setupServer,
+  graphqlRequest,
+  networkedGraphqlRequest,
+} = require('@keystone-alpha/test-utils');
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
@@ -244,7 +249,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       describe('read: false on related list', () => {
         test(
           'has no impact when disconnecting directly with an id',
-          runner(setupKeystone, async ({ keystone, create, findById }) => {
+          runner(setupKeystone, async ({ app, create, findById }) => {
             const noteContent = sampleOne(alphanumGenerator);
 
             // Create an item to link against
@@ -257,21 +262,21 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             });
 
             // Update the item and link the relationship field
-            const { errors } = await graphqlRequest({
-              keystone,
+            const { errors } = await networkedGraphqlRequest({
+              app,
               query: `
-          mutation {
-            updateUserToNotesNoRead(
-              id: "${createUser.id}"
-              data: {
-                username: "A thing",
-                notes: { disconnect: [{ id: "${createNote.id}" }] }
-              }
-            ) {
-              id
-            }
-          }
-      `,
+                mutation {
+                  updateUserToNotesNoRead(
+                    id: "${createUser.id}"
+                    data: {
+                      username: "A thing",
+                      notes: { disconnect: [{ id: "${createNote.id}" }] }
+                    }
+                  ) {
+                    id
+                  }
+                }
+              `,
             });
 
             expect(errors).toBe(undefined);

--- a/api-tests/relationships/nested-mutations/disconnect-singular.test.js
+++ b/api-tests/relationships/nested-mutations/disconnect-singular.test.js
@@ -1,7 +1,12 @@
 const { gen, sampleOne } = require('testcheck');
 const { Text, Relationship } = require('@keystone-alpha/fields');
 const cuid = require('cuid');
-const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystone-alpha/test-utils');
+const {
+  multiAdapterRunners,
+  setupServer,
+  graphqlRequest,
+  networkedGraphqlRequest,
+} = require('@keystone-alpha/test-utils');
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
@@ -211,7 +216,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       describe('read: false on related list', () => {
         test(
           'has no effect when disconnecting a specific id',
-          runner(setupKeystone, async ({ keystone, create, findById }) => {
+          runner(setupKeystone, async ({ app, create, findById }) => {
             const groupName = sampleOne(alphanumGenerator);
 
             // Create an item to link against
@@ -227,20 +232,20 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(createEvent.group.toString()).toBe(createGroup.id);
 
             // Update the item and link the relationship field
-            const { errors } = await graphqlRequest({
-              keystone,
+            const { errors } = await networkedGraphqlRequest({
+              app,
               query: `
-          mutation {
-            updateEventToGroupNoRead(
-              id: "${createEvent.id}"
-              data: {
-                group: { disconnect: { id: "${createGroup.id}" } }
-              }
-            ) {
-              id
-            }
-          }
-      `,
+                mutation {
+                  updateEventToGroupNoRead(
+                    id: "${createEvent.id}"
+                    data: {
+                      group: { disconnect: { id: "${createGroup.id}" } }
+                    }
+                  ) {
+                    id
+                  }
+                }
+              `,
             });
             expect(errors).toBe(undefined);
 

--- a/packages/keystone/README.md
+++ b/packages/keystone/README.md
@@ -188,8 +188,8 @@ Disconnect all adapters.
 Use this method to execute queries or mutations directly against a Keystone
 instance.
 
-> ℹ️ When querying or mutating via `keystone.query`, there are differences to keep
-> in mind:
+> ℹ️ When querying or mutating via `keystone.executeQuery`, there are differences
+> to keep in mind:
 >
 > - No access control checks are run (everything is set to `() => true`)
 > - The `context.req` object is set to `{}` (you can override this if necessary,

--- a/packages/keystone/README.md
+++ b/packages/keystone/README.md
@@ -16,6 +16,7 @@ order: 1
 | `prepare`             | Manually peapare Keystone middlewares.                                       |
 | `createItems`         | Add items to a Keystone list.                                                |
 | `disconnect`          | Disconnect from all adapters.                                                |
+| `executeQuery`        | Run GraphQL queries and mutations directly against a Keystone instance.      |
 
 <!--
 
@@ -181,3 +182,48 @@ See: [Custom Server](https://v5.keystonejs.com/guides/custom-server).
 ## disconnect()
 
 Disconnect all adapters.
+
+## `keystone.executeQuery(queryString, options)`
+
+Use this method to execute queries or mutations directly against a Keystone
+instance.
+
+> ℹ️ When querying or mutating via `keystone.query`, there are differences to keep
+> in mind:
+>
+> - No access control checks are run (everything is set to `() => true`)
+> - The `context.req` object is set to `{}` (you can override this if necessary,
+>   see options below)
+> - Attempting to authenticate will throw errors (due to `req` being mocked)
+
+Returns a Promise representing the result of the given query or mutation.
+
+### `queryString`
+
+A graphQL query string. For example:
+
+```graphql
+query {
+  allTodos {
+    id
+    name
+  }
+}
+```
+
+Can also be a mutation:
+
+```graphql
+mutation newTodo($name: String) {
+  createTodo(name: $name) {
+    id
+  }
+}
+```
+
+### `options`
+
+| Option              | Type      | Default | Description                                                                                                                          |
+| ------------------- | --------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `variables`         | `Object`  | `{}`    | The variables passed to the graphql query for the given queryString.                                                                 |
+| `context`           | `Object`  | `{}`    | Override the default `context` object passed to the GraphQL engine. Useful for adding a `req` or setting the `schemaName`            |

--- a/packages/test-utils/index.js
+++ b/packages/test-utils/index.js
@@ -2,7 +2,14 @@ const {
   setupServer,
   multiAdapterRunners,
   graphqlRequest,
+  networkedGraphqlRequest,
   matchFilter,
 } = require('./lib/test-utils');
 
-module.exports = { setupServer, multiAdapterRunners, graphqlRequest, matchFilter };
+module.exports = {
+  setupServer,
+  multiAdapterRunners,
+  graphqlRequest,
+  networkedGraphqlRequest,
+  matchFilter,
+};

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -10,9 +10,11 @@
   "dependencies": {
     "@keystone-alpha/adapter-knex": "^4.0.5",
     "@keystone-alpha/adapter-mongoose": "^4.0.3",
-    "@keystone-alpha/keystone": "^12.0.0",
     "@keystone-alpha/app-graphql": "^6.3.1",
+    "@keystone-alpha/keystone": "^12.0.0",
+    "express": "^4.17.1",
     "mongodb-memory-server": "^5.1.5",
-    "p-finally": "^2.0.1"
+    "p-finally": "^2.0.1",
+    "supertest-light": "^1.0.2"
   }
 }


### PR DESCRIPTION
Synthesising a bunch of discussions from #1275 & #1091, I've attempted to implement a `keystone.executeQuery` method which takes into account as much of the possible use-cases I can think of.

What do you think?

From the docs:

## `keystone.executeQuery(queryString, options)`

Use this method to execute queries or mutations directly against a Keystone
instance.

> ℹ️ When querying or mutating via `keystone.query`, there are differences to keep
in mind:
> - No access control checks are run (everything is set to `() => true`)
> - The `context.req` object is set to `{}` (you can override this if necessary,
  see options below)
> - Attempting to authenticate will throw errors (due to `req` being mocked)

Returns a Promise representing the result of the given query or mutation.

### `queryString`

A graphQL query string. For example:

```graphql
query {
  allTodos {
    id
    name
  }
}
```

Can also be a mutation:

```graphql
mutation newTodo($name: String) {
  createTodo(name: $name) {
    id
  }
}
```

### `options`

| Option    | Type     | Default | Description                                                            |
| --------- | -------- | ------- | ---------------------------------------------------------------------- |
| `variables` | `Object` | `{}`  | The variables passed to the graphql query for the given queryString. |
| `context` | `Object` | `{}`  | Override the default `context` object passed to the GraphQL engine. Useful for adding a `req` or setting the `schemaName` |

---

**Todo**:
- [x] ~Get tests passing~
- [x] ~Split into logical PR chunks~
- [x] ~Add tests for new method(s)~
- [x] ~Add a changeset~
- [x] ~Move PR out of draft~