### PR TITLE
Add support for grouping access control by schema name

### DIFF
--- a/.changeset/eight-donuts-work/changes.json
+++ b/.changeset/eight-donuts-work/changes.json
@@ -1,0 +1,8 @@
+{
+  "releases": [
+    { "name": "@keystone-alpha/access-control", "type": "major" },
+    { "name": "@keystone-alpha/fields", "type": "patch" },
+    { "name": "@keystone-alpha/keystone", "type": "patch" }
+  ],
+  "dependents": []
+}

--- a/.changeset/eight-donuts-work/changes.md
+++ b/.changeset/eight-donuts-work/changes.md
@@ -1,0 +1,32 @@
+`parseListAccess` and `parseFieldAccess` now take `schemaNames` as an argument, and return a nested access object, with the `schemaNames` as keys.
+
+For example,
+
+```js
+parseListAccess({ defaultAccess: false, access: { public: true }, schemaNames: ['public', 'internal'] }
+```
+
+will return
+
+```js
+{
+  public: { create: true, read: true, update: true, delete: true },
+  internal: { create: false, read: false, update: false, delete: false },
+}
+```
+
+These changes are backwards compatible with regard to the `access` argument, so
+
+```js
+const access = { create: true, read: true, update: true, delete: true };
+parseListAccess({ access, schemaNames: ['public', 'internal'] }
+```
+
+will return
+
+```js
+{
+  public: { create: true, read: true, update: true, delete: true },
+  internal: { create: true, read: true, update: true, delete: true },
+}
+```

