### PR TITLE
Dont populate many fields in knex _findById

### DIFF
--- a/.changeset/hot-tables-hammer/changes.json
+++ b/.changeset/hot-tables-hammer/changes.json
@@ -1,0 +1,39 @@
+{
+  "releases": [{ "name": "@keystone-alpha/adapter-knex", "type": "major" }],
+  "dependents": [
+    {
+      "name": "@keystone-alpha/api-tests",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/fields",
+        "@keystone-alpha/test-utils",
+        "@keystone-alpha/adapter-knex"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/fields",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/test-utils", "@keystone-alpha/adapter-knex"]
+    },
+    {
+      "name": "@keystone-alpha/fields-auto-increment",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields", "@keystone-alpha/adapter-knex"]
+    },
+    {
+      "name": "@keystone-alpha/fields-datetime-utc",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields", "@keystone-alpha/adapter-knex"]
+    },
+    {
+      "name": "@keystone-alpha/fields-mongoid",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/fields", "@keystone-alpha/adapter-knex"]
+    },
+    {
+      "name": "@keystone-alpha/test-utils",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/adapter-knex"]
+    }
+  ]
+}

--- a/.changeset/hot-tables-hammer/changes.md
+++ b/.changeset/hot-tables-hammer/changes.md
@@ -1,0 +1,1 @@
+`KnexListAdapter.findById()` will no longer populate `many` relationship fields.

--- a/api-tests/relationships/nested-mutations/disconnect-all-many.test.js
+++ b/api-tests/relationships/nested-mutations/disconnect-all-many.test.js
@@ -149,7 +149,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       describe('read: false on related list', () => {
         test(
           'has no effect when specifying disconnectAll',
-          runner(setupKeystone, async ({ app, create, findById }) => {
+          runner(setupKeystone, async ({ keystone, app, create }) => {
             const noteContent = sampleOne(alphanumGenerator);
 
             // Create an item to link against
@@ -180,9 +180,20 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             });
 
             expect(errors).toBe(undefined);
-            const userData = await findById('UserToNotesNoRead', createUser.id);
 
-            expect(userData.notes).toHaveLength(0);
+            const result = await graphqlRequest({
+              keystone,
+              query: `
+                query getUserNodes($userId: ID!){
+                  UserToNotesNoRead(where: { id: $userId }) {
+                    id
+                    notes { id }
+                  }
+                }
+            `,
+              variables: { userId: createUser.id },
+            });
+            expect(result.data.UserToNotesNoRead.notes).toHaveLength(0);
           })
         );
 

--- a/api-tests/relationships/nested-mutations/disconnect-many.test.js
+++ b/api-tests/relationships/nested-mutations/disconnect-many.test.js
@@ -249,7 +249,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       describe('read: false on related list', () => {
         test(
           'has no impact when disconnecting directly with an id',
-          runner(setupKeystone, async ({ app, create, findById }) => {
+          runner(setupKeystone, async ({ keystone, app, create }) => {
             const noteContent = sampleOne(alphanumGenerator);
 
             // Create an item to link against
@@ -280,9 +280,20 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             });
 
             expect(errors).toBe(undefined);
-            const userData = await findById('UserToNotesNoRead', createUser.id);
 
-            expect(userData.notes).toHaveLength(0);
+            const result = await graphqlRequest({
+              keystone,
+              query: `
+                query getUserNodes($userId: ID!){
+                  UserToNotesNoRead(where: { id: $userId }) {
+                    id
+                    notes { id }
+                  }
+                }
+            `,
+              variables: { userId: createUser.id },
+            });
+            expect(result.data.UserToNotesNoRead.notes).toHaveLength(0);
           })
         );
 

--- a/packages/adapter-knex/lib/adapter-knex.js
+++ b/packages/adapter-knex/lib/adapter-knex.js
@@ -377,7 +377,8 @@ class KnexListAdapter extends BaseListAdapter {
       })
     );
 
-    return this._findById(item.id);
+    const result = await this._findById(item.id);
+    return result ? this._populateMany(result) : null;
   }
 
   async _findAll() {
@@ -385,10 +386,11 @@ class KnexListAdapter extends BaseListAdapter {
   }
 
   async _findById(id) {
-    const item = (await this._query()
-      .from(this.key)
-      .where('id', id))[0];
-    return item ? this._populateMany(item) : null;
+    return (
+      (await this._query()
+        .from(this.key)
+        .where('id', id))[0] || null
+    );
   }
 
   async _find(condition) {


### PR DESCRIPTION
Aside from certain tests, we don't rely on this behaviour anywhere. Populating many fields is an expensive operation which we should only perform when absolutely necessary.