### PR TITLE
README: remove brew install hint for mongodb

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,12 +291,6 @@ yarn global add bolt
 
 Also make sure you have a local MongoDB server running
 ([instructions](https://docs.mongodb.com/manual/installation/)).
-If you don't have it installed, on MacOS use Homebrew (run these once):
-
-```sh
-brew install mongodb
-brew services start mongodb
-```
 
 Then install the dependencies and start the test project:
 


### PR DESCRIPTION
The remaining `instructions` link is acceptable IMHO.
We should instead show how to use `postgres` in development! 

Ref https://github.com/Homebrew/homebrew-core/pull/43770