### PR TITLE
Rename Keystone to KeystoneJS in docs where possible

### DIFF
--- a/.changeset/hot-laws-travel/changes.json
+++ b/.changeset/hot-laws-travel/changes.json
@@ -1,21 +1,21 @@
 {
   "releases": [
-    { "name": "@keystone-alpha/demo-project-blog", "type": "minor" },
-    { "name": "@keystone-alpha/demo-project-todo", "type": "minor" },
-    { "name": "@keystone-alpha/adapter-knex", "type": "minor" },
-    { "name": "@keystone-alpha/adapter-mongoose", "type": "minor" },
-    { "name": "@keystone-alpha/apollo-helpers", "type": "minor" },
-    { "name": "@keystone-alpha/app-graphql-playground", "type": "minor" },
-    { "name": "@keystone-alpha/app-graphql", "type": "minor" },
-    { "name": "@keystone-alpha/app-schema-router", "type": "minor" },
-    { "name": "@keystone-alpha/app-static", "type": "minor" },
-    { "name": "@keystone-alpha/auth-password", "type": "minor" },
-    { "name": "@keystone-alpha/fields", "type": "minor" },
-    { "name": "@keystone-alpha/file-adapters", "type": "minor" },
-    { "name": "@keystone-alpha/keystone", "type": "minor" },
-    { "name": "@keystone-alpha/session", "type": "minor" },
-    { "name": "@keystone-alpha/test-utils", "type": "minor" },
-    { "name": "@keystone-alpha/cypress-project-basic", "type": "minor" }
+    { "name": "@keystone-alpha/demo-project-blog", "type": "patch" },
+    { "name": "@keystone-alpha/demo-project-todo", "type": "patch" },
+    { "name": "@keystone-alpha/adapter-knex", "type": "patch" },
+    { "name": "@keystone-alpha/adapter-mongoose", "type": "patch" },
+    { "name": "@keystone-alpha/apollo-helpers", "type": "patch" },
+    { "name": "@keystone-alpha/app-graphql-playground", "type": "patch" },
+    { "name": "@keystone-alpha/app-graphql", "type": "patch" },
+    { "name": "@keystone-alpha/app-schema-router", "type": "patch" },
+    { "name": "@keystone-alpha/app-static", "type": "patch" },
+    { "name": "@keystone-alpha/auth-password", "type": "patch" },
+    { "name": "@keystone-alpha/fields", "type": "patch" },
+    { "name": "@keystone-alpha/file-adapters", "type": "patch" },
+    { "name": "@keystone-alpha/keystone", "type": "patch" },
+    { "name": "@keystone-alpha/session", "type": "patch" },
+    { "name": "@keystone-alpha/test-utils", "type": "patch" },
+    { "name": "@keystone-alpha/cypress-project-basic", "type": "patch" }
   ],
   "dependents": []
 }

--- a/.changeset/hot-laws-travel/changes.json
+++ b/.changeset/hot-laws-travel/changes.json
@@ -1,0 +1,21 @@
+{
+  "releases": [
+    { "name": "@keystone-alpha/demo-project-blog", "type": "minor" },
+    { "name": "@keystone-alpha/demo-project-todo", "type": "minor" },
+    { "name": "@keystone-alpha/adapter-knex", "type": "minor" },
+    { "name": "@keystone-alpha/adapter-mongoose", "type": "minor" },
+    { "name": "@keystone-alpha/apollo-helpers", "type": "minor" },
+    { "name": "@keystone-alpha/app-graphql-playground", "type": "minor" },
+    { "name": "@keystone-alpha/app-graphql", "type": "minor" },
+    { "name": "@keystone-alpha/app-schema-router", "type": "minor" },
+    { "name": "@keystone-alpha/app-static", "type": "minor" },
+    { "name": "@keystone-alpha/auth-password", "type": "minor" },
+    { "name": "@keystone-alpha/fields", "type": "minor" },
+    { "name": "@keystone-alpha/file-adapters", "type": "minor" },
+    { "name": "@keystone-alpha/keystone", "type": "minor" },
+    { "name": "@keystone-alpha/session", "type": "minor" },
+    { "name": "@keystone-alpha/test-utils", "type": "minor" },
+    { "name": "@keystone-alpha/cypress-project-basic", "type": "minor" }
+  ],
+  "dependents": []
+}

--- a/.changeset/hot-laws-travel/changes.md
+++ b/.changeset/hot-laws-travel/changes.md
@@ -1,0 +1,1 @@
+Rename Keystone to KeystoneJS in docs where possible in docs

--- a/.changeset/ninety-boats-chew/changes.json
+++ b/.changeset/ninety-boats-chew/changes.json
@@ -1,1 +1,0 @@
-{ "releases": [{ "name": "@keystone-alpha/test-utils", "type": "minor" }], "dependents": [] }

