### PR TITLE
Allow configuration of Express settings

### DIFF
--- a/.changeset/curly-paws-beg/changes.json
+++ b/.changeset/curly-paws-beg/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/keystone", "type": "patch" }], "dependents": [] }

--- a/.changeset/curly-paws-beg/changes.md
+++ b/.changeset/curly-paws-beg/changes.md
@@ -1,0 +1,1 @@
+Removed adapterConnectOptions key (unused as of 144e6e86)

--- a/.changeset/smart-buses-taste/changes.json
+++ b/.changeset/smart-buses-taste/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/keystone", "type": "minor" }], "dependents": [] }

--- a/.changeset/smart-buses-taste/changes.md
+++ b/.changeset/smart-buses-taste/changes.md
@@ -1,0 +1,1 @@
+Added expressConfig ctor option to pass settings to middleware Express instances

--- a/packages/keystone/README.md
+++ b/packages/keystone/README.md
@@ -20,20 +20,21 @@ const keystone = new Keystone({
 
 ### Config
 
-| Option                  | Type       | Default    | Description                                                                                                                                       |
-| ----------------------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                  | `String`   | `null`     | The name of the project. Appears in the Admin UI.                                                                                                 |
-| `adapter`               | `Object`   | Required   | The database storage adapter. See the [Adapter Framework](https://v5.keystonejs.com/keystone-alpha/keystone/lib/adapters/) page for more details. |
-| `adapters`              | `Array`    | `[]`       |                                                                                                                                                   |
-| `defaultAdapter`        | `Object`   | `null`     |                                                                                                                                                   |
-| `adapterConnectOptions` | `Object`   | `{}`       |                                                                                                                                                   |
-| `defaultAccess`         | `Object`   | `{}`       |                                                                                                                                                   |
-| `onConnect`             | `Function` | `null`     |                                                                                                                                                   |
-| `cookieSecret`          | `String`   | `qwerty`   |                                                                                                                                                   |
-| `cookieMaxAge`          | `Int`      | 30 days    |                                                                                                                                                   |
-| `secureCookies`         | `Boolean`  | Variable   | Defaults to true in production mode, false otherwise.                                                                                             |
-| `sessionStore`          | `Object`   | `null`     |                                                                                                                                                   |
-| `schemaNames`           | `Array`    | `[public]` |                                                                                                                                                   |
+| Option                  | Type       | Default    | Description                                                                                                                                                |
+| ----------------------- | ---------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                  | `String`   | `null`     | The name of the project. Appears in the Admin UI.                                                                                                          |
+| `adapter`               | `Object`   | Required   | The database storage adapter. See the [Adapter Framework](https://v5.keystonejs.com/keystone-alpha/keystone/lib/adapters/) page for more details.          |
+| `adapters`              | `Array`    | `[]`       |                                                                                                                                                            |
+| `defaultAdapter`        | `Object`   | `null`     |                                                                                                                                                            |
+| `adapterConnectOptions` | `Object`   | `{}`       |                                                                                                                                                            |
+| `defaultAccess`         | `Object`   | `{}`       |                                                                                                                                                            |
+| `onConnect`             | `Function` | `null`     |                                                                                                                                                            |
+| `cookieSecret`          | `String`   | `qwerty`   |                                                                                                                                                            |
+| `cookieMaxAge`          | `Int`      | 30 days    |                                                                                                                                                            |
+| `secureCookies`         | `Boolean`  | Variable   | Defaults to true in production mode, false otherwise.                                                                                                      |
+| `sessionStore`          | `Object`   | `null`     |                                                                                                                                                            |
+| `schemaNames`           | `Array`    | `[public]` |                                                                                                                                                            |
+| `expressOptions`        | `Object`   | `{}`       | Settings to pass to middleware Express instances. Refer to the [Express documentation](https://expressjs.com/en/4x/api.html#app.set) for more information. |
 | `queryLimits`           | `Object`   | `{}`       | Configures global query limits                                                                                                                    |
 
 ### `queryLimits`

--- a/packages/keystone/README.md
+++ b/packages/keystone/README.md
@@ -20,21 +20,20 @@ const keystone = new Keystone({
 
 ### Config
 
-| Option                  | Type       | Default    | Description                                                                                                                                                |
-| ----------------------- | ---------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                  | `String`   | `null`     | The name of the project. Appears in the Admin UI.                                                                                                          |
-| `adapter`               | `Object`   | Required   | The database storage adapter. See the [Adapter Framework](https://v5.keystonejs.com/keystone-alpha/keystone/lib/adapters/) page for more details.          |
-| `adapters`              | `Array`    | `[]`       |                                                                                                                                                            |
-| `defaultAdapter`        | `Object`   | `null`     |                                                                                                                                                            |
-| `adapterConnectOptions` | `Object`   | `{}`       |                                                                                                                                                            |
-| `defaultAccess`         | `Object`   | `{}`       |                                                                                                                                                            |
-| `onConnect`             | `Function` | `null`     |                                                                                                                                                            |
-| `cookieSecret`          | `String`   | `qwerty`   |                                                                                                                                                            |
-| `cookieMaxAge`          | `Int`      | 30 days    |                                                                                                                                                            |
-| `secureCookies`         | `Boolean`  | Variable   | Defaults to true in production mode, false otherwise.                                                                                                      |
-| `sessionStore`          | `Object`   | `null`     |                                                                                                                                                            |
-| `schemaNames`           | `Array`    | `[public]` |                                                                                                                                                            |
-| `expressOptions`        | `Object`   | `{}`       | Settings to pass to middleware Express instances. Refer to the [Express documentation](https://expressjs.com/en/4x/api.html#app.set) for more information. |
+| Option           | Type       | Default    | Description                                                                                                                                                |
+| ---------------- | ---------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`           | `String`   | `null`     | The name of the project. Appears in the Admin UI.                                                                                                          |
+| `adapter`        | `Object`   | Required   | The database storage adapter. See the [Adapter Framework](https://v5.keystonejs.com/keystone-alpha/keystone/lib/adapters/) page for more details.          |
+| `adapters`       | `Array`    | `[]`       |                                                                                                                                                            |
+| `defaultAdapter` | `Object`   | `null`     |                                                                                                                                                            |
+| `defaultAccess`  | `Object`   | `{}`       |                                                                                                                                                            |
+| `onConnect`      | `Function` | `null`     |                                                                                                                                                            |
+| `cookieSecret`   | `String`   | `qwerty`   |                                                                                                                                                            |
+| `cookieMaxAge`   | `Int`      | 30 days    |                                                                                                                                                            |
+| `secureCookies`  | `Boolean`  | Variable   | Defaults to true in production mode, false otherwise.                                                                                                      |
+| `sessionStore`   | `Object`   | `null`     |                                                                                                                                                            |
+| `schemaNames`    | `Array`    | `[public]` |                                                                                                                                                            |
+| `expressOptions` | `Object`   | `{}`       | Settings to pass to middleware Express instances. Refer to the [Express documentation](https://expressjs.com/en/4x/api.html#app.set) for more information. |
 | `queryLimits`           | `Object`   | `{}`       | Configures global query limits                                                                                                                    |
 
 ### `queryLimits`

--- a/packages/keystone/lib/Keystone/index.js
+++ b/packages/keystone/lib/Keystone/index.js
@@ -50,7 +50,6 @@ module.exports = class Keystone {
     adapter,
     defaultAdapter,
     name,
-    adapterConnectOptions = {},
     onConnect,
     cookieSecret = 'qwerty',
     sessionStore,
@@ -61,7 +60,6 @@ module.exports = class Keystone {
     expressOptions = {},
   }) {
     this.name = name;
-    this.adapterConnectOptions = adapterConnectOptions;
     this.defaultAccess = { list: true, field: true, custom: true, ...defaultAccess };
     this.auth = {};
     this.lists = {};


### PR DESCRIPTION
In KS4 it was possible to set your desired Express template engine (among other things) in `keystone.init`. I couldn't find any way to do that simply in KS5 without running a custom server for a single `app.set` line. Since StaticApp is the bare-bones view wrapper (the Next and Nuxt apps use React and Vue), I think it would be useful to allow setting that (and other things) here.

To avoid unnecessary specificity, I made it so you can configure any Express setting.

