### PR TITLE
Add queryLimits to List API with maxResults config

### DIFF
--- a/.changeset/gold-doors-melt/changes.json
+++ b/.changeset/gold-doors-melt/changes.json
@@ -1,0 +1,7 @@
+{
+  "releases": [
+    { "name": "@keystone-alpha/api-tests", "type": "minor" },
+    { "name": "@keystone-alpha/keystone", "type": "minor" }
+  ],
+  "dependents": []
+}

--- a/.changeset/gold-doors-melt/changes.md
+++ b/.changeset/gold-doors-melt/changes.md
@@ -1,0 +1,1 @@
+Add queryLimits and maxResults to List API

--- a/api-tests/queries/limits.test.js
+++ b/api-tests/queries/limits.test.js
@@ -1,0 +1,269 @@
+const { Integer, Text, Relationship } = require('@keystone-alpha/fields');
+const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystone-alpha/test-utils');
+
+const cuid = require('cuid');
+
+function setupKeystone(adapterName) {
+  return setupServer({
+    adapterName,
+    name: `ks5-testdb-${cuid()}`,
+    createLists: keystone => {
+      keystone.createList('Post', {
+        fields: {
+          title: { type: Text },
+          author: { type: Relationship, ref: 'User', many: true },
+        },
+      });
+
+      keystone.createList('User', {
+        fields: {
+          name: { type: Text },
+          favNumber: { type: Integer },
+        },
+        queryLimits: {
+          maxResults: 2,
+        },
+      });
+    },
+  });
+}
+multiAdapterRunners().map(({ runner, adapterName }) =>
+  describe(`Adapter: ${adapterName}`, () => {
+    describe('maxResults Limit', () => {
+      describe('Basic querying', () => {
+        test(
+          'users',
+          runner(setupKeystone, async ({ keystone, create }) => {
+            await Promise.all([
+              create('User', { name: 'Jess', favNumber: 1 }),
+              create('User', { name: 'Johanna', favNumber: 8 }),
+              create('User', { name: 'Sam', favNumber: 5 }),
+            ]);
+
+            // 2 results is okay
+            let { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
+          query {
+            allUsers(
+              where: { name_contains: "J" },
+              orderBy: "name_ASC",
+            ) {
+              name
+            }
+          }
+      `,
+            });
+
+            expect(errors).toBe(undefined);
+            expect(data).toHaveProperty('allUsers');
+            expect(data.allUsers).toEqual([{ name: 'Jess' }, { name: 'Johanna' }]);
+
+            // No results is okay
+            ({ data, errors } = await graphqlRequest({
+              keystone,
+              query: `
+          query {
+            allUsers(
+              where: { name: "Nope" }
+            ) {
+              name
+            }
+          }
+      `,
+            }));
+
+            expect(errors).toBe(undefined);
+            expect(data).toHaveProperty('allUsers');
+            expect(data.allUsers.length).toEqual(0);
+
+            // This query is only okay because of the "first" parameter
+            ({ data, errors } = await graphqlRequest({
+              keystone,
+              query: `
+          query {
+            allUsers(first: 1) {
+              name
+            }
+          }
+      `,
+            }));
+
+            expect(errors).toBe(undefined);
+            expect(data).toHaveProperty('allUsers');
+            expect(data.allUsers.length).toEqual(1);
+
+            // This query returns too many results
+            ({ data, errors } = await graphqlRequest({
+              keystone,
+              query: `
+          query {
+            allUsers {
+              name
+            }
+          }
+      `,
+            }));
+
+            expect(errors).toMatchObject([{ message: 'Your request exceeded server limits' }]);
+
+            // The query results don't break the limits, but the "first" parameter does
+            ({ data, errors } = await graphqlRequest({
+              keystone,
+              query: `
+          query {
+            allUsers(
+              where: { name: "Nope" },
+              first: 100000
+            ) {
+              name
+            }
+          }
+      `,
+            }));
+
+            expect(errors).toMatchObject([{ message: 'Your request exceeded server limits' }]);
+          })
+        );
+      });
+
+      describe('Relationship querying', () => {
+        test(
+          'posts by user',
+          runner(setupKeystone, async ({ keystone, create }) => {
+            const users = await Promise.all([
+              create('User', { name: 'Jess', favNumber: 1 }),
+              create('User', { name: 'Johanna', favNumber: 8 }),
+              create('User', { name: 'Sam', favNumber: 5 }),
+            ]);
+
+            await Promise.all([
+              create('Post', { author: [users[0].id], title: 'One author' }),
+              create('Post', { author: [users[0].id, users[1].id], title: 'Two authors' }),
+              create('Post', {
+                author: [users[0].id, users[1].id, users[2].id],
+                title: 'Three authors',
+              }),
+            ]);
+
+            // A basic query that should work
+            let { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
+          query {
+            allPosts(
+              where: { title: "One author" },
+            ) {
+              title
+              author {
+                name
+              }
+            }
+          }
+      `,
+            });
+
+            expect(errors).toBe(undefined);
+            expect(data).toHaveProperty('allPosts');
+            expect(data.allPosts).toEqual([
+              {
+                title: 'One author',
+                author: [{ name: 'Jess' }],
+              },
+            ]);
+
+            // Each subquery is within the limit (even though the total isn't)
+            ({ data, errors } = await graphqlRequest({
+              keystone,
+              query: `
+          query {
+            allPosts(
+              where: {
+                OR: [
+                  { title: "One author" },
+                  { title: "Two authors" },
+                ]
+              }
+              orderBy: "title_ASC",
+            ) {
+              title
+              author(orderBy: "name_ASC") {
+                name
+              }
+            }
+          }
+      `,
+            }));
+
+            expect(errors).toBe(undefined);
+            expect(data).toHaveProperty('allPosts');
+            expect(data.allPosts).toEqual([
+              {
+                title: 'One author',
+                author: [{ name: 'Jess' }],
+              },
+              {
+                title: 'Two authors',
+                author: [{ name: 'Jess' }, { name: 'Johanna' }],
+              },
+            ]);
+
+            // This post has too many authors
+            ({ data, errors } = await graphqlRequest({
+              keystone,
+              query: `
+          query {
+            allPosts(
+              where: { title: "Three authors" },
+            ) {
+              title
+              author {
+                name
+              }
+            }
+          }
+      `,
+            }));
+
+            expect(errors).toMatchObject([{ message: 'Your request exceeded server limits' }]);
+
+            // Requesting the too-many-authors post is okay as long as the authors aren't returned
+            ({ data, errors } = await graphqlRequest({
+              keystone,
+              query: `
+          query {
+            allPosts(
+              where: { title: "Three authors" },
+            ) {
+              title
+            }
+          }
+      `,
+            }));
+
+            expect(errors).toBe(undefined);
+            expect(data).toHaveProperty('allPosts');
+            expect(data.allPosts).toEqual([{ title: 'Three authors' }]);
+
+            // Some posts are okay, but one breaks the limit
+            ({ data, errors } = await graphqlRequest({
+              keystone,
+              query: `
+          query {
+            allPosts {
+              title
+              author {
+                name
+              }
+            }
+          }
+      `,
+            }));
+
+            expect(errors).toMatchObject([{ message: 'Your request exceeded server limits' }]);
+          })
+        );
+      });
+    });
+  })
+);

