### PR TITLE
Always cast IDs to strings before comparison

### DIFF
--- a/.changeset/fast-sheep-compete/changes.json
+++ b/.changeset/fast-sheep-compete/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/adapter-knex", "type": "patch" }], "dependents": [] }

--- a/.changeset/fast-sheep-compete/changes.md
+++ b/.changeset/fast-sheep-compete/changes.md
@@ -1,0 +1,1 @@
+Fix a bug which limited the number of items in a many-relatinoship to 65K

--- a/packages/adapter-knex/lib/adapter-knex.js
+++ b/packages/adapter-knex/lib/adapter-knex.js
@@ -345,11 +345,10 @@ class KnexListAdapter extends BaseListAdapter {
           .select(a.refListId)
           .from(tableName)
           .where(`${this.key}_id`, item.id);
+        const currentRefIds = currentValues.map(x => x[a.refListId].toString());
 
         // Delete what needs to be deleted
-        const needsDelete = currentValues
-          .filter(x => !newValues.includes(x[a.refListId]))
-          .map(row => row[a.refListId]);
+        const needsDelete = currentRefIds.filter(x => !newValues.includes(x));
         if (needsDelete.length) {
           await this._query()
             .table(tableName)
@@ -358,7 +357,6 @@ class KnexListAdapter extends BaseListAdapter {
             .del();
         }
         // Add what needs to be added
-        const currentRefIds = currentValues.map(x => x[a.refListId]);
         const valuesToInsert = newValues
           .filter(id => !currentRefIds.includes(id))
           .map(id => ({


### PR DESCRIPTION
This fixes a bug which was causing the adapter to try to re-insert *all* items into the table at once, which was causing crashes when there were more than 65K items.