### PR TITLE
Add robots exclusion meta tags to Admin UI

### DIFF
--- a/.changeset/dull-cameras-tan/changes.json
+++ b/.changeset/dull-cameras-tan/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/app-admin-ui", "type": "patch" }], "dependents": [] }

--- a/.changeset/dull-cameras-tan/changes.md
+++ b/.changeset/dull-cameras-tan/changes.md
@@ -1,0 +1,1 @@
+Add robots exclusion meta tags to Admin UI

--- a/packages/app-admin-ui/client/index.html
+++ b/packages/app-admin-ui/client/index.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex, nofollow">
     <title><%= htmlWebpackPlugin.options.title %></title>
   </head>
   <body>


### PR DESCRIPTION
The admin login page, etc, shouldn't appear in search engine listings.