--- a/api-tests/queries/limits.test.js
+++ b/api-tests/queries/limits.test.js
@@ -94,7 +94,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(data.allUsers.length).toEqual(1);
 
             // This query returns too many results
-            ({ data, errors } = await graphqlRequest({
+            ({ errors } = await graphqlRequest({
               keystone,
               query: `
           query {
@@ -108,7 +108,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(errors).toMatchObject([{ message: 'Your request exceeded server limits' }]);
 
             // The query results don't break the limits, but the "first" parameter does
-            ({ data, errors } = await graphqlRequest({
+            ({ errors } = await graphqlRequest({
               keystone,
               query: `
           query {
@@ -209,7 +209,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             ]);
 
             // This post has too many authors
-            ({ data, errors } = await graphqlRequest({
+            ({ errors } = await graphqlRequest({
               keystone,
               query: `
           query {
@@ -246,7 +246,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(data.allPosts).toEqual([{ title: 'Three authors' }]);
 
             // Some posts are okay, but one breaks the limit
-            ({ data, errors } = await graphqlRequest({
+            ({ errors } = await graphqlRequest({
               keystone,
               query: `
           query {

--- a/docs/api/create-list.md
+++ b/docs/api/create-list.md
@@ -290,3 +290,20 @@ keystone.createList('User', {
 ```
 
 This provides a method for packaging features that can be applied to multiple lists.
+
+### `queryLimits`
+
+Configuration for limiting the kinds of queries that can be made against the list, to avoid queries that might overload the server.
+
+- `maxResults`: maximum number of results that can be returned in a query (or subquery)
+
+```javascript
+keystone.createList('Post', {
+  fields: {
+    title: { type: Text },
+  },
+  queryLimits: {
+    maxResults: 100,
+  },
+});
+```

--- a/packages/keystone/lib/List/graphqlErrors.js
+++ b/packages/keystone/lib/List/graphqlErrors.js
@@ -13,4 +13,10 @@ module.exports = {
       showPath: true,
     },
   }),
+  LimitsExceededError: createError('LimitsExceededError', {
+    message: 'Your request exceeded server limits',
+    options: {
+      showPath: true,
+    },
+  }),
 };

--- a/packages/keystone/tests/List.test.js
+++ b/packages/keystone/tests/List.test.js
@@ -103,19 +103,21 @@ class MockListAdapter {
   delete = async id => {
     this.items[id] = undefined;
   };
-  itemsQuery = ({ where: { id_in: ids, id, id_not_in } }) => {
-    return id
-      ? [this.items[id]]
-      : ids.filter(i => !id_not_in || !id_not_in.includes(i)).map(i => this.items[i]);
-  };
-  itemsQueryMeta = async ({ where: { id_in: ids, id, id_not_in } }) => {
-    return {
-      count: (id
+  itemsQuery = async ({ where: { id_in: ids, id, id_not_in } }, { meta = false } = {}) => {
+    if (meta) {
+      return {
+        count: (id
+          ? [this.items[id]]
+          : ids.filter(i => !id_not_in || !id_not_in.includes(i)).map(i => this.items[i])
+        ).length,
+      };
+    } else {
+      return id
         ? [this.items[id]]
-        : ids.filter(i => !id_not_in || !id_not_in.includes(i)).map(i => this.items[i])
-      ).length,
-    };
+        : ids.filter(i => !id_not_in || !id_not_in.includes(i)).map(i => this.items[i]);
+    }
   };
+  itemsQueryMeta = async args => this.itemsQuery(args, { meta: true });
   update = (id, item) => {
     this.items[id] = { ...this.items[id], ...item };
     return this.items[id];


### PR DESCRIPTION
This limits the number of results returned in a (sub)query for the List.

Note that the limit is per subquery, not global.  It's intended that
devs base limits on the "reasonable" number of results for the list
type, rather than try to model the capacity of the server.  Combined
with limits on query nesting (not yet implemented), it should be enough
to stop easy OOM DoS attacks.