### PR TITLE
Enable useUnifiedTopology in the Mongoose adapter

### DIFF
--- a/.changeset/seven-zoos-refuse/changes.json
+++ b/.changeset/seven-zoos-refuse/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/adapter-mongoose", "type": "patch" }], "dependents": [] }

--- a/.changeset/seven-zoos-refuse/changes.md
+++ b/.changeset/seven-zoos-refuse/changes.md
@@ -1,0 +1,1 @@
+Enabled useUnifiedTopology to address deprecation warning

--- a/packages/adapter-mongoose/lib/adapter-mongoose.js
+++ b/packages/adapter-mongoose/lib/adapter-mongoose.js
@@ -104,6 +104,7 @@ class MongooseAdapter extends BaseKeystoneAdapter {
     await this.mongoose.connect(uri, {
       useNewUrlParser: true,
       useFindAndModify: false,
+      useUnifiedTopology: true,
       ...mongooseConfig,
     });
   }


### PR DESCRIPTION
Addresses this warning:
```
- Connecting to database(node:16844) DeprecationWarning: current Server Discovery and Monitoring engine is deprecated, and will be removed in a future version. To use the new Server Discover and Monitoring engine, pass option { useUnifiedTopology: true } to the MongoClient constructor.
```

See also: https://github.com/mongodb/node-mongodb-native/releases/tag/v3.2.1