### PR TITLE
Remove getRelationshipQueryCondition method from Relationship

### DIFF
--- a/.changeset/clever-walls-destroy/changes.json
+++ b/.changeset/clever-walls-destroy/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/adapter-mongoose", "type": "patch" }], "dependents": [] }

--- a/.changeset/clever-walls-destroy/changes.md
+++ b/.changeset/clever-walls-destroy/changes.md
@@ -1,0 +1,1 @@
+Internal refactor to inline the logic which was previously computed by getRelationshipQueryCondition().

--- a/.changeset/five-toes-rescue/changes.json
+++ b/.changeset/five-toes-rescue/changes.json
@@ -1,0 +1,181 @@
+{
+  "releases": [{ "name": "@keystone-alpha/fields", "type": "major" }],
+  "dependents": [
+    {
+      "name": "@keystone-alpha/api-tests",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/auth-password",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-blog",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/app-admin-ui",
+        "@keystone-alpha/auth-password",
+        "@keystone-alpha/fields-markdown",
+        "@keystone-alpha/fields-wysiwyg-tinymce",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-meetup",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/app-admin-ui",
+        "@keystone-alpha/auth-password",
+        "@keystone-alpha/fields-wysiwyg-tinymce",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-todo",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/app-admin-ui",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/app-admin-ui",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields"]
+    },
+    {
+      "name": "@keystone-alpha/auth-passport",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields"]
+    },
+    {
+      "name": "@keystone-alpha/auth-password",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields"]
+    },
+    {
+      "name": "@keystone-alpha/example-projects-nuxt",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/app-admin-ui",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/example-projects-starter",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/app-admin-ui",
+        "@keystone-alpha/auth-password",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/example-projects-todo",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/app-admin-ui",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/field-content",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields"]
+    },
+    {
+      "name": "@keystone-alpha/fields-auto-increment",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields"]
+    },
+    {
+      "name": "@keystone-alpha/fields-datetime-utc",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields"]
+    },
+    {
+      "name": "@keystone-alpha/fields-markdown",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields"]
+    },
+    {
+      "name": "@keystone-alpha/fields-mongoid",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields"]
+    },
+    {
+      "name": "@keystone-alpha/fields-wysiwyg-tinymce",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields"]
+    },
+    {
+      "name": "@keystone-alpha/keystone",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields"]
+    },
+    {
+      "name": "@keystone-alpha/list-plugins",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields"]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-access-control",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/app-admin-ui",
+        "@keystone-alpha/auth-password",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-basic",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/app-admin-ui",
+        "@keystone-alpha/field-content",
+        "@keystone-alpha/fields-markdown",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-client-validation",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/app-admin-ui",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-login",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/app-admin-ui",
+        "@keystone-alpha/auth-password",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/list-plugins",
+        "@keystone-alpha/fields"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-social-login",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/app-admin-ui",
+        "@keystone-alpha/auth-passport",
+        "@keystone-alpha/auth-password",
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/fields"
+      ]
+    }
+  ]
+}

--- a/.changeset/five-toes-rescue/changes.md
+++ b/.changeset/five-toes-rescue/changes.md
@@ -1,0 +1,1 @@
+MongoRelationshipInterface.getRelationshipQueryCondition() has been removed.

--- a/.changeset/giant-mugs-refuse/changes.json
+++ b/.changeset/giant-mugs-refuse/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/build-field-types", "type": "patch" }], "dependents": [] }

--- a/.changeset/giant-mugs-refuse/changes.md
+++ b/.changeset/giant-mugs-refuse/changes.md
@@ -1,0 +1,1 @@
+Remove lodash.omitby dependency

