### PR TITLE
Embed fields should handle receiving null or '' when being unset

### DIFF
--- a/.changeset/pink-rockets-listen/changes.json
+++ b/.changeset/pink-rockets-listen/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/fields", "type": "patch" }], "dependents": [] }

--- a/.changeset/pink-rockets-listen/changes.md
+++ b/.changeset/pink-rockets-listen/changes.md
@@ -1,0 +1,1 @@
+Embed fields should handle receiving null or '' when being unset

--- a/packages/fields/src/Controller.js
+++ b/packages/fields/src/Controller.js
@@ -83,7 +83,7 @@ export default class FieldController {
    * @param initialData {Object} An object containing the most recently received
    * data from the server, keyed by the field's path. The values have already
    * been passed to this.serialize() for you.
-   * @param initialData {Object} An object containing all of the data for the
+   * @param currentData {Object} An object containing all of the data for the
    * current item, keyed by the field's path. The values have already been
    * passed to this.serialize() for you
    * @return boolean

--- a/packages/fields/src/types/OEmbed/Implementation.js
+++ b/packages/fields/src/types/OEmbed/Implementation.js
@@ -183,9 +183,9 @@ export class OEmbed extends Implementation {
       return undefined;
     }
 
-    if (inputUrl === null) {
-      // `null` was specifically uploaded, and we should set the field value to
-      // null. To do that we... return `null`
+    if (inputUrl === null || inputUrl.trim() === '') {
+      // `null` or `''` was specifically uploaded, and we should set the field
+      // value to null. To do that we... return `null`
       return null;
     }
 

--- a/packages/fields/src/types/OEmbed/Implementation.test.js
+++ b/packages/fields/src/types/OEmbed/Implementation.test.js
@@ -1,0 +1,51 @@
+import { OEmbed } from './Implementation';
+
+const path = 'foo';
+
+const newOEmbed = ({ config = {} } = {}) => {
+  return new OEmbed(
+    path,
+    { access: true, ...config },
+    { listAdapter: { newFieldAdapter: () => {} } }
+  );
+};
+
+describe('iframely OEmbed adapter', () => {
+  it('should throw when no adapter provided', () => {
+    expect(() => {
+      newOEmbed();
+    }).toThrow(/An OEmbed Adapter must be supplied/);
+  });
+
+  it('should throw when adapter is missing a fetch() method', () => {
+    expect(() => {
+      newOEmbed({ config: { adapter: {} } });
+    }).toThrow(/An invalid OEmbed Adapter/);
+  });
+
+  describe('resolveInput()', () => {
+    it('coerces null string to null', () => {
+      const oembed = newOEmbed({ config: { adapter: { fetch: () => {} } } });
+      expect(oembed.resolveInput({ resolvedData: { [path]: null } })).resolves.toEqual(null);
+    });
+
+    it('coerces empty string to null', () => {
+      const oembed = newOEmbed({ config: { adapter: { fetch: () => {} } } });
+      expect(oembed.resolveInput({ resolvedData: { [path]: '' } })).resolves.toEqual(null);
+    });
+
+    it('coerces spaces-only string to null', () => {
+      const oembed = newOEmbed({ config: { adapter: { fetch: () => {} } } });
+      expect(oembed.resolveInput({ resolvedData: { [path]: '  ' } })).resolves.toEqual(null);
+    });
+
+    it('calls the adapters fetch with the url', async () => {
+      const url = 'http://example.com?ck03fftlg0000y5pf13wy5ijm';
+      const fetch = jest.fn(() => ({}));
+      const oembed = newOEmbed({ config: { adapter: { fetch } } });
+      await oembed.resolveInput({ resolvedData: { [path]: url } });
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledWith(expect.objectContaining({ url }));
+    });
+  });
+});

--- a/packages/fields/src/types/OEmbed/views/Controller.js
+++ b/packages/fields/src/types/OEmbed/views/Controller.js
@@ -11,9 +11,8 @@ export default class FileController extends FieldController {
   deserialize = data => {
     const oEmbed = data[this.path];
     if (!oEmbed || !oEmbed.originalUrl) {
-      // Nothing set, so force to an empty object (removes null checks from the
-      // `Field` view)
-      return {};
+      // Nothing set, so force to null
+      return null;
     }
 
     return {
@@ -36,10 +35,6 @@ export default class FileController extends FieldController {
   serialize = data => {
     const { path } = this;
     // We only send the URL itself to the mutation
-    return (data[path] && data[path].originalUrl) || '';
-  };
-
-  hasChanged = (initial, current) => {
-    return initial !== current;
+    return (data[path] && data[path].originalUrl) || null;
   };
 }

--- a/packages/fields/src/types/OEmbed/views/Field.js
+++ b/packages/fields/src/types/OEmbed/views/Field.js
@@ -49,7 +49,7 @@ export default class OEmbedField extends Component {
   };
 
   render() {
-    const { autoFocus, field, value = {}, savedValue = {}, errors } = this.props;
+    const { autoFocus, field, value = null, savedValue = null, errors } = this.props;
     const htmlID = `ks-oembed-${field.path}`;
     const canRead = errors.every(
       error => !(error instanceof Error && error.name === 'AccessDeniedError')
@@ -57,7 +57,7 @@ export default class OEmbedField extends Component {
     const error = errors.find(
       error => error instanceof Error && error.name === 'AccessDeniedError'
     );
-    const hasChanged = field.hasChanged(savedValue.originalUrl, value.originalUrl);
+    const hasChanged = field.hasChanged({ [field.path]: savedValue }, { [field.path]: value });
 
     return (
       <FieldContainer>
@@ -67,16 +67,16 @@ export default class OEmbedField extends Component {
             autoComplete="off"
             autoFocus={autoFocus}
             type="url"
-            value={canRead && value.originalUrl}
+            value={(canRead && value && value.originalUrl) || ''}
             placeholder={canRead ? undefined : error.message}
             onChange={this.onChange}
             id={htmlID}
           />
         </FieldInput>
-        {value.originalUrl && hasChanged && (
+        {value && value.originalUrl && hasChanged && (
           <PlaceholderPreview originalUrl={value.originalUrl} fieldPath={field.path} />
         )}
-        {value.originalUrl && !hasChanged && (
+        {value && value.originalUrl && !hasChanged && (
           <StyledPreview
             preview={value.preview}
             originalUrl={value.originalUrl}

--- a/packages/oembed-adapters/src/iframely.js
+++ b/packages/oembed-adapters/src/iframely.js
@@ -6,7 +6,7 @@ const VALID_URL = /^https?:\/\//i;
 const IS_MD5 = /[a-f0-9]{32}/i;
 
 export class IframelyOEmbedAdapter {
-  constructor({ apiKey }) {
+  constructor({ apiKey } = {}) {
     if (!apiKey) {
       throw new Error('Must provide an apiKey to IFramely OEmbed Adapter');
     }

--- a/packages/oembed-adapters/src/iframely.test.js
+++ b/packages/oembed-adapters/src/iframely.test.js
@@ -1,0 +1,22 @@
+const { IframelyOEmbedAdapter } = require('./iframely');
+
+describe('iframely OEmbed adapter', () => {
+  it('should throw when no apiKey provided', () => {
+    expect(() => {
+      new IframelyOEmbedAdapter();
+    }).toThrow(/Must provide an apiKey/);
+  });
+
+  it('doesnt throw when an apiKey provided', () => {
+    expect(() => {
+      new IframelyOEmbedAdapter({ apiKey: 'foo' });
+    }).not.toThrow();
+  });
+
+  it('throws when invalid URL passed to .fetch()', () => {
+    const adapter = new IframelyOEmbedAdapter({ apiKey: 'foo' });
+    expect(adapter.fetch({ url: 'foo' })).rejects.toThrow(
+      /must start with either http:\/\/ or https:\/\//
+    );
+  });
+});


### PR DESCRIPTION
There are 2 bugs being fixed here;

1. The Admin UI would always send an OEmbed field that didn't have a value because `'' !== null`. This would trigger the second bug;
2. The OEmbed type wasn't correctly handling empty strings; they should coerce to `null`.