### PR TITLE
Better StaticApp errors   when no "path" or "src" options are specified

### DIFF
--- a/.changeset/slow-needles-attend/changes.json
+++ b/.changeset/slow-needles-attend/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/app-static", "type": "patch" }], "dependents": [] }

--- a/.changeset/slow-needles-attend/changes.md
+++ b/.changeset/slow-needles-attend/changes.md
@@ -1,0 +1,1 @@
+throwing errors when the StaticApp doesn't have a string valued passed to the "path" or "src" properties

--- a/packages/app-static/README.md
+++ b/packages/app-static/README.md
@@ -36,11 +36,11 @@ module.exports = {
 
 ### `path`
 
-The path to serve files from.
+The path to serve files from. This is required and must be a string.
 
 ### `src`
 
-The path to the folder containing static files.
+The path to the folder containing static files. This is required and must be a string.
 
 #### `fallback` (optional)
 

--- a/packages/app-static/index.js
+++ b/packages/app-static/index.js
@@ -10,6 +10,12 @@ const getDistDir = (src, distDir) => {
 
 class StaticApp {
   constructor({ path, src, fallback }) {
+    if (typeof path !== 'string') {
+      throw new Error('StaticApp requires a "path" option, which must be a string.');
+    }
+    if (typeof src !== 'string') {
+      throw new Error('StaticApp requires a "src" option, which must be a string.');
+    }
     this._path = path;
     this._src = src;
     this._fallback = fallback;


### PR DESCRIPTION
Got stuck for a while figuring out what was breaking the StaticApp - turns out no `path` option pas passed, but a string is required for it to work.

This PR improves that experience by throwing errors if no string is passed for `path` and `src` options in a `new StaticApp()`.