### PR TITLE
Add docs for Docker-based KS deployments

### DIFF
--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -1,0 +1,79 @@
+<!--[meta]
+section: guides
+title: Deployment Recommendations
+[meta]-->
+
+# Deployment Recommendations
+
+## General
+
+Keystone files need to be built with `keystone build` before running in production mode.
+
+## Using Docker
+
+Keystone can be easily built as a Docker container image, suitable for deploying on Kubernetes or other environments.
+
+Recommended guides:
+
+- [Get Started with Docker](https://docs.docker.com/get-started/)
+- [Intro Guide to Dockerfile Best Practices](https://blog.docker.com/2019/07/intro-guide-to-dockerfile-best-practices/)
+- [Dockerfile Reference](https://docs.docker.com/engine/reference/builder/)
+
+You'll need to add a [`.dockerignore`](https://docs.docker.com/engine/reference/builder/#dockerignore-file) file to the root of your Keystone project (or wherever the image is built from) to avoid including unwanted files in the image. Here's an example of what it might look like:
+
+```
+.git/
+docs/
+dist/
+.env.secret
+```
+
+If you're already familiar with Heroku or Pivotal Cloudfoundry, you might find [Cloud Native Buildpacks](https://buildpacks.io/) a simple way to build Docker images.
+
+The following is an example of production-ready Dockerfile for a Keystone app built with `yarn build` and started with `yarn start`:
+
+```
+# https://docs.docker.com/samples/library/node/
+ARG NODE_VERSION=12.10.0
+# https://github.com/Yelp/dumb-init/releases
+ARG DUMB_INIT_VERSION=1.2.2
+
+# Build container
+FROM node:${NODE_VERSION}-alpine AS build
+ARG DUMB_INIT_VERSION
+
+WORKDIR /home/node
+
+RUN apk add --no-cache build-base python2 yarn && \
+    wget -O dumb-init -q https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_amd64 && \
+    chmod +x dumb-init
+ADD . /home/node
+RUN yarn install && yarn build && yarn cache clean
+
+# Runtime container
+FROM node:${NODE_VERSION}-alpine
+
+WORKDIR /home/node
+
+COPY --from=build /home/node /home/node
+
+EXPOSE 3000
+CMD ["./dumb-init", "yarn", "start"]
+```
+
+When using Docker for deployment, you'll also need a registry to serve your images. This can be [the official Docker Hub](https://hub.docker.com/), a registry in your cloud provider, a third-party hosted registry, or a [self-hosted private registry](https://github.com/docker/distribution).
+
+If you have `.dockerignore` and `Dockerfile` files in the root of your Keystone project, and you're set up with a registry, you can build and push your image like this:
+
+```shell
+my-cool-keystone-app$ # Build on local machine
+my-cool-keystone-app$ docker build -t my-registry.example.com/my-cool-keystone-app:v1.0 .
+my-cool-keystone-app$ # Push to registry server
+my-cool-keystone-app$ docker push my-registry.example.com/my-cool-keystone-app:v1.0
+```
+
+You can test running your image locally (no need to push) with a command like this (assuming your server runs on port 3000):
+
+```shell
+my-cool-keystone-app$ docker run --rm -p 127.0.0.1:3000:3000 my-registry.example.com/my-cool-keystone-app:v1.0
+```


### PR DESCRIPTION
I've added a placeholder section for explaining the keystone build/start
commands, etc.

https://github.com/keystonejs/keystone-5/issues/1266
https://github.com/keystonejs/keystone-5/issues/1257

@MadeByMike I'm not sure about Keystone's deployment "style" (e.g., recommended `yarn` usage or whatever), so the docs might need some tweaks.