--- a/packages/adapter-mongoose/lib/tokenizers/relationship.js
+++ b/packages/adapter-mongoose/lib/tokenizers/relationship.js
@@ -1,3 +1,5 @@
+import omitBy from 'lodash.omitby';
+
 const relationshipTokenizer = ({ getRelatedListAdapterFromQueryPath }) => (
   query,
   queryKey,
@@ -14,7 +16,49 @@ const relationshipTokenizer = ({ getRelatedListAdapterFromQueryPath }) => (
 
   // Nothing found, return an empty operation
   // TODO: warn?
-  return (fieldAdapter && fieldAdapter.getRelationshipQueryCondition(queryKey, uid)) || {};
+  if (!fieldAdapter) return {};
+  const filterType = {
+    [fieldAdapter.path]: 'every',
+    [`${fieldAdapter.path}_every`]: 'every',
+    [`${fieldAdapter.path}_some`]: 'some',
+    [`${fieldAdapter.path}_none`]: 'none',
+  }[queryKey];
+
+  return {
+    from: fieldAdapter.getRefListAdapter().model.collection.name, // the collection name to join with
+    field: fieldAdapter.path, // The field on this collection
+    // A mutation to run on the data post-join. Useful for merging joined
+    // data back into the original object.
+    // Executed on a depth-first basis for nested relationships.
+    postQueryMutation: (parentObj /*, keyOfRelationship, rootObj, pathToParent*/) => {
+      return omitBy(
+        parentObj,
+        /*
+        {
+          ...parentObj,
+          // Given there could be sorting and limiting that's taken place, we
+          // want to overwrite the entire object rather than merging found items
+          // in.
+          [field]: parentObj[keyOfRelationship],
+        },
+        */
+        // Clean up the result to remove the intermediate results
+        (_, keyToOmit) => keyToOmit.startsWith(uid)
+      );
+    },
+    // The conditions under which an item from the 'orders' collection is
+    // considered a match and included in the end result
+    // All the keys on an 'order' are available, plus 3 special keys:
+    // 1) <uid>_<field>_every - is `true` when every joined item matches the
+    //    query
+    // 2) <uid>_<field>_some - is `true` when some joined item matches the
+    //    query
+    // 3) <uid>_<field>_none - is `true` when none of the joined items match
+    //    the query
+    matchTerm: { [`${uid}_${fieldAdapter.path}_${filterType}`]: true },
+    // Flag this is a to-many relationship
+    many: fieldAdapter.field.many,
+  };
 };
 
 module.exports = { relationshipTokenizer };

--- a/packages/adapter-mongoose/package.json
+++ b/packages/adapter-mongoose/package.json
@@ -14,6 +14,7 @@
     "@keystone-alpha/mongo-join-builder": "^2.0.3",
     "@keystone-alpha/utils": "^3.1.0",
     "@sindresorhus/slugify": "^0.6.0",
+    "lodash.omitby": "^4.6.0",
     "mongoose": "^5.6.5",
     "p-settle": "^3.1.0"
   }

--- a/packages/adapter-mongoose/tests/list-adapter.test.js
+++ b/packages/adapter-mongoose/tests/list-adapter.test.js
@@ -76,13 +76,9 @@ describe('MongooseListAdapter', () => {
         isRelationship: true,
         getQueryConditions: () => {},
         supportsRelationshipQuery: query => query === 'posts_some',
-        getRelationshipQueryCondition: () => ({
-          from: 'posts',
-          field: 'posts',
-          matchTerm: { posts_some: true },
-          // Flag this is a to-many relationship
-          many: true,
-        }),
+        getRefListAdapter: () => ({ model: { collection: { name: 'posts' } } }),
+        field: { many: true },
+        path: 'posts',
       },
     ];
 
@@ -109,7 +105,7 @@ describe('MongooseListAdapter', () => {
         },
       },
       { $addFields: expect.any(Object) },
-      { $match: { $and: [{ posts_some: true }, { title: { $eq: 'bar' } }] } },
+      { $match: { $and: [expect.any(Object), { title: { $eq: 'bar' } }] } },
       { $addFields: { id: '$_id' } },
     ]);
 
@@ -131,7 +127,7 @@ describe('MongooseListAdapter', () => {
         },
       },
       { $addFields: expect.any(Object) },
-      { $match: { $or: [{ posts_some: true }, { title: { $eq: 'bar' } }] } },
+      { $match: { $or: [expect.any(Object), { title: { $eq: 'bar' } }] } },
       { $addFields: { id: '$_id' } },
     ]);
   });
@@ -163,13 +159,9 @@ describe('MongooseListAdapter', () => {
         isRelationship: true,
         getQueryConditions: () => ({}),
         supportsRelationshipQuery: query => query === 'posts_some',
-        getRelationshipQueryCondition: () => ({
-          from: 'posts',
-          field: 'posts',
-          matchTerm: { posts_some: true },
-          // Flag this is a to-many relationship
-          many: true,
-        }),
+        getRefListAdapter: () => ({ model: { collection: { name: 'posts' } } }),
+        field: { many: true },
+        path: 'posts',
       },
     ];
 
@@ -191,7 +183,7 @@ describe('MongooseListAdapter', () => {
         },
       },
       { $addFields: expect.any(Object) },
-      { $match: { posts_some: true } },
+      { $match: expect.any(Object) },
       { $addFields: { id: '$_id' } },
     ]);
 
