### PR TITLE
Remove skipAccessControl from keystone.getTypeDefs()

### DIFF
--- a/.changeset/gorgeous-papayas-fry/changes.json
+++ b/.changeset/gorgeous-papayas-fry/changes.json
@@ -1,0 +1,89 @@
+{
+  "releases": [{ "name": "@keystone-alpha/keystone", "type": "major" }],
+  "dependents": [
+    {
+      "name": "@keystone-alpha/api-tests",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-knex",
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/test-utils",
+        "@keystone-alpha/keystone"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-blog",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-meetup",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-todo",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/adapter-knex",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/adapter-mongoose",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/example-projects-blank",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/example-projects-starter",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/example-projects-todo",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/test-utils",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/adapter-knex",
+        "@keystone-alpha/adapter-mongoose",
+        "@keystone-alpha/keystone"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-access-control",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-basic",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-client-validation",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-login",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-social-login",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose", "@keystone-alpha/keystone"]
+    }
+  ]
+}

--- a/.changeset/gorgeous-papayas-fry/changes.md
+++ b/.changeset/gorgeous-papayas-fry/changes.md
@@ -1,0 +1,1 @@
+Remove `skipAccessControl` option from `keystone.getTypeDefs()`, `List.getGqlTypes()`, `List.getGqlQueries()`, and `List.getGqlMutations()`.

--- a/docs/quick-start/getting-started.md
+++ b/docs/quick-start/getting-started.md
@@ -17,7 +17,6 @@ This quick start guide will get you up and running in just a few minutes. Let's 
 
 ## Requirements
 
-
 Before we start, check that your computer or server meets the following requirements:
 
 - [Node.js](https://nodejs.org/) >= 10.x: Node.js is a server platform which runs JavaScript.

--- a/packages/fields/src/Implementation.js
+++ b/packages/fields/src/Implementation.js
@@ -54,10 +54,6 @@ class Field {
    *
    * NOTE: When a naming conflic occurs, a list's types/queries/mutations will
    * overwrite any auxiliary types defined by an individual type.
-   *
-   * @param options Object skipAccessControl: will be true when the types
-   * should include those that otherwise would be excluded due to access control
-   * checks.
    */
   getGqlAuxTypes() {
     return [];
@@ -66,11 +62,6 @@ class Field {
     return {};
   }
 
-  /**
-   * @param options Object skipAccessControl: will be true when the types
-   * should include those that otherwise would be excluded due to access control
-   * checks.
-   */
   getGqlAuxQueries() {
     return [];
   }
@@ -78,11 +69,6 @@ class Field {
     return {};
   }
 
-  /**
-   * @param options Object skipAccessControl: will be true when the types
-   * should include those that otherwise would be excluded due to access control
-   * checks.
-   */
   getGqlAuxMutations() {
     return [];
   }

--- a/packages/keystone/lib/Keystone/index.js
+++ b/packages/keystone/lib/Keystone/index.js
@@ -278,7 +278,7 @@ module.exports = class Keystone {
     return { lists, name: this.name };
   }
 
-  getTypeDefs({ skipAccessControl = false } = {}) {
+  getTypeDefs() {
     // Aux lists are only there for typing and internal operations, they should
     // not have any GraphQL operations performed on them
     const firstClassLists = this.listsArray.filter(list => !list.isAuxList);
@@ -289,7 +289,7 @@ module.exports = class Keystone {
     // graphql-tools will blow up (rightly so) on duplicated types.
     // Deduping here avoids that problem.
     return [
-      ...unique(flatten(this.listsArray.map(list => list.getGqlTypes({ skipAccessControl })))),
+      ...unique(flatten(this.listsArray.map(list => list.getGqlTypes()))),
       ...unique(this._extendedTypes),
       `"""NOTE: Can be JSON, or a Boolean/Int/String
           Why not a union? GraphQL doesn't support a union including a scalar
@@ -351,7 +351,7 @@ module.exports = class Keystone {
       `type Query {
           ${unique(
             flatten([
-              ...firstClassLists.map(list => list.getGqlQueries({ skipAccessControl })),
+              ...firstClassLists.map(list => list.getGqlQueries()),
               this._extendedQueries.map(({ schema }) => schema),
             ])
           ).join('\n')}
@@ -361,7 +361,7 @@ module.exports = class Keystone {
       `type Mutation {
           ${unique(
             flatten([
-              ...firstClassLists.map(list => list.getGqlMutations({ skipAccessControl })),
+              ...firstClassLists.map(list => list.getGqlMutations()),
               this._extendedMutations.map(({ schema }) => schema),
             ])
           ).join('\n')}
@@ -495,7 +495,7 @@ module.exports = class Keystone {
     // reinsert it.
     const schema = `
       scalar Upload
-      ${this.getTypeDefs({ skipAccessControl: true }).join('\n')}
+      ${this.getTypeDefs().join('\n')}
     `;
     fs.writeFileSync(file, schema);
   }


### PR DESCRIPTION
This makes the output of `keystone.dumpSchema()` consistent with the schema generated with Apollo.