### PR TITLE
Prepare release

### DIFF
--- a/.changeset/thick-roses-peel/changes.json
+++ b/.changeset/thick-roses-peel/changes.json
@@ -1,7 +1,0 @@
-{
-  "releases": [
-    { "name": "@keystone-alpha/app-admin-ui", "type": "patch" },
-    { "name": "@keystone-alpha/fields", "type": "patch" }
-  ],
-  "dependents": []
-}

--- a/.changeset/thick-roses-peel/changes.md
+++ b/.changeset/thick-roses-peel/changes.md
@@ -1,1 +1,0 @@
-Revert usage of Apollo Hooks

--- a/packages/app-admin-ui/CHANGELOG.md
+++ b/packages/app-admin-ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @keystone-alpha/app-admin-ui
 
+## 5.6.1
+
+### Patch Changes
+
+- [99dc6cae](https://github.com/keystonejs/keystone-5/commit/99dc6cae): Revert usage of Apollo Hooks
+
 ## 5.6.0
 
 ### Minor Changes

--- a/packages/app-admin-ui/package.json
+++ b/packages/app-admin-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keystone-alpha/app-admin-ui",
   "description": "KeystoneJS Admin UI App.",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "author": "The KeystoneJS Development Team",
   "license": "MIT",
   "engines": {
@@ -40,7 +40,7 @@
     "@emotion/styled": "^10.0.14",
     "@keystone-alpha/build-field-types": "^1.0.5",
     "@keystone-alpha/field-views-loader": "^2.2.0",
-    "@keystone-alpha/fields": "^10.7.0",
+    "@keystone-alpha/fields": "^10.7.2",
     "@keystone-alpha/session": "^2.0.1",
     "@keystone-alpha/utils": "^3.0.2",
     "apollo-cache-inmemory": "^1.5.1",

--- a/packages/fields/CHANGELOG.md
+++ b/packages/fields/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @keystone-alpha/fields
 
+## 10.7.2
+
+### Patch Changes
+
+- [99dc6cae](https://github.com/keystonejs/keystone-5/commit/99dc6cae): Revert usage of Apollo Hooks
+
 ## 10.7.1
 
 ### Patch Changes

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keystone-alpha/fields",
   "description": "KeystoneJS Field Types including Text, Password, DateTime, Integer, and more.",
-  "version": "10.7.1",
+  "version": "10.7.2",
   "main": "dist/fields.cjs.js",
   "module": "dist/fields.esm.js",
   "author": "The KeystoneJS Development Team",


### PR DESCRIPTION
## `@keystone-alpha/app-admin-ui@5.6.1`
## `@keystone-alpha/fields@10.7.2`

### Patch Changes

- [99dc6cae](https://github.com/keystonejs/keystone-5/commit/99dc6cae): Revert usage of Apollo Hooks (#1543)