### PR TITLE
Remove .queryBuilder property of MongooseListAdapter

### DIFF
--- a/.changeset/pretty-teachers-dress/changes.json
+++ b/.changeset/pretty-teachers-dress/changes.json
@@ -1,0 +1,94 @@
+{
+  "releases": [{ "name": "@keystone-alpha/adapter-mongoose", "type": "major" }],
+  "dependents": [
+    {
+      "name": "@keystone-alpha/api-tests",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/fields",
+        "@keystone-alpha/test-utils",
+        "@keystone-alpha/adapter-mongoose"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-blog",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields", "@keystone-alpha/adapter-mongoose"]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-meetup",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields", "@keystone-alpha/adapter-mongoose"]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-todo",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields", "@keystone-alpha/adapter-mongoose"]
+    },
+    {
+      "name": "@keystone-alpha/example-projects-blank",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose"]
+    },
+    {
+      "name": "@keystone-alpha/example-projects-nuxt",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields", "@keystone-alpha/adapter-mongoose"]
+    },
+    {
+      "name": "@keystone-alpha/example-projects-starter",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields", "@keystone-alpha/adapter-mongoose"]
+    },
+    {
+      "name": "@keystone-alpha/example-projects-todo",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields", "@keystone-alpha/adapter-mongoose"]
+    },
+    {
+      "name": "@keystone-alpha/fields",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/test-utils", "@keystone-alpha/adapter-mongoose"]
+    },
+    {
+      "name": "@keystone-alpha/fields-datetime-utc",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields", "@keystone-alpha/adapter-mongoose"]
+    },
+    {
+      "name": "@keystone-alpha/fields-mongoid",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields", "@keystone-alpha/adapter-mongoose"]
+    },
+    {
+      "name": "@keystone-alpha/test-utils",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-mongoose"]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-access-control",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields", "@keystone-alpha/adapter-mongoose"]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-basic",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields", "@keystone-alpha/adapter-mongoose"]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-client-validation",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields", "@keystone-alpha/adapter-mongoose"]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-login",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields", "@keystone-alpha/adapter-mongoose"]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-social-login",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields", "@keystone-alpha/adapter-mongoose"]
+    }
+  ]
+}

--- a/.changeset/pretty-teachers-dress/changes.md
+++ b/.changeset/pretty-teachers-dress/changes.md
@@ -1,0 +1,1 @@
+Remove `.queryBuilder` property of the `MongooseListAdapter`.


### PR DESCRIPTION
This finally breaks the back of the query mechanism so it's now a single inline call to the model methods.