--- a/.changeset/ninety-boats-chew/changes.md
+++ b/.changeset/ninety-boats-chew/changes.md
@@ -1,1 +1,0 @@
-Add `schemaName` and `schemaNames` parameters to `setupServer()`.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It is currently in alpha and under intensive development by [Thinkmill](https://
 
 ## What's new?
 
-Keystone 5 is a complete re-imagining of KeystoneJS for the future. It builds on the lessons we learned over the last 5 years of the Keystone's history and focuses on the things we believe are the most powerful features for modern web and mobile applications.
+Keystone 5 is a complete re-imagining of KeystoneJS for the future. It builds on the lessons we learned over the last 5 years of the KeystoneJS' history and focuses on the things we believe are the most powerful features for modern web and mobile applications.
 
 This means less focus on hand-holding Node.js template-driven websites and more focus on flexible architecture, a powerful GraphQL API with deep access control features, an extensible Admin UI and plugins for rich field types, file and database adapters, and session management.
 
@@ -43,10 +43,9 @@ yarn start
 For more details and system requirements, check out the [5 Minute Quick Start
 Guide](https://v5.keystonejs.com/quick-start/).
 
-
 ### API
 
-The [API documentation](https://v5.keystonejs.com/api/) contains a reference for all Keystone packages.
+The [API documentation](https://v5.keystonejs.com/api/) contains a reference for all KeystoneJS packages.
 
 ### Demo Projects
 
@@ -75,7 +74,6 @@ Add a script to your `package.json`:
 Create a file `index.js`:
 
 <!-- prettier-ignore -->
-
 ```javascript
 const { Keystone }        = require('@keystone-alpha/keystone');
 const { MongooseAdapter } = require('@keystone-alpha/adapter-mongoose');
@@ -104,7 +102,7 @@ module.exports = {
 };
 ```
 
-Now you have everything you need to run a Keystone instance:
+Now you have everything you need to run a `Keystone` instance:
 
 ```bash
 yarn dev

--- a/demo-projects/blog/README.md
+++ b/demo-projects/blog/README.md
@@ -13,7 +13,7 @@ The Keystone Admin UI is reachable from `localhost:3000/admin`. To log in, use t
 Username: `admin@keystonejs.com`
 Password: `password`
 
-To see an example Next.js app using Keystone's GraphQl APIs, head to `localhost:3000`.
+To see an example Next.js app using KeystoneJS' GraphQl APIs, head to `localhost:3000`.
 
 You can change the port that this demo runs on by setting the `PORT` environment variable.
 

--- a/demo-projects/todo/README.md
+++ b/demo-projects/todo/README.md
@@ -6,7 +6,7 @@ This is the todo list - the simplest implementation of Keystone. The todo list a
 
 To run this demo project, all you need to do is run `bolt` within the Keystone project root to install all required packages, then run `bolt start todo` to begin running Keystone.
 
-Once running, the Keystone Admin UI is reachable from `localhost:3000/admin`. To see an example React app using Keystone's GraphQl APIs, head to `localhost:3000`.
+Once running, the Keystone Admin UI is reachable from `localhost:3000/admin`. To see an example React app using KeystoneJS' GraphQl APIs, head to `localhost:3000`.
 
 You can change the port that this application runs on by setting the `PORT` environment variable.
 
@@ -16,4 +16,4 @@ PORT=5000 bolt start todo
 
 ## Demo React App
 
-The one 'extra' that this project includes is an example React App that consumes the data from Keystone via GraphQl. The app uses React's UMD build and is housed within the `/public` directory. It allows you to see how easy it is to create an app that can use Keystone's GraphQL APIs.
+The one 'extra' that this project includes is an example React App that consumes the data from Keystone via GraphQl. The app uses React's UMD build and is housed within the `/public` directory. It allows you to see how easy it is to create an app that can use KeystoneJS' GraphQL APIs.

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -6,7 +6,7 @@ order: 4
 
 # Authentication
 
-Authentication strategies allow users to identify themselves to Keystone. This can be used to restrict access to the AdminUI, and to configure [access controls](https://v5.keystonejs.com/guides/access-control/).
+Authentication strategies allow users to identify themselves to KeystoneJS. This can be used to restrict access to the AdminUI, and to configure [access controls](https://v5.keystonejs.com/guides/access-control/).
 
 - For password logins see: [`auth-password`](https://v5.keystonejs.com/keystone-alpha/auth-password/)
 - For social logins using [Passport.js](http://www.passportjs.org/) see: [`auth-passport`](https://v5.keystonejs.com/keystone-alpha/auth-passport/)

--- a/docs/api/create-list.md
+++ b/docs/api/create-list.md
@@ -27,8 +27,8 @@ keystone.createList('Post', {
 | `adapterConfig` | `Object`                            |                               | Override the adapter config options for a specific list.                                |
 | `itemQueryName` | `String`                            |                               | Changes the _item_ name in GraphQL queries and mutations.                               |
 | `listQueryName` | `String`                            |                               | Changes the _list_ name in GraphQL queries and mutations.                               |
-| `singular`      | `String`                            |                               | Specify a singular noun for Keystone to use for the list.                               |
-| `plural`        | `String`                            |                               | Specify a plural for Keystone to use for the list.                                      |
+| `singular`      | `String`                            |                               | Specify a singular noun for `Keystone` to use for the list.                             |
+| `plural`        | `String`                            |                               | Specify a plural for `Keystone` to use for the list.                                    |
 | `path`          | `String`                            |                               | Changes the path in the Admin UI.                                                       |
 | `plugins`       | `Array`                             | `[]`                          | An array of `plugins` that can modify the list config.                                  |
 
@@ -121,7 +121,7 @@ keystone.createList('User', {
 
 [Access control](https://v5.keystonejs.com/guides/access-control) options for the list.
 
-Options for `create`, `read`, `update` and `delete` - can be a function, GraphQL where clause or Boolean. See the (access control API documentation)[https://v5.keystonejs.com/api/access-control] for more details.
+Options for `create`, `read`, `update` and `delete` - can be a function, GraphQL where clause or Boolean. See the [access control API documentation](https://v5.keystonejs.com/api/access-control) for more details.
 
 #### Usage
 
@@ -214,13 +214,13 @@ query {
 
 ### `singular`
 
-Keystone list names should be singular and Keystone will attempt to determine a plural.
+KeystoneJS list names should be singular and KeystoneJS will attempt to determine a plural.
 
-Where Keystone can't determine a plural you may be forced to use a different list name.
+Where KeystoneJS can't determine a plural you may be forced to use a different list name.
 
 The `singular` option allows you to change the display label for singular items.
 
-E.g. Keystone can't determine a plural for 'Sheep'. Let's change the `singular` option:
+E.g. KeystoneJS can't determine a plural for 'Sheep'. Let's change the `singular` option:
 
 ```javascript
 keystone.createList('WoolyBoi', {
@@ -236,9 +236,9 @@ _Note_: This will override labels in the AdminUI but will not change graphQL que
 
 ### `plural`
 
-Keystone will attempt to determine a plural for list items. Sometimes Keystone will not be able to determine the plural forcing you to change the list name. Or sometimes Keystone may get it wrong, especially for non-English words.
+KeystoneJS will attempt to determine a plural for list items. Sometimes KeystoneJS will not be able to determine the plural forcing you to change the list name. Or sometimes KeystoneJS may get it wrong, especially for non-English words.
 
-E.g. Keystone thinks the correct plural for Octopus is "Octopi". Everyone knows the scientifically accurate plural is "Octopodes":
+E.g. KeystoneJS thinks the correct plural for Octopus is "Octopi". Everyone knows the scientifically accurate plural is "Octopodes":
 
 ```javascript
 keystone.createList('Octopus', {
@@ -255,7 +255,7 @@ Changes the path in the Admin UI. Updating `plural` and `singular` values will n
 
 ### `adapterConfig`
 
-Override the adapter config options for a specific list. Normally `adapterConfig` is provided when initialising Keystone:
+Override the adapter config options for a specific list. Normally `adapterConfig` is provided when initialising KeystoneJS:
 
 ```javascript
 const keystone = new Keystone({

--- a/docs/api/validation.md
+++ b/docs/api/validation.md
@@ -6,7 +6,7 @@ order: 6
 
 # Query Validation
 
-Stop maliciously complex or invalid queries against your Keystone instance.
+Stop maliciously complex or invalid queries against your `Keystone` instance.
 
 ```javascript
 const { validation } = require('@keystone-alpha/app-graphql');

--- a/docs/guides/access-control.md
+++ b/docs/guides/access-control.md
@@ -9,7 +9,7 @@ title: Access Control
 
 ## Intro
 
-What a user _can_ and _cannot_ do in Keystone depends on two things: _authentication_ and _access control_.
+What a user _can_ and _cannot_ do in KeystoneJS depends on two things: _authentication_ and _access control_.
 
 This guide focuses on the GraphQL API _access control_, which refers to the specific actions an authenticated or anonymous user can take.
 
@@ -19,7 +19,7 @@ _Authentication_, on the other hand, refers to a user identifying themselves in 
 
 Access control is about limiting CRUD (Create, Read, Update, Delete) actions that can be performed based on the current user (authenticated or anonymous).
 
-In Keystone, both [Lists](/api/create-list) and [Fields](keystone-alpha/fields) take an `access` option, which lets you define rules of access control with fine precision - see [Access Control API](/api/access-control) docs for more details.
+In KeystoneJS, both [Lists](/api/create-list) and [Fields](keystone-alpha/fields) take an `access` option, which lets you define rules of access control with fine precision - see [Access Control API](/api/access-control) docs for more details.
 
 ### Example
 
@@ -29,7 +29,7 @@ Let's assume we want set the following access controls for a `User` list:
 2. Only authenticated users can _read/update_ their own email, not any other user's. Admins can _read/update_ anyone's email.
 3. Only admins can see if a password is set. No-one can read their own or other
    user's passwords.
-   - _NOTE: It is **never** possible in Keystone to read a password via the
+   - _NOTE: It is **never** possible in KeystoneJS to read a password via the
      Admin UI or the API)_
 4. Only authenticated users can update their own password. Admins can update
    anyone's password.

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -54,7 +54,7 @@ const authStrategy = keystone.createAuthStrategy({
 const admin = new AdminUIApp({ authStrategy });
 ```
 
-Once your Keystone server is restarted, the Admin UI will now enforce
+Once your KeystoneJS server is restarted, the Admin UI will now enforce
 authentication.
 
 ### Logging in to the Admin UI
@@ -70,7 +70,7 @@ the `new AdminUIApp()` call:
 + const admin = new AdminUIApp({ });
 ```
 
-Restart your Keystone App, and visit <http://localhost:3000/users> - you should now be able to access the Admin UI without logging in.
+Restart your KeystoneJS App, and visit <http://localhost:3000/users> - you should now be able to access the Admin UI without logging in.
 
 Next, create a User (be sure to set both a username and password).
 
@@ -81,7 +81,7 @@ Add the `authStrategy` config back to the `new AdminUIApp()` call
 + const admin = new AdminUIApp({ authStrategy });
 ```
 
-Restart your Keystone App once more, and try to visit <http://localhost:3000/users>; you will be presented with the login screen.
+Restart your KeystoneJS App once more, and try to visit <http://localhost:3000/users>; you will be presented with the login screen.
 
 Finally; login with the newly created `User`'s credentials.
 

--- a/docs/guides/custom-field-types.md
+++ b/docs/guides/custom-field-types.md
@@ -31,7 +31,7 @@ methods, and other helper utilities.
 ## Implementation
 
 This is the back-end class that implements the field type and its schema in
-Keystone. It implements the GraphQL schema types, custom argument definitions
+KeystoneJS. It implements the GraphQL schema types, custom argument definitions
 and resolvers, as well as Field Config and Admin Meta management.
 
 Back-end logic for value validation, processing and hooks should be implemented

--- a/docs/guides/custom-server.md
+++ b/docs/guides/custom-server.md
@@ -22,7 +22,7 @@ Server must handle initialising a http server which correctly executes any given
 
 _Note_: Before reaching for a custom server, consider using a KeystoneJS
 App which can enhance the functionality of the default server. Apps
-available in Keystone include:
+available in KeystoneJS include:
 
 - [Static App](../../keystone-alpha/app-static) for serving static files.
 - [Next.js App](../../keystone-alpha/app-next) for serving a Next.js App on the same server as the API
@@ -145,13 +145,13 @@ Promise.all(preparations)
 
 ## Custom Server as a Lambda
 
-Keystone is powered by Node, so can run in "Serverless" environments such as
+KeystoneJS is powered by Node, so can run in "Serverless" environments such as
 [AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/welcome.html) which
 support Node >= 10.x.
 
 With a little finesse (and the [`serverless-http`
 library](https://github.com/dougmoscrop/serverless-http)), we can run our
-Keystone instance in AWS Lambda:
+KeystoneJS instance in AWS Lambda:
 
 `lambda.js`
 

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -8,7 +8,7 @@ title: Hooks
 > _NOTE: Below is an overview of hooks. For API docs see
 > [Hooks API](https://v5.keystonejs.com/api/hooks)._
 
-Keystone provide a system of hooks on the `create`, `update`, and `delete` mutations which allow developers to customise the behaviour of their system.
+KeystoneJS provide a system of hooks on the `create`, `update`, and `delete` mutations which allow developers to customise the behaviour of their system.
 
 There are 7 hooks available to use, which can be grouped into pre- and post-hooks depending on whether they get invoked before or after the database update operation.
 

--- a/docs/guides/initial-data.md
+++ b/docs/guides/initial-data.md
@@ -48,11 +48,7 @@ module.exports = {
 
 Initialising a list is not always the straight forward problem it seems.
 
-```javascript
-
-```
-
-You can achieve this setup by running the Keystone CLI and selecting the `Starter` template.
+You can achieve this setup by running the KeystoneJS CLI and selecting the `Starter` template.
 
 This method's primary use is intended for migration scripts, or initial seeding of databases.
 
@@ -72,7 +68,7 @@ _Note_: The format of the data must match the schema setup with calls to `keysto
 
 #### Relationships
 
-It is possible to create relationships upon insertion by using the Keystone
+It is possible to create relationships upon insertion by using the KeystoneJS
 query syntax.
 
 ##### Single Relationships
@@ -101,7 +97,7 @@ keystone.createList('Post', {
 });
 ```
 
-Upon insertion, Keystone will resolve the `{ where: { name: 'Ticiana' } }` query
+Upon insertion, KeystoneJS will resolve the `{ where: { name: 'Ticiana' } }` query
 against the `User` list, ultimately setting the `author` field to the ID of the
 _first_ `User` that is found.
 
@@ -136,7 +132,7 @@ keystone.createItems({
     { title: 'Hello Everyone' },
     { title: 'Talking about React' },
     { title: 'React is the Best' },
-    { title: 'Keystone Rocks' },
+    { title: 'KeystoneJS Rocks' },
   ],
 });
 ```
@@ -151,7 +147,7 @@ keystone.createItems({
       posts: [
         // Notice the Array of queries
         { where: { title: 'Hello Everyone' } },
-        { where: { title: 'Keystone Rocks' } },
+        { where: { title: 'KeystoneJS Rocks' } },
       ],
     },
     { name: 'Lauren' },
@@ -160,7 +156,7 @@ keystone.createItems({
     { title: 'Hello Everyone' },
     { title: 'Talking about React' },
     { title: 'React is the Best' },
-    { title: 'Keystone Rocks' },
+    { title: 'KeystoneJS Rocks' },
   ],
 });
 ```
@@ -170,7 +166,7 @@ any items, an Error will be thrown._
 
 ---
 
-The entire power of Keystone Query Syntax is supported.
+The entire power of KeystoneJS Query Syntax is supported.
 
 If you need to related to the 3rd item, you'd use a query like:
 

--- a/docs/guides/intro-to-graphql.md
+++ b/docs/guides/intro-to-graphql.md
@@ -5,11 +5,11 @@ title: GraphQL
 
 # Introduction to the GraphQL API
 
-_Before you begin:_ This guide assumes you have running instance of Keystone with the GraphQL App configured, and a list with some data to query. (Get started in 5min by running `npx create-keystone-app` and select the `Starter` project)
+_Before you begin:_ This guide assumes you have running instance of KeystoneJS with the GraphQL App configured, and a list with some data to query. (Get started in 5min by running `npx create-keystone-app` and select the `Starter` project)
 
-Examples in this guide will refer to a `Users` list, however the queries, mutations and methods listed here would be the same for any Keystone list.
+Examples in this guide will refer to a `Users` list, however the queries, mutations and methods listed here would be the same for any KeystoneJS list.
 
-For each list, Keystone generates four top level queries. Given the following example:
+For each list, KeystoneJS generates four top level queries. Given the following example:
 
 ```javascript
 keystone.createList('User', {
@@ -21,7 +21,7 @@ keystone.createList('User', {
 
 ## Queries
 
-Keystone would generate the following queries:
+KeystoneJS would generate the following queries:
 
 - `allUsers`
 - `_allUsersMeta`
@@ -76,7 +76,7 @@ Retrieves meta information about the `User` list itself (ie; not about items in 
 
 ## Mutations
 
-For each list Keystone generates six top level mutations:
+For each list KeystoneJS generates six top level mutations:
 
 - `createUser`
 - `createUsers`
@@ -161,9 +161,9 @@ mutation {
 
 ## Executing Queries and Mutations
 
-Before you begin writing application code, a great place test queries and mutations is the [GraphQL Playground](https://www.apollographql.com/docs/apollo-server/features/graphql-playground/). The default path for Keystone's GraphQl Playground is `http://localhost:3000/admin/graphql`. Here you can execute queries and mutations against the Keystone API without writing any JavaScript.
+Before you begin writing application code, a great place test queries and mutations is the [GraphQL Playground](https://www.apollographql.com/docs/apollo-server/features/graphql-playground/). The default path for KeystoneJS' GraphQl Playground is `http://localhost:3000/admin/graphql`. Here you can execute queries and mutations against the KeystoneJS API without writing any JavaScript.
 
-Once you have determined the correct query or mutation, you can add this to your application. To do this you will need to submit a `POST` request to Keystone's API. The default API endpoint is: `http://localhost:3000/admin/api`.
+Once you have determined the correct query or mutation, you can add this to your application. To do this you will need to submit a `POST` request to KeystoneJS' API. The default API endpoint is: `http://localhost:3000/admin/api`.
 
 In our examples we're going to use the browser's [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) to make a `POST` request.
 
@@ -393,7 +393,7 @@ Both `skip` and `first` respect the values of the `where`, `search` and `orderBy
 
 ## Custom queries and Mutations
 
-You can add to Keystone's generated schema with custom types, queries, and mutations using the `keystone.extendGraphQLSchema()` method.
+You can add to KeystoneJS' generated schema with custom types, queries, and mutations using the `keystone.extendGraphQLSchema()` method.
 
 ### Usage
 

--- a/docs/guides/mutation-lifecycle.md
+++ b/docs/guides/mutation-lifecycle.md
@@ -33,7 +33,7 @@ title: Mutation Lifecycle
 
 ## Introduction
 
-The Keystone GraphQL API implements a CRUD API with `create`, `update` and `delete` mutations for each `List`.
+The KeystoneJS GraphQL API implements a CRUD API with `create`, `update` and `delete` mutations for each `List`.
 Each of these mutations can be applied to either a single item or many items at once.
 
 For a `List` called `User` the GraphQL mutations would be:
@@ -47,7 +47,7 @@ For a `List` called `User` the GraphQL mutations would be:
   - `updateUsers`
   - `deleteUsers`
 
-Each of these mutations is implemented within Keystone by a corresponding resolver, implemented as a method on the core `List` object.
+Each of these mutations is implemented within KeystoneJS by a corresponding resolver, implemented as a method on the core `List` object.
 
 - **GraphQL mutation** → **List resolver method**
 - `createUser` → `createMutation`
@@ -61,7 +61,7 @@ Each of these mutations is implemented within Keystone by a corresponding resolv
 Please refer to the [API documentation](LINK_TODO)) for full details on how to call these mutations either from [GraphQL](LINK_TODO)) or directly from [Keystone](LINK_TODO)).
 -->
 
-Keystone provides [access control](https://v5.keystonejs.com/guides/access-control)) mechanisms and a [hook system](https://v5.keystonejs.com/guides/hooks)) which allows the developer to customise the behaviour of each of these mutations.
+KeystoneJS provides [access control](https://v5.keystonejs.com/guides/access-control)) mechanisms and a [hook system](https://v5.keystonejs.com/guides/hooks)) which allows the developer to customise the behaviour of each of these mutations.
 
 This document details the lifecycle of each mutation, and how the different access control mechanisms and hooks interact.
 

--- a/docs/guides/new-project.md
+++ b/docs/guides/new-project.md
@@ -1,11 +1,11 @@
 <!--[meta]
 section: guides
-title: Creating a New Keystone Project
+title: Creating a New KeystoneJS Project
 [meta]-->
 
-# Creating a New Keystone Project
+# Creating a New KeystoneJS Project
 
-In this guide we will learn how to manually create and run a new Keystone project.
+In this guide we will learn how to manually create and run a new KeystoneJS project.
 
 ## Initialization and basic packages
 
@@ -18,7 +18,7 @@ yarn init
 ```
 
 Let's start from minimal setup. We will need two packages here:
-`@keystone-alpha/keystone` which is Keystone's core and `@keystone-alpha/adapter-mongoose` which allows our app to connect to MongoDB.
+`@keystone-alpha/keystone` which is KeystoneJS' core and `@keystone-alpha/adapter-mongoose` which allows our app to connect to MongoDB.
 
 Do
 
@@ -28,7 +28,7 @@ yarn add @keystone-alpha/keystone @keystone-alpha/adapter-mongoose
 
 ## First steps in coding
 
-After installation we can start to write our code. Main entry point of Keystone app is `index.js` file placed in root folder. Create it and type following:
+After installation we can start to write our code. Main entry point of KeystoneJS app is `index.js` file placed in root folder. Create it and type following:
 
 ```javascript
 // import necessary modules
@@ -42,7 +42,7 @@ const keystone = new Keystone({
 });
 ```
 
-You can specify any suitable name for your application. Note that we created an instance of Mongoose adapter and passed it to Keystone's constructor.
+You can specify any suitable name for your application. Note that we created an instance of Mongoose adapter and passed it to KeystoneJS' constructor.
 
 Now we can export our instance and make it available for running. Add following to the end of `index.js`:
 
@@ -58,7 +58,7 @@ That's it. But now our app does nothing, just starting and connecting to databas
 TypeError: Router.use() requires a middleware function
 ```
 
-Let's create some routes! For this we will use another powerful Keystone's feature - GraphQL explorer UI.
+Let's create some routes! For this we will use another powerful KeystoneJS' feature - GraphQL explorer UI.
 
 ## Setting up GraphQL interface
 
@@ -83,7 +83,7 @@ module.exports = {
 };
 ```
 
-In order to be able to start an app we need to add at least one List. List is a model that is compatible with Keystone's admin UI.
+In order to be able to start an app we need to add at least one List. List is a model that is compatible with KeystoneJS' admin UI.
 
 ## Adding first List
 

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -83,8 +83,8 @@ const server = new WebServer(keystone, {
 });
 ```
 
-Next, start the Keystone server but include a `DUMP_SCHEMA` environment variable.
-This will output the Keystone schema to the given path
+Next, start the KeystoneJS server but include a `DUMP_SCHEMA` environment variable.
+This will output the KeystoneJS schema to the given path
 (ready for us to upload to Apollo Engine!):
 
 ```shell
@@ -131,7 +131,7 @@ node -r dotenv/config index.js
 
 _(Note: you do not need the `DUMP_SCHEMA` environment variable when starting the
 server - it is only used for exporting an updated schema and should not be set
-when trying to start the Keystone GraphQL API)_
+when trying to start the KeystoneJS GraphQL API)_
 
 Apollo Server will read the `ENGINE_API_KEY` env var and start sending graphQL
 stats to Apollo Engine.

--- a/docs/guides/relationships.md
+++ b/docs/guides/relationships.md
@@ -38,7 +38,7 @@ Now we can set a task for the User from the admin panel. But something is wrong!
 
 ## Enabling Back Reference between Users and Todos
 
-Back Reference is Keystone's mechanism that can overwrite fields of the referenced entity.
+Back Reference is KeystoneJS' mechanism that can overwrite fields of the referenced entity.
 It is better seen in action, so let's write some code first.
 
 In `Users.js` adjust the `task` field to the following:
@@ -63,7 +63,7 @@ Take a look at admin panel and try to assign a Todo to a user. Notice that the u
 
 ## Assigning a user to multiple tasks (to-many relationship)
 
-What if we need user to do multiple tasks? Keystone provides a way to do this easily.
+What if we need user to do multiple tasks? KeystoneJS provides a way to do this easily.
 Take a look at following code in `Users.js`:
 
 ```javascript

--- a/docs/guides/schema.md
+++ b/docs/guides/schema.md
@@ -162,7 +162,7 @@ Let's imagine we have a single item in our `Todo` list:
 
 | `id` | `task`       | `createdBy` |
 | ---- | ------------ | ----------- |
-| 1    | Use Keystone | Tici        |
+| 1    | Use KeystoneJS | Tici        |
 
 </div>
 
@@ -179,7 +179,7 @@ query {
 # output:
 # {
 #   allTodos: [
-#     { task: 'Use Keystone', createdBy: 'Tici' }
+#     { task: 'Use KeystoneJS', createdBy: 'Tici' }
 #   ]
 # }
 ```
@@ -191,7 +191,7 @@ Everything looks great so far. Now, let's add another task:
 
 | `id` | `task`       | `createdBy` |
 | ---- | ------------ | ----------- |
-| 1    | Use Keystone | Tici        |
+| 1    | Use KeystoneJS | Tici        |
 | 2    | Setup linter | Tici        |
 
 </div>
@@ -207,7 +207,7 @@ query {
 # output:
 # {
 #   allTodos: [
-#     { task: 'Use Keystone', createdBy: 'Tici' }
+#     { task: 'Use KeystoneJS', createdBy: 'Tici' }
 #     { task: 'Setup linter', createdBy: 'Tici' }
 #   ]
 # }
@@ -232,7 +232,7 @@ keystone.createList('Todo', {
 
 | `id` | `task`       | `createdBy` | `email`          |
 | ---- | ------------ | ----------- | ---------------- |
-| 1    | Use Keystone | Tici        | tici@example.com |
+| 1    | Use KeystoneJS | Tici        | tici@example.com |
 | 2    | Setup Linter | Tici        | tici@example.com |
 
 </div>
@@ -249,7 +249,7 @@ query {
 # output:
 # {
 #   allTodos: [
-#     { task: 'Use Keystone', createdBy: 'Tici', email: 'tici@example.com' }
+#     { task: 'Use KeystoneJS', createdBy: 'Tici', email: 'tici@example.com' }
 #     { task: 'Setup linter', createdBy: 'Tici', email: 'tici@example.com' }
 #   ]
 # }
@@ -267,7 +267,7 @@ We can avoid the duplicate data by moving it out into its own `User` list:
 
 | `id` | `task`       | `createdBy` |
 | ---- | ------------ | ----------- |
-| 1    | Use Keystone | 1           |
+| 1    | Use KeystoneJS | 1           |
 | 2    | Setup Linter | 1           |
 
 </div>
@@ -299,7 +299,7 @@ query {
 # output:
 # {
 #   allTodos: [
-#     { task: 'Use Keystone', createdBy: 1 }
+#     { task: 'Use KeystoneJS', createdBy: 1 }
 #     { task: 'Setup linter', createdBy: 1 }
 #   ]
 # }
@@ -370,7 +370,7 @@ query {
 # output:
 # {
 #   allTodos: [
-#     { task: 'Use Keystone', createdBy: { name: 'Tici', email: 'tici@example.com' } }
+#     { task: 'Use KeystoneJS', createdBy: { name: 'Tici', email: 'tici@example.com' } }
 #     { task: 'Setup linter', createdBy: { name: 'Tici', email: 'tici@example.com' } }
 #   ]
 # }
@@ -435,7 +435,7 @@ The data stored in the database for the `createdBy` field will be a single ID:
 
 | `id` | `task`       | `createdBy` |
 | ---- | ------------ | ----------- |
-| 1    | Use Keystone | 1           |
+| 1    | Use KeystoneJS | 1           |
 | 2    | Setup Linter | 1           |
 
 </div>
@@ -487,7 +487,7 @@ query {
 # {
 #   User: {
 #     todoList: [
-#       { task: 'Use Keystone' },
+#       { task: 'Use KeystoneJS' },
 #       { task: 'Setup linter' },
 #     ]
 #   ]
@@ -502,7 +502,7 @@ IDs:
 
 | `id` | `task`       |
 | ---- | ------------ |
-| 1    | Use Keystone |
+| 1    | Use KeystoneJS |
 | 2    | Setup Linter |
 | 3    | Be Awesome   |
 | 4    | Write docs   |
@@ -576,7 +576,7 @@ query {
 # {
 #   User: {
 #     todoList: [
-#       { task: 'Use Keystone' },
+#       { task: 'Use KeystoneJS' },
 #       { task: 'Setup linter' },
 #     ]
 #   ],
@@ -593,7 +593,7 @@ The database would look like:
 
 | `id` | `task`       | `createdBy` |
 | ---- | ------------ | ----------- |
-| 1    | Use Keystone | 1           |
+| 1    | Use KeystoneJS | 1           |
 | 2    | Setup Linter | 1           |
 | 3    | Be Awesome   | 2           |
 | 4    | Write docs   | 2           |

--- a/docs/quick-start/adapters.md
+++ b/docs/quick-start/adapters.md
@@ -7,7 +7,7 @@ title: Configuring Adapters
 
 ## Choosing an adapter
 
-Keystone currently provides two database adapters. Choose the [Mongoose Adapter](/keystone-alpha/adapter-mongoose/) for MongoDB or the [Knex Adapter](/keystone-alpha/adapter-knex/) for PostgreSQL.
+KeystoneJS currently provides two database adapters. Choose the [Mongoose Adapter](/keystone-alpha/adapter-mongoose/) for MongoDB or the [Knex Adapter](/keystone-alpha/adapter-knex/) for PostgreSQL.
 
 _Note_: PostgreSQL requires an additional step to create a database.
 

--- a/docs/quick-start/getting-started.md
+++ b/docs/quick-start/getting-started.md
@@ -90,6 +90,6 @@ KeystoneJS provides a web interface for this API at this URL:
 
 ## What next?
 
-This todo app is a good introduction to Keystone, but chances are you'll want to build something a bit more complex and secure than that!
+This todo app is a good introduction to KeystoneJS, but chances are you'll want to build something a bit more complex and secure than that!
 
 The [guides section](/guides) is a great next step. It will walk you through concepts like [creating lists](/guides/add-lists), setting up [content relationships](/guides/relationships), managing [access control](/guides/access-control) and much more.

--- a/packages/adapter-knex/README.md
+++ b/packages/adapter-knex/README.md
@@ -47,7 +47,7 @@ The `DEFAULT_CONNECTION_URL` will be either one of the following environmental v
 - `DATABASE_URL`,
 - `KNEX_URI`
 
-or `'postgres://localhost/<DATABASE_NAME>'`where `DATABASE_NAME` is be derived from the Keystone project name.
+or `'postgres://localhost/<DATABASE_NAME>'`where `DATABASE_NAME` is be derived from the KeystoneJS project name.
 
 ## Debugging
 

--- a/packages/adapter-mongoose/README.md
+++ b/packages/adapter-mongoose/README.md
@@ -25,7 +25,7 @@ This is used as the `uri` parameter for `mongoose.connect()`.
 
 _**Default:**_ Environmental variable (see below) or `'mongodb://localhost/<DATABASE_NAME>'`
 
-If not specified, Keystone will first look for one of the following environmental variables:
+If not specified, KeystoneJS will first look for one of the following environmental variables:
 
 - `CONNECT_TO`,
 - `DATABASE_URL`,
@@ -36,7 +36,7 @@ If not specified, Keystone will first look for one of the following environmenta
 - `MONGOLAB_URI`,
 - `MONGOLAB_URL`
 
-If none of these are found a connection string is derived with a `DATABASE_NAME` from the Keystone project name.
+If none of these are found a connection string is derived with a `DATABASE_NAME` from the KeystoneJS project name.
 
 ### `mongooseOptions` (optional)
 

--- a/packages/apollo-helpers/README.md
+++ b/packages/apollo-helpers/README.md
@@ -7,7 +7,7 @@ title: Apollo Helpers
 # Apollo Helpers
 
 A set of functions and components to ease using
-[Apollo](https://www.apollographql.com/docs/react/) with Keystone.
+[Apollo](https://www.apollographql.com/docs/react/) with KeystoneJS.
 
 ## Installation
 
@@ -269,7 +269,7 @@ Which, when using this module's `<Query>` component, will re-load the now remove
 
 Now everything's up to date and we didn't have to use `writeQuery` or couple any of our components.
 
-### But why is this coupled to Keystone?
+### But why is this coupled to KeystoneJS?
 
 Let's continue the example above with another query:
 
@@ -331,7 +331,7 @@ Now the cache is:
 
 Not only are `allEvents` & `Group:xyz789` out of date, but so is `_allEventsMeta` (it should be `{ count: 3 }`).
 
-If we were to use this module's `<Mutation>` component, _but decoupled from Keystone_, the cache at this point would be:
+If we were to use this module's `<Mutation>` component, _but decoupled from KeystoneJS_, the cache at this point would be:
 
 ```json
 {
@@ -348,9 +348,9 @@ If we were to use this module's `<Mutation>` component, _but decoupled from Keys
 
 This example highlights the limits of other approaches (see below for possible workarounds / other solutions to this).
 
-In swoops Keystone to the rescue! 🦅
+In swoops KeystoneJS to the rescue! 🦅
 
-We _do_ know the related type information within Keystone! It's a walled garden which we control, so can extract further information such as _`_allEventsMeta` is a query that relates to `Event`s_.
+We _do_ know the related type information within KeystoneJS! It's a walled garden which we control, so can extract further information such as _`_allEventsMeta` is a query that relates to `Event`s_.
 
 So, using this module's `<Mutation>` component:
 
@@ -395,7 +395,7 @@ Which, when using this module's `<Query>` component, will re-load the now remove
 }
 ```
 
-### Can we decouple from Keystone?
+### Can we decouple from KeystoneJS?
 
 If we only cared about queries that explicitly relate to a given type, then we can scan the GraphQL AST / Introspection query to get all the correct queries. This will miss queries such as `_allEventsMeta`.
 
@@ -423,4 +423,4 @@ type Query {
 }
 ```
 
-If we went with this method, we could automatically inject that directive into Keystone generated GraphQL schemas.
+If we went with this method, we could automatically inject that directive into KeystoneJS generated GraphQL schemas.

--- a/packages/app-graphql-playground/README.md
+++ b/packages/app-graphql-playground/README.md
@@ -7,7 +7,7 @@ draft: true
 
 # GraphQL Playground App
 
-A Keystone App that creates an Apollo GraphQL playground.
+A KeystoneJS App that creates an Apollo GraphQL playground.
 
 ## Usage
 

--- a/packages/app-graphql/README.md
+++ b/packages/app-graphql/README.md
@@ -7,9 +7,9 @@ draft: true
 
 # GraphQL App
 
-A Keystone App that creates a GraphQL API and Apollo GraphQL playground.
+A KeystoneJS App that creates a GraphQL API and Apollo GraphQL playground.
 
-For information about writing queries and mutations for Keystone see the [Introduction to Keystone's GraphQL API](https://v5.keystonejs.com/guides/intro-to-graphql).
+For information about writing queries and mutations for KeystoneJS see the [Introduction to KeystoneJS' GraphQL API](https://v5.keystonejs.com/guides/intro-to-graphql).
 
 ## Usage
 

--- a/packages/app-schema-router/README.md
+++ b/packages/app-schema-router/README.md
@@ -7,7 +7,7 @@ draft: true
 
 # GraphQL Schema Router
 
-A Keystone App that route requests to different GraphQL schemas.
+A KeystoneJS App that route requests to different GraphQL schemas.
 
 The `SchemaRouterApp` allows you to define a `routerFn` which takes `(req, res)` and returns
 a `routerId`, which is used to pick between different GraphQL schemas which exist at the same

--- a/packages/app-static/README.md
+++ b/packages/app-static/README.md
@@ -6,7 +6,7 @@ title: Static App
 
 # KeystoneJS Static File App
 
-A Keystone App to serve static files such as images, CSS and JavaScript with support for client side routing.
+A KeystoneJS App to serve static files such as images, CSS and JavaScript with support for client side routing.
 
 ## Usage
 

--- a/packages/auth-password/README.md
+++ b/packages/auth-password/README.md
@@ -24,7 +24,7 @@ keystone.createList('User', {
 });
 ```
 
-We can configure the Keystone auth strategy as:
+We can configure the KeystoneJS auth strategy as:
 
 ```js
 const authStrategy = keystone.createAuthStrategy({
@@ -86,7 +86,7 @@ The build in `Password` field type fulfils this requirements.
 
 #### `protectIdentities`
 
-Generally, Keystone strives to provide users with detailed error messages.
+Generally, KeystoneJS strives to provide users with detailed error messages.
 In the context of authentication this is often not desirable.
 Information about existing accounts can inadvertently leaked to malicious actors.
 

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -6,7 +6,7 @@ order: 3
 
 # Fields
 
-Keystone contains a set of primitive fields types that can be imported from `@keystone-alpha/fields`. These include:
+KeystoneJS contains a set of primitive fields types that can be imported from `@keystone-alpha/fields`. These include:
 
 - [CalendarDay](keystone-alpha/fields/src/types/calendar-day)
 - [Checkbox](keystone-alpha/fields/src/types/checkbox)
@@ -61,7 +61,7 @@ _Note_: Many field types have additional config options. See the documentation f
 
 ### `type`
 
-A valid Keystone field type.
+A valid `Keystone` field type.
 
 ### `label`
 
@@ -107,6 +107,6 @@ Specifies whether the field is required or not. Will return an error if mutation
 
 [Access control](https://v5.keystonejs.com/guides/access-control) options for fields.
 
-Options for `create`, `read`, `update` and `delete` - can be a function or Boolean. See the (access control API documentation)[https://v5.keystonejs.com/api/access-control] for more details.
+Options for `create`, `read`, `update` and `delete` - can be a function or Boolean. See the [access control API documentation](https://v5.keystonejs.com/api/access-control) for more details.
 
 _Note_: Field level access control does not accept graphQL where clauses.

--- a/packages/fields/src/types/CalendarDay/README.md
+++ b/packages/fields/src/types/CalendarDay/README.md
@@ -101,10 +101,10 @@ All filter fields expect values in the ISO8601 (`YYYY-MM-DD`) format.
 
 In Mongoose the field is added using the `String` schema type.
 
-The `isRequired` config option is enforced by Keystone only.
+The `isRequired` config option is enforced by KeystoneJS only.
 
 ### Knex Adaptor
 
 The Knex adaptor uses the [Knex `date` type](https://knexjs.org/#Schema-date):
 
-The `isRequired` config option is enforced by Keystone and, if equal to `true`, the column is set as not nullable.
+The `isRequired` config option is enforced by KeystoneJS and, if equal to `true`, the column is set as not nullable.

--- a/packages/fields/src/types/Checkbox/README.md
+++ b/packages/fields/src/types/Checkbox/README.md
@@ -57,10 +57,10 @@ The `Checkbox` field type doesn't support indexes or unique enforcement.
 
 In Mongoose the field is added using the `Boolean` schema type.
 
-The `isRequired` config option is enforces by Keystone only.
+The `isRequired` config option is enforces by KeystoneJS only.
 
 ### Knex Adaptor
 
 The Knex adaptor uses the [Knex `boolean` type](https://knexjs.org/#Schema-boolean):
 
-The `isRequired` config option is enforces by Keystone and, if equal to `true`, the column is set as not nullable.
+The `isRequired` config option is enforces by KeystoneJS and, if equal to `true`, the column is set as not nullable.

--- a/packages/fields/src/types/DateTime/README.md
+++ b/packages/fields/src/types/DateTime/README.md
@@ -79,7 +79,7 @@ On the Mongoose adapter the `DateTime` value are stored across three fields:
 | `${path}_utc`    | `Date`      | The timestamp in as a native JS-style epoch        |
 | `${path}_offset` | `String`    | The offset component as string                     |
 
-The `isRequired` config option is enforces by Keystone only.
+The `isRequired` config option is enforces by KeystoneJS only.
 
 ### Knex Adaptor
 
@@ -90,4 +90,4 @@ On the Knex adapter the `DateTime` value are stored across two fields:
 | `${path}_utc`    | `timestamp` | The timestamp in UTC           |
 | `${path}_offset` | `text`      | The offset component as string |
 
-The `isRequired` config option is enforces by Keystone and, if equal to `true`, the column is set as not nullable.
+The `isRequired` config option is enforces by KeystoneJS and, if equal to `true`, the column is set as not nullable.

--- a/packages/fields/src/types/Slug/README.md
+++ b/packages/fields/src/types/Slug/README.md
@@ -143,7 +143,7 @@ A mutation to create a new item will auto-generate a slug:
 
 ```graphql
 mutation {
-  createPost(data: { title: "Why I ♥ Keystone" }) {
+  createPost(data: { title: "Why I ♥ KeystoneJS" }) {
     id
     title
     url
@@ -154,8 +154,8 @@ mutation {
 # {
 #   createPost: {
 #     id: "1",
-#     title: "Why I ♥ Keystone",
-#     url: "why-i-love-keystone"
+#     title: "Why I ♥ KeystoneJS",
+#     url: "why-i-love-keystonejs"
 #   }
 # }
 ```
@@ -165,7 +165,7 @@ subsequently created item with the same `title` will generate a unique slug:
 
 ```graphql
 mutation {
-  createPost(data: { title: "Why I ♥ Keystone" }) {
+  createPost(data: { title: "Why I ♥ KeystoneJS" }) {
     id
     title
     url
@@ -176,8 +176,8 @@ mutation {
 # {
 #   createPost: {
 #     id: "2",
-#     title: "Why I ♥ Keystone",
-#     url: "why-i-love-keystone-2108fh3"
+#     title: "Why I ♥ KeystoneJS",
+#     url: "why-i-love-keystonejs-2108fh3"
 #   }
 # }
 ```
@@ -186,7 +186,7 @@ You can also manually override the slug's value:
 
 ```graphql
 mutation {
-  createPost(data: { title: "Why I ♥ Keystone", url: "keystone-is-great" }) {
+  createPost(data: { title: "Why I ♥ KeystoneJS", url: "keystonejs-is-great" }) {
     id
     title
     url
@@ -197,8 +197,8 @@ mutation {
 # {
 #   createPost: {
 #     id: "2",
-#     title: "Why I ♥ Keystone",
-#     url: "keystone-is-great"
+#     title: "Why I ♥ KeystoneJS",
+#     url: "keystonejs-is-great"
 #   }
 # }
 ```
@@ -208,7 +208,7 @@ And overwritten slugs will be uniquified for you when `isUnique: true` (with
 
 ```graphql
 mutation {
-  createPost(data: { title: "Why I ♥ Keystone", url: "keystone-is-great" }) {
+  createPost(data: { title: "Why I ♥ KeystoneJS", url: "keystonejs-is-great" }) {
     id
     title
     url
@@ -219,8 +219,8 @@ mutation {
 # {
 #   createPost: {
 #     id: "2",
-#     title: "Why I ♥ Keystone",
-#     url: "keystone-is-great-f80p5sm"
+#     title: "Why I ♥ KeystoneJS",
+#     url: "keystonejs-is-great-f80p5sm"
 #   }
 # }
 ```

--- a/packages/file-adapters/README.md
+++ b/packages/file-adapters/README.md
@@ -8,7 +8,7 @@ title: File Adapters
 
 The `File` field type can support files hosted in a range of different contexts, e.g. in the local filesystem, or on a cloud based file server.
 
-Different contexts are supported by different file adapters. This package contains the built-in file adapters supported by Keystone.
+Different contexts are supported by different file adapters. This package contains the built-in file adapters supported by KeystoneJS.
 
 ## `LocalFileAdapter`
 

--- a/packages/keystone/README.md
+++ b/packages/keystone/README.md
@@ -39,13 +39,13 @@ const keystone = new Keystone({
 
 | Method                | Description                                                                  |
 | --------------------- | ---------------------------------------------------------------------------- |
-| `createList`          | Add a list to the Keystone schema.                                           |
+| `createList`          | Add a list to the `Keystone` schema.                                         |
 | `extendGraphQLSchema` | Extend keystones generated schema with custom types, queries, and mutations. |
 | `connect`             | Manually connect to Adapters.                                                |
-| `prepare`             | Manually prepare Keystone middlewares.                                       |
-| `createItems`         | Add items to a Keystone list.                                                |
+| `prepare`             | Manually prepare `Keystone` middlewares.                                     |
+| `createItems`         | Add items to a `Keystone` list.                                              |
 | `disconnect`          | Disconnect from all adapters.                                                |
-| `executeQuery`        | Run GraphQL queries and mutations directly against a Keystone instance.      |
+| `executeQuery`        | Run GraphQL queries and mutations directly against a `Keystone` instance.    |
 
 <!--
 
@@ -78,7 +78,7 @@ keystone.createList('Posts', {
 
 ### Config
 
-Registers a new list with Keystone and returns a Keystone list object.
+Registers a new list with `Keystone` and returns a `Keystone` list object.
 
 | Option    | Type     | Default | Description                                                                                                 |
 | --------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------- |
@@ -163,11 +163,11 @@ keystone.createList('Post', {
 
 _Note_: The format of the data must match the lists and fields setup with `keystone.createList()`
 
-It is possible to create relationships at insertion using the Keystone query syntax.
+It is possible to create relationships at insertion using the KeystoneJS query syntax.
 
 E.g. `author: { where: { name: 'Ticiana' } }`
 
-Upon insertion, Keystone will resolve the `{ where: { name: 'Ticiana' } }` query
+Upon insertion, KeystoneJS will resolve the `{ where: { name: 'Ticiana' } }` query
 against the `User` list, ultimately setting the `author` field to the ID of the
 _first_ `User` that is found.
 
@@ -190,13 +190,13 @@ const { middlewares } = await keystone.prepare({
 
 | Option    | Type      | default | Description                                         |
 | --------- | --------- | ------- | --------------------------------------------------- |
-| `dev`     | `Boolean` | `false` | Sets the dev flag in Keystone's express middleware. |
+| `dev`     | `Boolean` | `false` | Sets the dev flag in KeystoneJS express middleware. |
 | `apps`    | `Array`   | `[]`    | An array of 'Apps' which are express middleware.    |
 | `distDir` | `String`  | `dist`  | The build directory for keystone.                   |
 
 ## connect()
 
-Manually connect Keystone to the adapters.
+Manually connect KeystoneJS to the adapters.
 
 ### Usage
 
@@ -214,8 +214,7 @@ Disconnect all adapters.
 
 ## executeQuery(queryString, config)
 
-Use this method to execute queries or mutations directly against a Keystone
-instance.
+Use this method to execute queries or mutations directly against a `Keystone` instance.
 
 **Note:** When querying or mutating via `keystone.executeQuery`, there are differences to keep in mind:
 

--- a/packages/keystone/README.md
+++ b/packages/keystone/README.md
@@ -78,7 +78,7 @@ keystone.createList('Posts', {
 
 ### Config
 
-Registers a new list with `Keystone` and returns a `Keystone` list object.
+Registers a new list with KeystoneJS and returns a `Keystone` list object.
 
 | Option    | Type     | Default | Description                                                                                                 |
 | --------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------- |
@@ -188,11 +188,11 @@ const { middlewares } = await keystone.prepare({
 
 ### Config
 
-| Option    | Type      | default | Description                                         |
-| --------- | --------- | ------- | --------------------------------------------------- |
-| `dev`     | `Boolean` | `false` | Sets the dev flag in KeystoneJS express middleware. |
-| `apps`    | `Array`   | `[]`    | An array of 'Apps' which are express middleware.    |
-| `distDir` | `String`  | `dist`  | The build directory for keystone.                   |
+| Option    | Type      | default | Description                                          |
+| --------- | --------- | ------- | ---------------------------------------------------- |
+| `dev`     | `Boolean` | `false` | Sets the dev flag in KeystoneJS' express middleware. |
+| `apps`    | `Array`   | `[]`    | An array of 'Apps' which are express middleware.     |
+| `distDir` | `String`  | `dist`  | The build directory for keystone.                    |
 
 ## connect()
 

--- a/packages/keystone/lib/adapters/README.md
+++ b/packages/keystone/lib/adapters/README.md
@@ -9,7 +9,7 @@ This document describes the role of data store adapters in Keystone 5 and how th
 
 A `Keystone` system consists of multiple `Lists`, each of which contains multiple `Fields`.
 This data structure needs to be backed by a persistent data store of some kind.
-The _Keystone Adapter Framework_ facilitates this by providing an abstraction layer which can be implemented
+The _KeystoneJS Adapter Framework_ facilitates this by providing an abstraction layer which can be implemented
 by adapters for different data stores (e.g. Mongoose, Postgres, etc).
 
 ## Usage
@@ -58,13 +58,13 @@ keystone.createList('Pages', {
 
 ## The Adapter Data Model
 
-The adapter framework data model mirrors the Keystone data model.
+The adapter framework data model mirrors the KeystoneJS data model.
 
 - Each `Keystone` object has one or more `KeystoneAdapter` instances, accessible by the `.adapters` property
 - Each `List` object has one `ListAdapter`, accessible by the `.adapter` property
 - Each `Field` object has one `FieldAdapter`, accessible by the `.adapter` property
 
-The adapters do not contain references back to the Keystone objects.
+The adapters do not contain references back to the KeystoneJS objects.
 All required information is passed in to the adapter as paramaters to the constructor/methods.
 
 Each `KeystoneAdapter` contains references to its associated `ListAdapter` intances, via the `.listAdapters` property.

--- a/packages/session/README.md
+++ b/packages/session/README.md
@@ -6,4 +6,4 @@ title: Session
 
 # Session
 
-This package contains functions to assist with setting up session management in your Keystone system.
+This package contains functions to assist with setting up session management in your KeystoneJS system.

--- a/packages/test-utils/CHANGELOG.md
+++ b/packages/test-utils/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @keystone-alpha/test-utils
 
+## 2.5.0
+
+### Minor Changes
+
+- [66e1c33e](https://github.com/keystonejs/keystone-5/commit/66e1c33e): Add `schemaName` and `schemaNames` parameters to `setupServer()`.
+
 ## 2.4.1
 
 ### Patch Changes

--- a/packages/test-utils/README.md
+++ b/packages/test-utils/README.md
@@ -6,7 +6,7 @@ title: Test Utils
 
 # Test Utils
 
-This package is an internal Keystone package which contains utility functions to assist in running tests against the GraphQL API.
+This package is an internal KeystoneJS package which contains utility functions to assist in running tests against the GraphQL API.
 
 ## Installation
 

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keystone-alpha/test-utils",
   "description": "Common utilities used while testing @keystone-alpha/* packages.",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "author": "The KeystoneJS Development Team",
   "license": "MIT",
   "engines": {

--- a/test-projects/basic/custom-fields/Stars/README.md
+++ b/test-projects/basic/custom-fields/Stars/README.md
@@ -5,12 +5,12 @@ Finally this is available in Keystone 5 🎉.
 
 In this post we will be creating a simple custom Field Type for star ratings ⭐️ ⭐️ ⭐️ ⭐️ ⭐️!
 
-![Screenshot of the Stars input field in Keystone Admin UI](<>)
+![Screenshot of the Stars input field in Keystone Admin UI]()
 
 For this component, our data requirements are simple. We need to store an Integer in the database
 to represent the number of stars on a blog post. This makes things easy because Integer is a built
 in field type so we can leverage much of the Integer field type's default implementation and then
-provide custom UI components for Keystone's admin interface.
+provide custom UI components for KeystoneJS' admin interface.
 
 ## Directory structure
 


### PR DESCRIPTION
I've gone through every page on the website and tried to rename every instance of "Keystone" to "KeystoneJS". It's a little tricky as sometimes it makes more sense to use `Keystone`, but in most cases it makes sense to use "KeystoneJS"

This PR closes #865  