### PR TITLE
[RFC] Password Auth identity filtering

### DIFF
--- a/.changeset/giant-readers-argue/changes.json
+++ b/.changeset/giant-readers-argue/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/auth-password", "type": "minor" }], "dependents": [] }

--- a/.changeset/giant-readers-argue/changes.md
+++ b/.changeset/giant-readers-argue/changes.md
@@ -6,8 +6,10 @@ The `identityFilter` has been added to configurations options:
 const authStrategy = keystone.createAuthStrategy({
   type: PasswordAuthStrategy,
   list: 'User',
-  identityFilter: ({ identityField, identity }) => ({
-    AND: [{ [identityField]: identity }, { isAdmin: true }],
-  }),
+  config: {
+    identityFilter: ({ identityField, identity }) => ({
+      AND: [{ [identityField]: identity }, { isAdmin: true }],
+    }),
+  },
 });
 ```

--- a/.changeset/giant-readers-argue/changes.md
+++ b/.changeset/giant-readers-argue/changes.md
@@ -1,0 +1,13 @@
+Adds the ability to filter users before authentication. 
+
+The `identityFilter` has been added to configurations options:
+
+```javascript
+const authStrategy = keystone.createAuthStrategy({
+  type: PasswordAuthStrategy,
+  list: 'User',
+  identityFilter: ({ identityField, identity }) => ({
+    AND: [{ [identityField]: identity }, { isAdmin: true }],
+  }),
+});
+```

--- a/packages/auth-password/README.md
+++ b/packages/auth-password/README.md
@@ -138,8 +138,10 @@ You may wish to modify this if you want to restrict users that can login to the 
 const authStrategy = keystone.createAuthStrategy({
   type: PasswordAuthStrategy,
   list: 'User',
-  identityFilter: ({ identityField, identity }) => ({
-    AND: [{ [identityField]: identity }, { isAdmin: true }],
-  }),
+  config: {
+    identityFilter: ({ identityField, identity }) => ({
+      AND: [{ [identityField]: identity }, { isAdmin: true }],
+    }),
+  },
 });
 ```

--- a/packages/auth-password/README.md
+++ b/packages/auth-password/README.md
@@ -61,11 +61,12 @@ app.post('/admin/signin', async (req, res) => {
 
 ### Config
 
-| Option              | Type      | Default    | Description                                                               |
-| ------------------- | --------- | ---------- | ------------------------------------------------------------------------- |
-| `identity`          | `String`  | `email`    | The field `path` for values that uniquely identifies items                |
-| `secret`            | `String`  | `password` | The field `path` for secret values known only to the authenticating party |
-| `protectIdentities` | `Boolean` | `false`    | Protect identities at the expense of usability                            |
+| Option              | Type       | Default                                 | Description                                                               |
+| ------------------- | ---------- | --------------------------------------- | ------------------------------------------------------------------------- |
+| `identity`          | `String`   | `email`                                 | The field `path` for values that uniquely identifies items                |
+| `secret`            | `String`   | `password`                              | The field `path` for secret values known only to the authenticating party |
+| `protectIdentities` | `Boolean`  | `false`                                 | Protect identities at the expense of usability                            |
+| `identityFilter`    | `Function` | See: (identityFilter)[#identity-filter] | Used to filter matched identities                                         |
 
 #### `identity`
 
@@ -118,3 +119,27 @@ which state:
 
 Efforts are also taken to protect against timing attacks.
 The time spend verifying an actors credentials should be constant-time regardless of the reason for failure.
+
+#### `identityFilter`
+
+A function used to restrict items matched for authentication. The function is passed the `identityField` and `identity` given at login. It should return a Keystone graphQL where statement. The default function for matching items is:
+
+```javascript
+const identityFilter = ({ identityField, identity }) => ({
+  [identityField]: identity,
+});
+```
+
+This returns items where the `identityField` matches the `identity` provided.
+
+You may wish to modify this if you want to restrict users that can login to the AdminUI. This example restricts the authentication strategy to only match admin users:
+
+```javascript
+const authStrategy = keystone.createAuthStrategy({
+  type: PasswordAuthStrategy,
+  list: 'User',
+  identityFilter: ({ identityField, identity }) => ({
+    AND: [{ [identityField]: identity }, { isAdmin: true }],
+  }),
+});
+```

--- a/packages/auth-password/index.js
+++ b/packages/auth-password/index.js
@@ -12,6 +12,9 @@ class PasswordAuthStrategy {
       identityField: 'email',
       secretField: 'password',
       protectIdentities: false,
+      identityFilter: ({ identityField, identity }) => ({
+        [identityField]: identity,
+      }),
       ...config,
     };
   }
@@ -52,8 +55,13 @@ class PasswordAuthStrategy {
       );
     }
 
+    const identityFilter = this.config.identityFilter({
+      identityField,
+      identity,
+    });
+
     // Match by identity
-    const results = await list.adapter.find({ [identityField]: identity });
+    const results = await list.adapter.find(identityFilter);
 
     // If we failed to match an identity and we're protecting existing identities then combat timing
     // attacks by creating an arbitrary hash (should take about as long has comparing an existing one)


### PR DESCRIPTION
This is a pretty simple change and it adds the ability to filter a list to exclude users from authentication.

For example I wanted to restrict users that can login to the AdminUI so I made this `identityFilter`  only try to match admin users:

```javascript
const authStrategy = keystone.createAuthStrategy({
  type: PasswordAuthStrategy,
  list: 'User',
 config: {
   identityFilter: ({ identityField, identity }) => ({
      AND: [{ [identityField]: identity }, { isAdmin: true }],
    })
  }
});
```

Any thoughts