### PR TITLE
Add schemaName and schemaNames parameters to setupServer()

### DIFF
--- a/.changeset/ninety-boats-chew/changes.json
+++ b/.changeset/ninety-boats-chew/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/test-utils", "type": "minor" }], "dependents": [] }

--- a/.changeset/ninety-boats-chew/changes.md
+++ b/.changeset/ninety-boats-chew/changes.md
@@ -1,0 +1,1 @@
+Add `schemaName` and `schemaNames` parameters to `setupServer()`.

--- a/packages/test-utils/lib/test-utils.js
+++ b/packages/test-utils/lib/test-utils.js
@@ -8,11 +8,11 @@ const { GraphQLApp } = require('@keystone-alpha/app-graphql');
 const { KnexAdapter } = require('@keystone-alpha/adapter-knex');
 const { MongooseAdapter } = require('@keystone-alpha/adapter-mongoose');
 
-const SCHEMA_NAME = 'testing';
-
 async function setupServer({
   name,
   adapterName,
+  schemaName = 'testing',
+  schemaNames = ['testing'],
   createLists = () => {},
   keystoneOptions,
   graphqlOptions = {},
@@ -31,7 +31,7 @@ async function setupServer({
     name,
     adapter: new Adapter(await argGenerator()),
     defaultAccess: { list: true, field: true },
-    schemaNames: [SCHEMA_NAME],
+    schemaNames,
     ...keystoneOptions,
   });
 
@@ -39,7 +39,7 @@ async function setupServer({
 
   const apps = [
     new GraphQLApp({
-      schemaName: SCHEMA_NAME,
+      schemaName,
       apiPath: '/admin/api',
       graphiqlPath: '/admin/graphiql',
       ...graphqlOptions,


### PR DESCRIPTION
This will allow users to use a `createLists` function which applies access control across multiple schemas, and will allow testing against a specific access control schema.