### PR TITLE
Properly connect to mongo DBs during tests.

### DIFF
--- a/.changeset/chilled-cycles-repeat/changes.json
+++ b/.changeset/chilled-cycles-repeat/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/test-utils", "type": "patch" }], "dependents": [] }

--- a/.changeset/chilled-cycles-repeat/changes.md
+++ b/.changeset/chilled-cycles-repeat/changes.md
@@ -1,0 +1,1 @@
+Clean up error messages when using the mongo test runner

--- a/packages/fields/src/types/Slug/Implementation.test.js
+++ b/packages/fields/src/types/Slug/Implementation.test.js
@@ -727,68 +727,47 @@ describe('Slug#implementation', () => {
       describe('error handling', () => {
         it("throws if 'regenerateOnUpdate' is not a bool", () => {
           return expect(
-            runner(
-              () =>
-                setupList(adapterName, {
-                  url: { type: Slug, from: 'foo', regenerateOnUpdate: 13 },
-                }),
-              // Empty test, we just want to assert the setup works
-              () => {}
+            runner(() =>
+              setupList(adapterName, {
+                url: { type: Slug, from: 'foo', regenerateOnUpdate: 13 },
+              })
             )()
           ).rejects.toThrow(/The 'regenerateOnUpdate' option on .*\.url must be true\/false/);
         });
 
         it("throws if 'alwaysMakeUnique' is not a bool", () => {
           return expect(
-            runner(
-              () =>
-                setupList(adapterName, {
-                  url: { type: Slug, from: 'foo', alwaysMakeUnique: 13 },
-                }),
-              // Empty test, we just want to assert the setup works
-              () => {}
+            runner(() =>
+              setupList(adapterName, {
+                url: { type: Slug, from: 'foo', alwaysMakeUnique: 13 },
+              })
             )()
           ).rejects.toThrow(/The 'alwaysMakeUnique' option on .*\.url must be true\/false/);
         });
 
         it("throws if both 'from' and 'generate' specified", () => {
           return expect(
-            runner(
-              () =>
-                setupList(adapterName, { url: { type: Slug, from: 'foo', generate: () => {} } }),
-              // Empty test, we just want to assert the setup works
-              () => {}
+            runner(() =>
+              setupList(adapterName, { url: { type: Slug, from: 'foo', generate: () => {} } })
             )()
           ).rejects.toThrow("Only one of 'from' or 'generate' can be supplied");
         });
 
         it("throws if 'from' is not a string", () => {
           return expect(
-            runner(
-              () => setupList(adapterName, { url: { type: Slug, from: 12 } }),
-              // Empty test, we just want to assert the setup works
-              () => {}
-            )()
+            runner(() => setupList(adapterName, { url: { type: Slug, from: 12 } }))()
           ).rejects.toThrow(/The 'from' option on .* must be a string/);
         });
 
         it("throws if 'from' is a function", () => {
           return expect(
-            runner(
-              () => setupList(adapterName, { url: { type: Slug, from: () => {} } }),
-              // Empty test, we just want to assert the setup works
-              () => {}
-            )()
+            runner(() => setupList(adapterName, { url: { type: Slug, from: () => {} } }))()
           ).rejects.toThrow(/A function was specified for the 'from' option/);
         });
 
         it("throws when 'makeUnique' isn't a function", () => {
           return expect(
-            runner(
-              () => setupList(adapterName, { url: { type: Slug, makeUnique: 'foo' } }),
-              // Empty test, we just want to assert the setup works
-              () => {}
-            )()
+            runner(() => setupList(adapterName, { url: { type: Slug, makeUnique: 'foo' } }))()
           ).rejects.toThrow(
             /The 'makeUnique' option on .* must be a function, but received string/
           );


### PR DESCRIPTION
`keystone.connect()` shouldn't take any arguments!

This gets rid of this annoying message which was polluting our test logs.

```
...
{"level":40,"time":1567407017297,"msg":"No MongoDB connection URI specified. Defaulting to 'mongodb://localhost/ks5-testdb-ck021o2oy0000pdmw76pcc61k'","pid":2209,"hostname":"f0e3509593f5","name":"mongoose","v":1}
...
```