--- a/packages/access-control/lib/access-control.js
+++ b/packages/access-control/lib/access-control.js
@@ -75,7 +75,9 @@ const parseAccess = ({
   // Check that none of the schemaNames match the accessTypes
   if (intersection(schemaNames, accessTypes).length > 0) {
     throw new Error(
-      `${JSON.stringify(intersection(schemaNames, accessTypes))} are reserved words and cannot be used as schema names.`
+      `${JSON.stringify(
+        intersection(schemaNames, accessTypes)
+      )} are reserved words and cannot be used as schema names.`
     );
   }
 

--- a/packages/access-control/lib/access-control.js
+++ b/packages/access-control/lib/access-control.js
@@ -75,13 +75,13 @@ const parseAccess = ({
   // Check that none of the schemaNames match the accessTypes
   if (intersection(schemaNames, accessTypes).length > 0) {
     throw new Error(
-      `Invalid schemaNames: ${JSON.stringify(intersection(schemaNames, accessTypes))}`
+      `${JSON.stringify(intersection(schemaNames, accessTypes))} are reserved words and cannot be used as schema names.`
     );
   }
 
-  const N = intersection(Object.keys(access), schemaNames).length;
+  const providedNameCount = intersection(Object.keys(access), schemaNames).length;
   const type = getType(access);
-  if (type === 'Object' && N === Object.keys(access).length) {
+  if (type === 'Object' && providedNameCount === Object.keys(access).length) {
     // If all the keys are in schemaNames, parse each on their own
     return schemaNames.reduce(
       (acc, schemaName) => ({
@@ -96,7 +96,7 @@ const parseAccess = ({
       }),
       {}
     );
-  } else if (type === 'Object' && N > 0) {
+  } else if (type === 'Object' && providedNameCount > 0) {
     // If some are in, and some are out, throw an error!
     throw new Error(
       `Invalid schema names: ${JSON.stringify(

--- a/packages/access-control/lib/access-control.js
+++ b/packages/access-control/lib/access-control.js
@@ -1,4 +1,4 @@
-const { getType, pick, defaultObj } = require('@keystone-alpha/utils');
+const { getType, pick, defaultObj, intersection } = require('@keystone-alpha/utils');
 
 const validateGranularConfigTypes = (longHandAccess, validationError) => {
   const errors = Object.entries(longHandAccess)
@@ -35,7 +35,7 @@ const parseGranularAccessConfig = ({
   return finalAccess;
 };
 
-const parseAccess = ({
+const parseAccessCore = ({
   accessTypes,
   access,
   defaultAccess,
@@ -64,11 +64,64 @@ const parseAccess = ({
   }
 };
 
+const parseAccess = ({
+  schemaNames,
+  accessTypes,
+  access,
+  defaultAccess,
+  onGranularParseError,
+  validateGranularType,
+}) => {
+  // Check that none of the schemaNames match the accessTypes
+  if (intersection(schemaNames, accessTypes).length > 0) {
+    throw new Error(
+      `Invalid schemaNames: ${JSON.stringify(intersection(schemaNames, accessTypes))}`
+    );
+  }
+
+  const N = intersection(Object.keys(access), schemaNames).length;
+  const type = getType(access);
+  if (type === 'Object' && N === Object.keys(access).length) {
+    // If all the keys are in schemaNames, parse each on their own
+    return schemaNames.reduce(
+      (acc, schemaName) => ({
+        ...acc,
+        [schemaName]: parseAccessCore({
+          accessTypes,
+          access: access.hasOwnProperty(schemaName) ? access[schemaName] : defaultAccess,
+          defaultAccess,
+          onGranularParseError,
+          validateGranularType,
+        }),
+      }),
+      {}
+    );
+  } else if (type === 'Object' && N > 0) {
+    // If some are in, and some are out, throw an error!
+    throw new Error(
+      `Invalid schema names: ${JSON.stringify(
+        Object.keys(access).filter(k => !schemaNames.includes(k))
+      )}`
+    );
+  } else {
+    // Otherwise, treat it as common across all schemaNames
+    const commonAccess = parseAccessCore({
+      accessTypes,
+      access,
+      defaultAccess,
+      onGranularParseError,
+      validateGranularType,
+    });
+    return schemaNames.reduce((acc, schemaName) => ({ ...acc, [schemaName]: commonAccess }), {});
+  }
+};
+
 module.exports = {
-  parseListAccess({ listKey, defaultAccess, access = defaultAccess }) {
+  parseListAccess({ listKey, defaultAccess, access = defaultAccess, schemaNames }) {
     const accessTypes = ['create', 'read', 'update', 'delete'];
 
     return parseAccess({
+      schemaNames,
       accessTypes,
       access,
       defaultAccess,
@@ -95,10 +148,11 @@ module.exports = {
     });
   },
 
-  parseFieldAccess({ listKey, fieldKey, defaultAccess, access = defaultAccess }) {
+  parseFieldAccess({ listKey, fieldKey, defaultAccess, access = defaultAccess, schemaNames }) {
     const accessTypes = ['create', 'read', 'update'];
 
     return parseAccess({
+      schemaNames,
       accessTypes,
       access,
       defaultAccess,

--- a/packages/fields/src/Implementation.js
+++ b/packages/fields/src/Implementation.js
@@ -30,11 +30,12 @@ class Field {
     this.isRelationship = false;
 
     this.access = parseFieldAccess({
+      schemaNames: ['public'],
       listKey,
       fieldKey: path,
       defaultAccess,
       access: access,
-    });
+    })['public'];
   }
 
   // Field types should replace this if they want to any fields to the output type

--- a/packages/keystone/lib/List/index.js
+++ b/packages/keystone/lib/List/index.js
@@ -215,10 +215,11 @@ module.exports = class List {
     this.adapter = adapter.newListAdapter(this.key, adapterConfig);
 
     this.access = parseListAccess({
+      schemaNames: ['public'],
       listKey: key,
       access,
       defaultAccess: this.defaultAccess.list,
-    });
+    })['public'];
 
     this.queryLimits = {
       maxResults: Infinity,


### PR DESCRIPTION
`parseListAccess` and `parseFieldAccess` now take `schemaNames` as an argument, and return a nested access object, with the `schemaNames` as keys.

For example,

```js
parseListAccess({ defaultAccess: false, access: { public: true }, schemaNames: ['public', 'internal'] }
```

will return

```js
{
  public: { create: true, read: true, update: true, delete: true },
  internal: { create: false, read: false, update: false, delete: false },
}
```

These changes are backwards compatible with regard to the `access` argument, so

```js
const access = { create: true, read: true, update: true, delete: true };
parseListAccess({ access, schemaNames: ['public', 'internal'] }
```

will return

```js
{
  public: { create: true, read: true, update: true, delete: true },
  internal: { create: true, read: true, update: true, delete: true },
}
```
