### PR TITLE
Replace alpha symbol on website with alpha version number

### DIFF
--- a/website/src/components/Header.js
+++ b/website/src/components/Header.js
@@ -66,17 +66,17 @@ const Logo = () => (
         KeystoneJS{' '}
       </span>
     </Link>
-    <abbr
+    <span
       css={{
-        cursor: 'help',
-        fontSize: '1.2em',
-        marginLeft: '0.2em',
-        textDecoration: 'none',
+        display: 'inline-block',
+        color: colors.N40,
+        fontStyle: 'italic',
+        marginLeft: '1.5em',
+        textDecoration: 'underline',
       }}
-      title="Keystone 5 is currently in alpha"
     >
-      (α)
-    </abbr>
+      v5.x alpha
+    </span>
   </div>
 );
 const NavItem = ({ as, lgOnly, ...props }) => {

--- a/website/src/components/Header.js
+++ b/website/src/components/Header.js
@@ -63,20 +63,19 @@ const Logo = () => (
           },
         }}
       >
-        KeystoneJS{' '}
+        KeystoneJS
+      </span>
+      <span
+        css={{
+          display: 'inline-block',
+          color: colors.N40,
+          fontStyle: 'italic',
+          marginLeft: '0.5em',
+        }}
+      >
+        v5.x alpha
       </span>
     </Link>
-    <span
-      css={{
-        display: 'inline-block',
-        color: colors.N40,
-        fontStyle: 'italic',
-        marginLeft: '1.5em',
-        textDecoration: 'underline',
-      }}
-    >
-      v5.x alpha
-    </span>
   </div>
 );
 const NavItem = ({ as, lgOnly, ...props }) => {

--- a/website/src/components/homepage/HomepageContent.js
+++ b/website/src/components/homepage/HomepageContent.js
@@ -7,21 +7,26 @@ import { media, mediaMax, mq } from '../../utils/media';
 
 const HomepageContent = () => (
   <Content>
-    <Heading>
-      Keystone 5
-      <abbr
+    <div
+      css={{
+        display: 'flex',
+        alignItems: 'baseline',
+      }}
+    >
+      <Heading>Keystone 5</Heading>
+      <span
         css={{
-          cursor: 'help',
-          // fontSize: '0.8em',
-          marginLeft: '0.2em',
-          textDecoration: 'none',
-          fontWeight: 'normal',
+          display: 'inline-block',
+          color: colors.N40,
+          fontSize: '0.9em',
+          fontStyle: 'italic',
+          marginLeft: '1em',
+          textDecoration: 'underline',
         }}
-        title="Keystone 5 is currently in alpha"
       >
-        (α)
-      </abbr>
-    </Heading>
+        v5.x alpha
+      </span>
+    </div>
     <div css={{ color: colors.N80, maxWidth: 640 }}>
       <p>A scalable platform and CMS to build Node.js applications.</p>
       <p>

--- a/website/src/components/homepage/HomepageContent.js
+++ b/website/src/components/homepage/HomepageContent.js
@@ -7,26 +7,7 @@ import { media, mediaMax, mq } from '../../utils/media';
 
 const HomepageContent = () => (
   <Content>
-    <div
-      css={{
-        display: 'flex',
-        alignItems: 'baseline',
-      }}
-    >
-      <Heading>Keystone 5</Heading>
-      <span
-        css={{
-          display: 'inline-block',
-          color: colors.N40,
-          fontSize: '0.9em',
-          fontStyle: 'italic',
-          marginLeft: '1em',
-          textDecoration: 'underline',
-        }}
-      >
-        v5.x alpha
-      </span>
-    </div>
+    <Heading>Keystone 5</Heading>
     <div css={{ color: colors.N80, maxWidth: 640 }}>
       <p>A scalable platform and CMS to build Node.js applications.</p>
       <p>


### PR DESCRIPTION
This PR attempts to close #1006 .

1. In the website header, I've removed the alpha symbol `(α)` and replaced that with `v5.x alpha`.
1. On the home page, I've removed the alpha symbol `(α)` and have not replaced it with anything. I think it looks weird having the version number here since its already right there in the header. What does everyone think?

### Screenshots

**Home Page**
<img width="1440" alt="Screen Shot 2019-09-25 at 9 20 27 am" src="https://user-images.githubusercontent.com/6265154/65557351-5d8a7200-df76-11e9-8a40-5694896a33e3.png">

**Content page**
<img width="1440" alt="Screen Shot 2019-09-25 at 9 20 10 am" src="https://user-images.githubusercontent.com/6265154/65557355-611df900-df76-11e9-88ae-d1ccf89a9d79.png">

**Mobile**
<img width="384" alt="Screen Shot 2019-09-25 at 9 19 18 am" src="https://user-images.githubusercontent.com/6265154/65557367-65e2ad00-df76-11e9-9bce-59eded3ee3ac.png">