@@ -213,7 +205,7 @@ describe('MongooseListAdapter', () => {
         },
       },
       { $addFields: expect.any(Object) },
-      { $match: { posts_some: true } },
+      { $match: expect.any(Object) },
       { $addFields: { id: '$_id' } },
     ]);
   });

--- a/packages/adapter-mongoose/tests/relationship.test.js
+++ b/packages/adapter-mongoose/tests/relationship.test.js
@@ -2,25 +2,26 @@ const { relationshipTokenizer } = require('../lib/tokenizers/relationship');
 
 describe('Relationship tokenizer', () => {
   test('Uses correct conditions', () => {
-    const relationshipConditions = { name: { foo: 'bar' } };
-    const findFieldAdapterForQuerySegment = jest.fn(() => ({
-      getRelationshipQueryCondition: queryKey => relationshipConditions[queryKey],
-    }));
+    const relationshipConditions = {
+      getRefListAdapter: () => ({ model: { collection: { name: 'name' } } }),
+      field: { many: false },
+      path: 'name',
+    };
+    const findFieldAdapterForQuerySegment = jest.fn(() => relationshipConditions);
     const getRelatedListAdapterFromQueryPath = jest.fn(() => ({ findFieldAdapterForQuerySegment }));
+    const relationship = relationshipTokenizer({ getRelatedListAdapterFromQueryPath });
 
-    const relationship = relationshipTokenizer({
-      getRelatedListAdapterFromQueryPath,
+    expect(relationship({ name: 'hi' }, 'name', ['name'], 'abc123')).toMatchObject({
+      field: 'name',
+      from: 'name',
+      matchTerm: { abc123_name_every: true },
+      many: false,
     });
-
-    expect(relationship({ name: 'hi' }, 'name', ['name'])).toMatchObject({ foo: 'bar' });
     expect(findFieldAdapterForQuerySegment).toHaveBeenCalledTimes(1);
   });
 
   test('returns empty array when no matches found', () => {
-    const relationshipConditions = { notinuse: { foo: 'bar' } };
-    const findFieldAdapterForQuerySegment = jest.fn(() => ({
-      getRelationshipQueryCondition: queryKey => relationshipConditions[queryKey],
-    }));
+    const findFieldAdapterForQuerySegment = jest.fn(() => {});
     const getRelatedListAdapterFromQueryPath = jest.fn(() => ({ findFieldAdapterForQuerySegment }));
 
     const relationship = relationshipTokenizer({
@@ -30,21 +31,5 @@ describe('Relationship tokenizer', () => {
     const result = relationship({ name: 'hi' }, 'name', ['name']);
     expect(result).toMatchObject({});
     expect(findFieldAdapterForQuerySegment).toHaveBeenCalledTimes(1);
-  });
-
-  test('calls condition function with correct parameters', () => {
-    const nameConditions = jest.fn(() => ({ foo: 'bar' }));
-    const relationshipConditions = { getRelationshipQueryCondition: nameConditions };
-    const findFieldAdapterForQuerySegment = jest.fn(() => relationshipConditions);
-    const getRelatedListAdapterFromQueryPath = jest.fn(() => ({ findFieldAdapterForQuerySegment }));
-
-    const relationship = relationshipTokenizer({
-      getRelatedListAdapterFromQueryPath,
-    });
-
-    expect(relationship({ name: 'hi' }, 'name', ['name'], 'abc123')).toMatchObject({ foo: 'bar' });
-    expect(findFieldAdapterForQuerySegment).toHaveBeenCalledTimes(1);
-    expect(nameConditions).toHaveBeenCalledTimes(1);
-    expect(nameConditions).toHaveBeenCalledWith('name', 'abc123');
   });
 });

--- a/packages/build-field-types/package.json
+++ b/packages/build-field-types/package.json
@@ -37,7 +37,6 @@
     "install-packages": "^0.2.5",
     "jest-worker": "^24.6.0",
     "lodash.isempty": "^4.4.0",
-    "lodash.omitby": "^4.6.0",
     "magic-string": "^0.25.1",
     "meow": "^5.0.0",
     "ms": "^2.1.1",

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -50,7 +50,6 @@
     "intersection-observer": "^0.5.1",
     "lodash.groupby": "^4.6.0",
     "lodash.isequal": "^4.5.0",
-    "lodash.omitby": "^4.6.0",
     "luxon": "^1.11.4",
     "mongoose": "^5.6.5",
     "node-fetch": "^2.3.0",


### PR DESCRIPTION
Since this method only gets used in one place, this PR moves the code closer to where it's actually used.