### PR TITLE
Move Session handling logic from graphQL app to keystone package

### DIFF
--- a/.changeset/kind-gorillas-work/changes.json
+++ b/.changeset/kind-gorillas-work/changes.json
@@ -1,0 +1,131 @@
+{
+  "releases": [
+    { "name": "@keystone-alpha/app-graphql", "type": "major" },
+    { "name": "@keystone-alpha/auth-passport", "type": "major" },
+    { "name": "@keystone-alpha/keystone", "type": "major" },
+    { "name": "@keystone-alpha/cypress-project-social-login", "type": "patch" }
+  ],
+  "dependents": [
+    {
+      "name": "@keystone-alpha/api-tests",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/test-utils",
+        "@keystone-alpha/adapter-knex",
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/app-graphql",
+        "@keystone-alpha/keystone"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-blog",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/app-graphql",
+        "@keystone-alpha/keystone"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-meetup",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/app-graphql",
+        "@keystone-alpha/keystone"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-todo",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/app-graphql",
+        "@keystone-alpha/keystone"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/example-projects-blank",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/app-graphql",
+        "@keystone-alpha/keystone"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/example-projects-starter",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/app-graphql",
+        "@keystone-alpha/keystone"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/example-projects-todo",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/app-graphql",
+        "@keystone-alpha/keystone"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/test-utils",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-knex",
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/app-graphql",
+        "@keystone-alpha/keystone"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-access-control",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/app-graphql",
+        "@keystone-alpha/keystone"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-basic",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/app-graphql",
+        "@keystone-alpha/keystone"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-client-validation",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/app-graphql",
+        "@keystone-alpha/keystone"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-login",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/app-graphql",
+        "@keystone-alpha/keystone"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/adapter-knex",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/adapter-mongoose",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/keystone"]
+    }
+  ]
+}

--- a/.changeset/kind-gorillas-work/changes.md
+++ b/.changeset/kind-gorillas-work/changes.md
@@ -1,0 +1,1 @@
+`cookieSecret` and `sessionStore` config options are now passed to the `Keystone` constructor instead of the individual auth or graphql packages.

--- a/packages/app-graphql/lib/apolloServer.js
+++ b/packages/app-graphql/lib/apolloServer.js
@@ -6,7 +6,6 @@ const StackUtils = require('stack-utils');
 const cuid = require('cuid');
 const { omit } = require('@keystone-alpha/utils');
 const { logger } = require('@keystone-alpha/logger');
-const { startAuthedSession, endAuthedSession } = require('@keystone-alpha/session');
 
 const { NestedError } = require('./graphqlErrors');
 
@@ -140,7 +139,7 @@ const _formatError = error => {
   }
 };
 
