### PR TITLE
Remove `hostURL` and `apiPath` options from `PassportAuthStrategy` constructor

### DIFF
--- a/.changeset/shy-horses-repair/changes.json
+++ b/.changeset/shy-horses-repair/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/auth-passport", "type": "minor" }], "dependents": [] }

--- a/.changeset/shy-horses-repair/changes.md
+++ b/.changeset/shy-horses-repair/changes.md
@@ -1,0 +1,1 @@
+Remove unnecessary `hostURL` and `apiPath` options from `PassportAuthStrategy` constructor thanks to usage of the new `keystone.executeQuery()` internally.

--- a/package.json
+++ b/package.json
@@ -138,7 +138,6 @@
     "get-selection-range": "^0.1.0",
     "globby": "^9.1.0",
     "graphql": "^14.4.2",
-    "graphql-request": "^1.8.2",
     "graphql-tag": "^2.10.1",
     "graphql-type-json": "^0.2.1",
     "gray-matter": "^4.0.2",

--- a/packages/auth-passport/README.md
+++ b/packages/auth-passport/README.md
@@ -100,6 +100,7 @@ const cookieSecret = '<Something super secret>';
 const keystone = new Keystone({
   name: 'Login With Google Example',
   adapter: new MongooseAdapter(),
+  cookieSecret,
 });
 
 keystone.createList('User', {
@@ -120,9 +121,6 @@ const googleStrategy = keystone.createAuthStrategy({
     idField: 'googleId',
     appId: '<Your Google App Id>',
     appSecret: '<Your Google App Secret>',
-    cookieSecret,
-    hostURL: 'http://localhost:3000',
-    apiPath: '/admin/api',
     loginPath: '/auth/google',
     callbackPath: '/auth/google/callback',
 
@@ -147,7 +145,7 @@ const googleStrategy = keystone.createAuthStrategy({
 
 module.exports = {
   keystone,
-  apps: [new GraphQLApp({ cookieSecret }), new AdminUIApp()],
+  apps: [new GraphQLApp(), new AdminUIApp()],
 };
 ```
 
@@ -178,6 +176,7 @@ const cookieSecret = '<Something super secret>';
 const keystone = new Keystone({
   name: 'Login With Google Example',
   adapter: new MongooseAdapter(),
+  cookieSecret,
 });
 
 keystone.createList('User', {
@@ -198,9 +197,6 @@ const googleStrategy = keystone.createAuthStrategy({
     idField: 'googleId',
     appId: '<Your Google App Id>',
     appSecret: '<Your Google App Secret>',
-    cookieSecret,
-    hostURL: 'http://localhost:3000',
-    apiPath: '/admin/api',
     loginPath: '/auth/google',
     callbackPath: '/auth/google/callback',
 
@@ -256,7 +252,7 @@ const googleStrategy = keystone.createAuthStrategy({
 
 keystone
   .prepare({
-    apps: [new GraphQLApp({ cookieSecret }), new AdminUIApp()],
+    apps: [new GraphQLApp(), new AdminUIApp()],
     dev: process.env.NODE_ENV !== 'production',
   })
   .then(async ({ middlewares }) => {

--- a/packages/auth-passport/package.json
+++ b/packages/auth-passport/package.json
@@ -11,7 +11,6 @@
     "@keystone-alpha/fields": "^10.4.0",
     "@keystone-alpha/session": "^2.0.1",
     "express": "^4.17.1",
-    "graphql-request": "^1.8.2",
     "nanoassert": "^2.0.0",
     "passport": "^0.4.0",
     "passport-facebook": "^3.0.0",

--- a/test-projects/social-login/config.js
+++ b/test-projects/social-login/config.js
@@ -1,7 +1,6 @@
 const path = require('path');
 
 exports.port = process.env.PORT || 3000;
-exports.hostURL = process.env.HOST_URL || `http://localhost:${exports.port}`;
 
 exports.facebook = process.env.FACEBOOK_APP_ID &&
   process.env.FACEBOOK_APP_SECRET && {

--- a/test-projects/social-login/index.js
+++ b/test-projects/social-login/index.js
@@ -75,18 +75,33 @@ keystone.createList('User', {
       },
     },
     // TODO: Create a Facebook field type to encapsulate these
-    facebookId: { type: Text },
+    facebookId: {
+      type: Text,
+      access: ({ authentication: { item: user } }) => !!user && !!user.isAdmin,
+    },
     // TODO: Create a GitHub field type to encapsulate these
-    githubId: { type: Text },
+    githubId: {
+      type: Text,
+      access: ({ authentication: { item: user } }) => !!user && !!user.isAdmin,
+    },
 
     // TODO: Create a Twitter field type to encapsulate these
-    twitterId: { type: Text },
+    twitterId: {
+      type: Text,
+      access: ({ authentication: { item: user } }) => !!user && !!user.isAdmin,
+    },
 
     // TODO: Create a Google field type to encapsulate these
-    googleId: { type: Text },
+    googleId: {
+      type: Text,
+      access: ({ authentication: { item: user } }) => !!user && !!user.isAdmin,
+    },
 
     // TODO: Create a WordPress field type to encapsulate these
-    wordpressId: { type: Text },
+    wordpressId: {
+      type: Text,
+      access: ({ authentication: { item: user } }) => !!user && !!user.isAdmin,
+    },
 
     isAdmin: { type: Checkbox },
     company: {

--- a/test-projects/social-login/server.js
+++ b/test-projects/social-login/server.js
@@ -8,7 +8,7 @@ const {
 } = require('@keystone-alpha/auth-passport');
 
 const { keystone, apps } = require('./index');
-const { google, facebook, twitter, github, hostURL, port } = require('./config');
+const { google, facebook, twitter, github, port } = require('./config');
 const initialData = require('./data');
 
 let googleStrategy;
@@ -20,8 +20,6 @@ if (google) {
       idField: 'googleId',
       appId: google.appId,
       appSecret: google.appSecret,
-      apiPath: '/admin/api',
-      hostURL,
       loginPath: '/auth/google',
       callbackPath: '/auth/google/callback',
 
@@ -102,8 +100,6 @@ if (facebook) {
       idField: 'facebookId',
       appId: facebook.appId,
       appSecret: facebook.appSecret,
-      apiPath: '/admin/api',
-      hostURL,
       loginPath: '/auth/facebook',
       callbackPath: '/auth/facebook/callback',
       // Called when there's no existing user for the given googleId
@@ -145,8 +141,6 @@ if (twitter) {
       idField: 'twitterId',
       appId: twitter.appId,
       appSecret: twitter.appSecret,
-      apiPath: '/admin/api',
-      hostURL,
       loginPath: '/auth/twitter',
       callbackPath: '/auth/twitter/callback',
       resolveCreateData: ({ createData, serviceProfile }) => {
@@ -175,8 +169,6 @@ if (github) {
       idField: 'githubId',
       appId: github.appId,
       appSecret: github.appSecret,
-      apiPath: '/admin/api',
-      hostURL,
       loginPath: '/auth/github',
       callbackPath: '/auth/github/callback',
       resolveCreateData: ({ createData, serviceProfile }) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10984,7 +10984,7 @@ graphql-playground-middleware-express@^1.7.10:
   dependencies:
     graphql-playground-html "1.6.12"
 
-graphql-request@^1.5.0, graphql-request@^1.8.2:
+graphql-request@^1.5.0:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-1.8.2.tgz#398d10ae15c585676741bde3fc01d5ca948f8fbe"
   integrity sha512-dDX2M+VMsxXFCmUX0Vo0TopIZIX4ggzOtiCsThgtrKR4niiaagsGTDIHj3fsOMFETpa064vzovI+4YV4QnMbcg==


### PR DESCRIPTION
Thanks to usage of the new `keystone.executeQuery()` internally.

I've tested this against the `test-projects/social-auth`, and it all works great 👍 

You'll notice I've added access control checks in the test project. These checks would previously cause the social sign in flow to error out because it made a networked graphQL request as an anonymous user 😱  Now it hits `keystone.executeQuery` directly, so doesn't get blocked by Access Control 👍 