### PR TITLE
Fix a test flake

### DIFF
--- a/.changeset/lazy-plums-mate/changes.json
+++ b/.changeset/lazy-plums-mate/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/fields", "type": "patch" }], "dependents": [] }

--- a/.changeset/lazy-plums-mate/changes.md
+++ b/.changeset/lazy-plums-mate/changes.md
@@ -1,0 +1,1 @@
+Fix test flake

--- a/packages/fields/src/types/Slug/Implementation.test.js
+++ b/packages/fields/src/types/Slug/Implementation.test.js
@@ -17,7 +17,7 @@ const generateListName = () =>
   // Add randomness
   cuid.slug() +
   // Ensure plurality isn't a problem
-  'n';
+  'foo';
 
 const setupList = (adapterName, fields) =>
   setupServer({


### PR DESCRIPTION
Sometimes a slug ending in "men" would get generated.  There aren't any
special rules for words ending in "foo" (probably because there aren't
any words ending in "foo" :)