### PR TITLE
Prepare release

### DIFF
--- a/.changeset/pink-rockets-listen/changes.json
+++ b/.changeset/pink-rockets-listen/changes.json
@@ -1,1 +1,0 @@
-{ "releases": [{ "name": "@keystone-alpha/fields", "type": "patch" }], "dependents": [] }

--- a/.changeset/pink-rockets-listen/changes.md
+++ b/.changeset/pink-rockets-listen/changes.md
@@ -1,1 +1,0 @@
-Embed fields should handle receiving null or '' when being unset

--- a/packages/fields/CHANGELOG.md
+++ b/packages/fields/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @keystone-alpha/fields
 
+## 10.7.1
+
+### Patch Changes
+
+- [d9bd327e](https://github.com/keystonejs/keystone-5/commit/d9bd327e): Embed fields should handle receiving null or '' when being unset
+
 ## 10.7.0
 
 ### Minor Changes

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keystone-alpha/fields",
   "description": "KeystoneJS Field Types including Text, Password, DateTime, Integer, and more.",
-  "version": "10.7.0",
+  "version": "10.7.1",
   "main": "dist/fields.cjs.js",
   "module": "dist/fields.esm.js",
   "author": "The KeystoneJS Development Team",

--- a/test-projects/basic/cypress/mock/upload.txt
+++ b/test-projects/basic/cypress/mock/upload.txt
@@ -1,1 +1,1 @@
-Some important content 0.17855030509504588
+Some important content 0.100393664270916


### PR DESCRIPTION
## `@keystone-alpha/fields@10.7.1`

### Bug fixes

- [d9bd327e](https://github.com/keystonejs/keystone-5/commit/d9bd327e): Embed fields should handle receiving null or '' when being unset