### PR TITLE
Populate session item using getAccessControlledItem rather than findById

### DIFF
--- a/.changeset/silly-pianos-thank/changes.json
+++ b/.changeset/silly-pianos-thank/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/session", "type": "patch" }], "dependents": [] }

--- a/.changeset/silly-pianos-thank/changes.md
+++ b/.changeset/silly-pianos-thank/changes.md
@@ -1,0 +1,1 @@
+Populate session item using `getAccessControlledItem()` rather than `findById()`.

--- a/docs/quick-start/graphql-philosophy.md
+++ b/docs/quick-start/graphql-philosophy.md
@@ -12,12 +12,12 @@ order: 1
 
 A good GraphQL API is a combination of the following criteria:
 
-* **Quick prototyping** no matter the client (mobile, desktop, other APIs, etc)
-* Be **obvious**, **consistent**, and **predictable**
-* Is mostly **CRUD-based** with escape hatches for **Custom Operations**
-* Match developer's **domain knowledge**
-* Be **forward compatible** with future unknown use-cases
-* Fully **leverage the _Graph_** of GraphQL through Relationships
+- **Quick prototyping** no matter the client (mobile, desktop, other APIs, etc)
+- Be **obvious**, **consistent**, and **predictable**
+- Is mostly **CRUD-based** with escape hatches for **Custom Operations**
+- Match developer's **domain knowledge**
+- Be **forward compatible** with future unknown use-cases
+- Fully **leverage the _Graph_** of GraphQL through Relationships
 
 ## Keystone's Schema Design
 
@@ -25,15 +25,15 @@ Keystone's auto-generated GraphQL Schema meets these goals by following a patter
 
 1. **Domain Objects**
 
-    Modelled with CRUD (_Create, Read, Update, Delete_) operations, this covers the majority of functionality for most applications.
-    
-    For example; the `User` type would have `createUser` / `getUser` / `updateUser` / `deleteUser` mutations.
+   Modelled with CRUD (_Create, Read, Update, Delete_) operations, this covers the majority of functionality for most applications.
 
-1. **Custom Operations**.
+   For example; the `User` type would have `createUser` / `getUser` / `updateUser` / `deleteUser` mutations.
 
-    Become apparent over time while building applications and adding to the schema.
+2. **Custom Operations**.
 
-    For example; an `authenticateUser` / `submitTPSReport` mutation, or a `recentlyActiveUsers` query.
+   Become apparent over time while building applications and adding to the schema.
+
+   For example; an `authenticateUser` / `submitTPSReport` mutation, or a `recentlyActiveUsers` query.
 
 <p align="center">
   <img src="./img/tweet-graphql-2-things.png" alt="Tweet by Jess Telford: In my experience, the best GraphQL APIs have 2 distinct sets of things: 1. Domain Objects are modelled as type with CRUD mutations (`createUser`/`updateUser`/etc). 2. Common actions involving 0 or more Domain Objects are mutations (`sendEmail`/`finalizeTPSReport`)" width="500" />
@@ -56,23 +56,31 @@ By modeling a schema in this way, it enables fast iteration with a consistent an
 To define a set of Domain Objects, it helps to think about it in terms of what a user will see. A blog site may have a series of Domain Objects, each with their own CRUD operations:
 
 | Domain Object | C               | R            | U               | D               |
-|---------------|-----------------|--------------|-----------------|-----------------|
+| ------------- | --------------- | ------------ | --------------- | --------------- |
 | **Users**     | `createUser`    | `getUser`    | `updateUser`    | `deleteUser`    |
 | **Posts**     | `createPost`    | `getPost`    | `updatePost`    | `deletePost`    |
 | **Comments**  | `createComment` | `getComment` | `updateComment` | `deleteComment` |
 | **Images**    | `createImage`   | `getImage`   | `updateImage`   | `deleteImage`   |
 
 > 🤔 Why is **Images** its own Domain Object, and not part of the **Posts**?
-> 
+>
 > Because Images may be uploaded and interacted with independently of a Post, or used across multiple posts. Even if they're only used in a single Post, they still meet the definition as a _thing_ which might be queried or modified in some way (for example, querying for a thumbnail version of the image, or updating alt text).
-
+>
 > 💡 In general, Domain Objects map to Lists in Keystone:
-> 
+>
 > ```javascript
-> keystone.createList('User', { /* ... */ });
-> keystone.createList('Post', { /* ... */ });
-> keystone.createList('Comment', { /* ... */ });
-> keystone.createList('Image', { /* ... */ });
+> keystone.createList('User', {
+>   /* ... */
+> });
+> keystone.createList('Post', {
+>   /* ... */
+> });
+> keystone.createList('Comment', {
+>   /* ... */
+> });
+> keystone.createList('Image', {
+>   /* ... */
+> });
 > ```
 
 #### Related Domain Objects
@@ -119,14 +127,7 @@ For example, imagine a UI where an author could update their bio at the same tim
 
 ```graphql
 mutation {
-  createPost(data: {
-    title: "Hello World",
-    author: {
-      update: {
-        bio: "Hi, I'm a writer now!"
-      }
-    }
-  }) {
+  createPost(data: { title: "Hello World", author: { update: { bio: "Hi, I'm a writer now!" } } }) {
     title
   }
 }
@@ -135,7 +136,7 @@ mutation {
 Note the `data.author.update` object, this is the _Nested Mutation_. Beyond `update` there are also other operations you may wish to perform:
 
 | Operation    |                                                                                                                           |
-|--------------|---------------------------------------------------------------------------------------------------------------------------|
+| ------------ | ------------------------------------------------------------------------------------------------------------------------- |
 | `connect`    | Connect an existing item to the parent so future queries for related data return the connected item                       |
 | `disconnect` | Break the connection with an existing item (but do not delete that item) so future queries for related data return `null` |
 | `create`     | Create a new related item and connect it to the parent so future queries for related data return this item                |
@@ -143,7 +144,7 @@ Note the `data.author.update` object, this is the _Nested Mutation_. Beyond `upd
 | `delete`     | Delete an already connected item and disconnect it from the parent so future queries for related data return `null`       |
 
 > 🤔 Where is `get`?
-> 
+>
 > Since `get` is a query concern, and we're only dealing with Nested _Mutations_, it is not included here.
 
 This might be represented in the GraphQL Schema like so:
@@ -197,7 +198,6 @@ type Mutation {
 }
 ```
 
-
 ### Custom Operations
 
 Custom Operations are an emergent property of the schema design. They are not something which should be defined up front.
@@ -220,8 +220,8 @@ const resolvers = {
       const address = await getAddress(bossId);
       await courierService.submitJob({ from: 'printer', to: address });
       return true;
-    }
-  }
+    },
+  },
 };
 
 const server = new ApolloServer({ typeDefs, resolvers });

--- a/packages/session/lib/session.js
+++ b/packages/session/lib/session.js
@@ -73,7 +73,11 @@ function populateAuthedItemMiddleware(keystone) {
       // TODO: probably destroy the session
       return next();
     }
-    const item = await list.adapter.findById(req.session.keystoneItemId);
+    const item = await list.getAccessControlledItem(req.session.keystoneItemId, true, {
+      operation: 'read',
+      context: {},
+      info: {},
+    });
     if (!item) {
       // TODO: probably destroy the session
       return next();


### PR DESCRIPTION
This will allow session population to benefit from upcoming optimisations to getAccessControlledItem.