### PR TITLE
Prepare release

### DIFF
--- a/.changeset/hungry-dryers-push/changes.json
+++ b/.changeset/hungry-dryers-push/changes.json
@@ -1,1 +1,0 @@
-{ "releases": [{ "name": "@keystone-alpha/auth-passport", "type": "patch" }], "dependents": [] }

--- a/.changeset/hungry-dryers-push/changes.md
+++ b/.changeset/hungry-dryers-push/changes.md
@@ -1,1 +1,0 @@
-Fix assertion logic of cookieSecret deprecation message

--- a/packages/auth-passport/CHANGELOG.md
+++ b/packages/auth-passport/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @keystone-alpha/auth-passport
 
+## 4.0.1
+
+### Patch Changes
+
+- [12668191](https://github.com/keystonejs/keystone-5/commit/12668191): Fix assertion logic of cookieSecret deprecation message
+
 ## 4.0.0
 
 ### Major Changes

--- a/packages/auth-passport/package.json
+++ b/packages/auth-passport/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keystone-alpha/auth-passport",
   "description": "Provides Social Authentication Strategies based on PassportJS.",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "author": "The KeystoneJS Development Team",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
## `@keystone-alpha/auth-passport@4.0.1`

### Bug fixes

- [12668191](https://github.com/keystonejs/keystone-5/commit/12668191): Fix assertion logic of cookieSecret deprecation message