-function createApolloServer(keystone, apolloConfig, schemaName, dev, cookieSecret) {
+function createApolloServer(keystone, apolloConfig, schemaName, dev) {
   // add the Admin GraphQL API
   const server = new ApolloServer({
     maxFileSize: 200 * 1024 * 1024,
@@ -148,10 +147,7 @@ function createApolloServer(keystone, apolloConfig, schemaName, dev, cookieSecre
     ...apolloConfig,
     ...keystone.getAdminSchema(),
     context: ({ req }) => ({
-      startAuthedSession: ({ item, list }, audiences) =>
-        startAuthedSession(req, { item, list }, audiences, cookieSecret),
-      endAuthedSession: endAuthedSession.bind(null, req),
-      ...keystone.getAccessContext(schemaName, req),
+      ...keystone.getGraphQlContext({ schemaName, req }),
       req,
     }),
     ...(process.env.ENGINE_API_KEY

--- a/packages/app-graphql/package.json
+++ b/packages/app-graphql/package.json
@@ -24,7 +24,7 @@
     "falsey": "^1.0.0",
     "graphql": "^14.4.2",
     "graphql-tag": "^2.10.1",
-    "lodash.flattendeep": "^4.4.0",
+    "nanoassert": "^2.0.0",
     "object-hash": "^1.3.1",
     "serialize-error": "^3.0.0",
     "stack-utils": "^1.0.2",

--- a/packages/auth-passport/lib/Passport.js
+++ b/packages/auth-passport/lib/Passport.js
@@ -39,7 +39,10 @@ class PassportAuthStrategy {
     assert(!!config.hostURL, 'Must provide `config.hostURL` option.');
     assert(!!config.loginPath, 'Must provide `config.loginPath` option.');
     assert(!!config.idField, 'Must provide `config.idField` option.');
-    assert(!!config.cookieSecret, 'Must provide `config.cookieSecret` option.');
+    assert(
+      typeof config.cookieSecret !== 'undefined',
+      'The `cookieSecret` config option for `PassportAuthStrategy` has been moved to the `Keystone` constructor: `new Keystone({ cookieSecret: "abc" })`.'
+    );
     assert(
       ['function', 'undefined'].includes(typeof config.resolveCreateData),
       'When `config.resolveCreateData` is passed, it must be a function.'
@@ -67,13 +70,13 @@ class PassportAuthStrategy {
     this._keystone = keystone;
     this._listKey = listKey;
     this._ServiceStrategy = ServiceStrategy;
+    this._cookieSecret = keystone.getCookieSecret();
 
     // Pull all the required data off the `config` object
     this._apiPath = config.apiPath;
     this._serviceAppId = config.appId;
     this._serviceAppSecret = config.appSecret;
     this._hostURL = config.hostURL;
-    this._cookieSecret = config.cookieSecret;
     this._loginPath = config.loginPath;
     this._loginPathMiddleware = config.loginPathMiddleware || ((req, res, next) => next());
     this._callbackPath = config.callbackPath;

--- a/packages/test-utils/lib/test-utils.js
+++ b/packages/test-utils/lib/test-utils.js
@@ -35,7 +35,10 @@ function setupServer({ name, adapterName, createLists = () => {}, createApps, ke
 }
 
 function graphqlRequest({ keystone, query }) {
-  return keystone._graphQLQuery[SCHEMA_NAME](query, keystone.getAccessContext(SCHEMA_NAME, {}));
+  return keystone._graphQLQuery[SCHEMA_NAME](
+    query,
+    keystone.getGraphQlContext({ schemaName: SCHEMA_NAME })
+  );
 }
 
 // One instance per node.js thread which cleans itself up when the main process

--- a/test-projects/social-login/index.js
+++ b/test-projects/social-login/index.js
@@ -25,6 +25,7 @@ const { MongooseAdapter } = require('@keystone-alpha/adapter-mongoose');
 const keystone = new Keystone({
   name: 'Cypress Test for Social Login',
   adapter: new MongooseAdapter(),
+  cookieSecret,
 });
 
 // eslint-disable-next-line no-unused-vars
@@ -150,7 +151,7 @@ keystone.createList('PostCategory', {
 module.exports = {
   keystone,
   apps: [
-    new GraphQLApp({ cookieSecret }),
+    new GraphQLApp(),
     new StaticApp({ path: staticRoute, src: staticPath }),
     new AdminUIApp({ authStrategy: DISABLE_AUTH ? undefined : authStrategy }),
   ],

--- a/test-projects/social-login/server.js
+++ b/test-projects/social-login/server.js
@@ -8,7 +8,7 @@ const {
 } = require('@keystone-alpha/auth-passport');
 
 const { keystone, apps } = require('./index');
-const { google, facebook, twitter, github, hostURL, port, cookieSecret } = require('./config');
+const { google, facebook, twitter, github, hostURL, port } = require('./config');
 const initialData = require('./data');
 
 let googleStrategy;
@@ -20,7 +20,6 @@ if (google) {
       idField: 'googleId',
       appId: google.appId,
       appSecret: google.appSecret,
-      cookieSecret,
       apiPath: '/admin/api',
       hostURL,
       loginPath: '/auth/google',
@@ -103,7 +102,6 @@ if (facebook) {
       idField: 'facebookId',
       appId: facebook.appId,
       appSecret: facebook.appSecret,
-      cookieSecret,
       apiPath: '/admin/api',
       hostURL,
       loginPath: '/auth/facebook',
@@ -147,7 +145,6 @@ if (twitter) {
       idField: 'twitterId',
       appId: twitter.appId,
       appSecret: twitter.appSecret,
-      cookieSecret,
       apiPath: '/admin/api',
       hostURL,
       loginPath: '/auth/twitter',
@@ -178,7 +175,6 @@ if (github) {
       idField: 'githubId',
       appId: github.appId,
       appSecret: github.appSecret,
-      cookieSecret,
       apiPath: '/admin/api',
       hostURL,
       loginPath: '/auth/github',


### PR DESCRIPTION
This change is for 2 reasons:

1. Sessions are a Keystone-wide thing, and should be handled as such. We're already treating all the other sesssion/auth stuff as a Keystone-wide thing, so no the session middlewares are too.
2. It's needed for https://github.com/keystonejs/keystone-5/pull/1557