### PR TITLE
Add cookieMaxAge and secureCookies options

### DIFF
--- a/.changeset/smooth-pumpkins-deliver/changes.json
+++ b/.changeset/smooth-pumpkins-deliver/changes.json
@@ -1,7 +1,7 @@
 {
   "releases": [
     { "name": "@keystone-alpha/keystone", "type": "minor" },
-    { "name": "@keystone-alpha/session", "type": "minor" }
+    { "name": "@keystone-alpha/session", "type": "major" }
   ],
   "dependents": []
 }

--- a/.changeset/smooth-pumpkins-deliver/changes.json
+++ b/.changeset/smooth-pumpkins-deliver/changes.json
@@ -1,0 +1,7 @@
+{
+  "releases": [
+    { "name": "@keystone-alpha/keystone", "type": "minor" },
+    { "name": "@keystone-alpha/session", "type": "minor" }
+  ],
+  "dependents": []
+}

--- a/.changeset/smooth-pumpkins-deliver/changes.md
+++ b/.changeset/smooth-pumpkins-deliver/changes.md
@@ -9,3 +9,5 @@ const keystone = new Keystone({
   secureCookies: true,
 });
 ```
+
+Note: `commonSessionMiddleware` now accepts a config object rather than multiple arguments.

--- a/.changeset/smooth-pumpkins-deliver/changes.md
+++ b/.changeset/smooth-pumpkins-deliver/changes.md
@@ -1,0 +1,11 @@
+Adds a `cookieMaxAge` and `secureCookies` option to the keystone constructor. 
+
+These will default to 1 day and `true` in production. Or `null` and `false` in other environments.
+
+### Usage 
+```javascript
+const keystone = new Keystone({
+  cookieMaxAge: 1000 * 60 * 60 * 24 * 7, // 1 week 
+  secureCookies: true,
+});
+```

--- a/.changeset/smooth-pumpkins-deliver/changes.md
+++ b/.changeset/smooth-pumpkins-deliver/changes.md
@@ -1,6 +1,6 @@
 Adds a `cookieMaxAge` and `secureCookies` option to the keystone constructor. 
 
-These will default to 1 day and `true` in production. Or `null` and `false` in other environments.
+These will default to 30 days for `cookieMaxAge` and `true` in production `false` in other environments for `secureCookies`.
 
 ### Usage 
 ```javascript

--- a/packages/keystone/lib/Keystone/index.js
+++ b/packages/keystone/lib/Keystone/index.js
@@ -45,7 +45,7 @@ module.exports = class Keystone {
     cookieSecret = 'qwerty',
     sessionStore,
     secureCookies = process.env.NODE_ENV === 'production', // Default to true in production
-    cookieMaxAge = process.env.NODE_ENV === 'production' ? 1000 * 60 * 60 * 24 : null,
+    cookieMaxAge = 1000 * 60 * 60 * 24 * 30, // 30 days
   }) {
     this.name = name;
     this.adapterConnectOptions = adapterConnectOptions;

--- a/packages/keystone/lib/Keystone/index.js
+++ b/packages/keystone/lib/Keystone/index.js
@@ -63,6 +63,8 @@ module.exports = class Keystone {
     this._cookieMaxAge = cookieMaxAge;
     this._sessionStore = sessionStore;
     this.eventHandlers = { onConnect };
+    this._sessionStore = sessionStore;
+    this.registeredTypes = new Set();
 
     if (adapters) {
       this.adapters = adapters;

--- a/packages/session/lib/session.js
+++ b/packages/session/lib/session.js
@@ -2,7 +2,13 @@ const cookieSignature = require('cookie-signature');
 const expressSession = require('express-session');
 const cookie = require('cookie');
 
-const commonSessionMiddleware = (keystone, cookieSecret, sessionStore) => {
+const commonSessionMiddleware = ({
+  keystone,
+  cookieSecret,
+  sessionStore,
+  secureCookies,
+  cookieMaxAge,
+}) => {
   const COOKIE_NAME = 'keystone.sid';
 
   // We have at least one auth strategy
@@ -50,7 +56,9 @@ const commonSessionMiddleware = (keystone, cookieSecret, sessionStore) => {
     resave: false,
     saveUninitialized: false,
     name: COOKIE_NAME,
+    cookie: { secure: secureCookies },
     store: sessionStore,
+    maxAge: cookieMaxAge,
   });
 
   return [injectAuthCookieMiddleware, sessionMiddleware, populateAuthedItemMiddleware(keystone)];

--- a/packages/session/lib/session.js
+++ b/packages/session/lib/session.js
@@ -56,9 +56,8 @@ const commonSessionMiddleware = ({
     resave: false,
     saveUninitialized: false,
     name: COOKIE_NAME,
-    cookie: { secure: secureCookies },
+    cookie: { secure: secureCookies, maxAge: cookieMaxAge },
     store: sessionStore,
-    maxAge: cookieMaxAge,
   });
 
   return [injectAuthCookieMiddleware, sessionMiddleware, populateAuthedItemMiddleware(keystone)];


### PR DESCRIPTION
Resolves #1596 and #1595

I followed the pattern of adding options to the keystone object. Not sure if I should have grouped these under cookies or something, we're getting quite a few config options here and I'm not sure these should be on the Keystone constructor?

We could probably save the above for a more general discussion in future.

For both options I've set defaults for `dev` and `production` - Can you check these are right?

Can I also get some help on how best to test this? Commits welcome.
