### PR TITLE
Remove default schemaName from getGraphQlContext

### DIFF
--- a/.changeset/light-ties-retire/changes.json
+++ b/.changeset/light-ties-retire/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/keystone", "type": "patch" }], "dependents": [] }

--- a/.changeset/light-ties-retire/changes.md
+++ b/.changeset/light-ties-retire/changes.md
@@ -1,0 +1,1 @@
+`keystone.getGraphQlContext()` no longer provides a default value for `schemaName`.

--- a/packages/app-graphql/README.md
+++ b/packages/app-graphql/README.md
@@ -39,7 +39,7 @@ module.exports = {
 | Option         | Type     | Default                               | Description                                                                                          |
 | -------------- | -------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | `cors`         | `Object` | `{ origin: true, credentials: true }` | Options passed directly to the express [cors](https://github.com/expressjs/cors) middleware package. |
-|  |
+|                |          |                                       |                                                                                                      |
 | `apiPath`      | `String` | `/admin/api`                          | Change the API path                                                                                  |
 | `graphiqlPath` | `String` | `/admin/graphiql`                     | Change the Apollo GraphQL playground path                                                            |
 | `schemaName`   | `String` | `admin`                               | Change the graphQL schema name (not recommended)                                                     |

--- a/packages/app-graphql/README.md
+++ b/packages/app-graphql/README.md
@@ -39,7 +39,6 @@ module.exports = {
 | Option         | Type     | Default                               | Description                                                                                          |
 | -------------- | -------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | `cors`         | `Object` | `{ origin: true, credentials: true }` | Options passed directly to the express [cors](https://github.com/expressjs/cors) middleware package. |
-|                |          |                                       |                                                                                                      |
 | `apiPath`      | `String` | `/admin/api`                          | Change the API path                                                                                  |
 | `graphiqlPath` | `String` | `/admin/graphiql`                     | Change the Apollo GraphQL playground path                                                            |
 | `schemaName`   | `String` | `admin`                               | Change the graphQL schema name (not recommended)                                                     |

--- a/packages/keystone/lib/Keystone/index.js
+++ b/packages/keystone/lib/Keystone/index.js
@@ -93,7 +93,7 @@ module.exports = class Keystone {
   // The GraphQL App uses this method to build up the context required for each
   // incoming query.
   // It is also used for generating the `keystone.query` method
-  getGraphQlContext({ schemaName = 'public', req = {}, skipAccessControl = false } = {}) {
+  getGraphQlContext({ schemaName, req = {}, skipAccessControl = false } = {}) {
     let getListAccessControlForUser;
     let getFieldAccessControlForUser;
 


### PR DESCRIPTION
This default is never used and will only lead bugs.