### PR TITLE
Move back to 15.4.0 because of a multiple-merge-to-master

### DIFF
--- a/packages/keystone/package.json
+++ b/packages/keystone/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keystone-alpha/keystone",
   "description": "The main @keystone-alpha class & CLI. This is where the magic happens.",
-  "version": "15.5.0",
+  "version": "15.4.0",
   "author": "The KeystoneJS Development Team",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
https://github.com/keystonejs/keystone-5/pull/1731 followed by https://github.com/keystonejs/keystone-5/pull/1749 without a release in between.