### PR TITLE
Prepare release

### DIFF
--- a/.changeset/shy-horses-repair/changes.json
+++ b/.changeset/shy-horses-repair/changes.json
@@ -1,1 +1,0 @@
-{ "releases": [{ "name": "@keystone-alpha/auth-passport", "type": "minor" }], "dependents": [] }

--- a/.changeset/shy-horses-repair/changes.md
+++ b/.changeset/shy-horses-repair/changes.md
@@ -1,1 +1,0 @@
-Remove unnecessary `hostURL` and `apiPath` options from `PassportAuthStrategy` constructor thanks to usage of the new `keystone.executeQuery()` internally.

--- a/packages/auth-passport/CHANGELOG.md
+++ b/packages/auth-passport/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @keystone-alpha/auth-passport
 
+## 4.1.0
+
+### Minor Changes
+
+- [b08c499e](https://github.com/keystonejs/keystone-5/commit/b08c499e): Remove unnecessary `hostURL` and `apiPath` options from `PassportAuthStrategy` constructor thanks to usage of the new `keystone.executeQuery()` internally.
+
 ## 4.0.1
 
 ### Patch Changes

--- a/packages/auth-passport/package.json
+++ b/packages/auth-passport/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keystone-alpha/auth-passport",
   "description": "Provides Social Authentication Strategies based on PassportJS.",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "author": "The KeystoneJS Development Team",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
## `@keystone-alpha/auth-passport@4.1.0`

### Non-breaking additions:

- [b08c499e](https://github.com/keystonejs/keystone-5/commit/b08c499e): Remove unnecessary `hostURL` and `apiPath` options from `PassportAuthStrategy` constructor thanks to usage of the new `keystone.executeQuery()` internally.

![Screen Shot 2019-09-02 at 12 58 47 pm](https://user-images.githubusercontent.com/612020/64088849-b6575800-cd86-11e9-8faa-e3914781e662.png)
