### PR TITLE
[WIP] Allow keystone.initialise() to setup Db without connect

### DIFF
--- a/packages/adapter-knex/lib/adapter-knex.js
+++ b/packages/adapter-knex/lib/adapter-knex.js
@@ -68,7 +68,7 @@ class KnexAdapter extends BaseKeystoneAdapter {
     return result;
   }
 
-  async initialise() {
+  async _initialise() {
     const isSetup = await this.schema().hasTable(Object.keys(this.listAdapters)[0]);
     if (this.config.dropDatabase || !isSetup) {
       console.log('Knex adapter: Dropping database');

--- a/packages/adapter-knex/lib/adapter-knex.js
+++ b/packages/adapter-knex/lib/adapter-knex.js
@@ -68,7 +68,7 @@ class KnexAdapter extends BaseKeystoneAdapter {
     return result;
   }
 
-  async postConnect() {
+  async initialise() {
     const isSetup = await this.schema().hasTable(Object.keys(this.listAdapters)[0]);
     if (this.config.dropDatabase || !isSetup) {
       console.log('Knex adapter: Dropping database');
@@ -84,7 +84,7 @@ class KnexAdapter extends BaseKeystoneAdapter {
 
     if (errors.length) {
       if (errors.length === 1) throw errors[0];
-      const error = new Error('Multiple errors in KnexAdapter.postConnect():');
+      const error = new Error('Multiple errors in KnexAdapter.initialise():');
       error.errors = errors;
       throw error;
     }

--- a/packages/adapter-mongoose/lib/adapter-mongoose.js
+++ b/packages/adapter-mongoose/lib/adapter-mongoose.js
@@ -64,7 +64,7 @@ class MongooseAdapter extends BaseKeystoneAdapter {
     });
   }
 
-  async initialise() {
+  async _initialise() {
     return await pSettle(
       Object.values(this.listAdapters).map(listAdapter => listAdapter.initialise())
     );

--- a/packages/adapter-mongoose/lib/adapter-mongoose.js
+++ b/packages/adapter-mongoose/lib/adapter-mongoose.js
@@ -63,9 +63,10 @@ class MongooseAdapter extends BaseKeystoneAdapter {
       ...mongooseConfig,
     });
   }
-  async postConnect() {
+
+  async initialise() {
     return await pSettle(
-      Object.values(this.listAdapters).map(listAdapter => listAdapter.postConnect())
+      Object.values(this.listAdapters).map(listAdapter => listAdapter.initialise())
     );
   }
 
@@ -115,7 +116,6 @@ class MongooseListAdapter extends BaseListAdapter {
       { ...DEFAULT_MODEL_SCHEMA_OPTIONS, ...mongooseSchemaOptions }
     );
 
-    // Need to call postConnect() once all fields have registered and the database is connected to.
     this.model = null;
   }
 
@@ -130,7 +130,7 @@ class MongooseListAdapter extends BaseListAdapter {
    *
    * @return Promise<>
    */
-  async postConnect() {
+  async initialise() {
     if (this.configureMongooseSchema) {
       this.configureMongooseSchema(this.schema, { mongoose: this.mongoose });
     }
@@ -159,9 +159,8 @@ class MongooseListAdapter extends BaseListAdapter {
     // http://thecodebarbarian.com/whats-new-in-mongoose-5-2-syncindexes
     // NOTE: If an index has changed and needs recreating, this can have a
     // performance impact when dealing with large datasets!
-    return this.model.syncIndexes();
+    await this.model.syncIndexes();
   }
-
   _create(data) {
     return this.model.create(data);
   }

--- a/packages/keystone/lib/Keystone/index.js
+++ b/packages/keystone/lib/Keystone/index.js
@@ -58,6 +58,7 @@ module.exports = class Keystone {
     secureCookies = process.env.NODE_ENV === 'production', // Default to true in production
     cookieMaxAge = 1000 * 60 * 60 * 24 * 30, // 30 days
     schemaNames = ['public'],
+    initialiseOnConnect = false,
   }) {
     this.name = name;
     this.adapterConnectOptions = adapterConnectOptions;
@@ -66,6 +67,7 @@ module.exports = class Keystone {
     this.lists = {};
     this.listsArray = [];
     this.getListByKey = key => this.lists[key];
+    this._initialiseOnConnect = initialiseOnConnect;
     this._extendedTypes = [];
     this._extendedQueries = [];
     this._extendedMutations = [];
@@ -304,11 +306,20 @@ module.exports = class Keystone {
    */
   connect() {
     const { adapters, name } = this;
-    return resolveAllKeys(mapKeys(adapters, adapter => adapter.connect({ name }))).then(() => {
+    return resolveAllKeys(
+      mapKeys(adapters, adapter =>
+        adapter.connect({ name, initialiseOnConnect: this._initialiseOnConnect })
+      )
+    ).then(() => {
       if (this.eventHandlers.onConnect) {
         return this.eventHandlers.onConnect(this);
       }
     });
+  }
+
+  initialise() {
+    const { adapters, name } = this;
+    return resolveAllKeys(mapKeys(adapters, adapter => adapter.initialise({ name })));
   }
 
   /**

--- a/packages/keystone/lib/adapters/index.js
+++ b/packages/keystone/lib/adapters/index.js
@@ -30,7 +30,7 @@ class BaseKeystoneAdapter {
 
     // Set up all list adapters
     try {
-      const taskResults = await this.initialise();
+      const taskResults = await this._initialise();
       const errors = taskResults.filter(({ isRejected }) => isRejected).map(({ reason }) => reason);
 
       if (errors.length) {
@@ -54,7 +54,7 @@ class BaseKeystoneAdapter {
     }
   }
 
-  async initialise() {}
+  async _initialise() {}
 }
 
 class BaseListAdapter {

--- a/packages/keystone/lib/adapters/index.js
+++ b/packages/keystone/lib/adapters/index.js
@@ -30,7 +30,7 @@ class BaseKeystoneAdapter {
 
     // Set up all list adapters
     try {
-      const taskResults = await this._initialise();
+      const taskResults = await this.initialise();
       const errors = taskResults.filter(({ isRejected }) => isRejected).map(({ reason }) => reason);
 
       if (errors.length) {
@@ -54,7 +54,7 @@ class BaseKeystoneAdapter {
     }
   }
 
-  async _initialise() {}
+  async initialise() {}
 }
 
 class BaseListAdapter {

--- a/packages/keystone/lib/adapters/index.js
+++ b/packages/keystone/lib/adapters/index.js
@@ -17,18 +17,25 @@ class BaseKeystoneAdapter {
     return this.listAdapters[key];
   }
 
-  async connect({ name }) {
+  async connect({ name, initialiseOnConnect }) {
     // Connect to the database
+    await this._connect({ name }, this.config);
+    if (initialiseOnConnect) {
+      this.initialise({ name });
+    }
+  }
+
+  async initialise({ name }) {
     await this._connect({ name }, this.config);
 
     // Set up all list adapters
     try {
-      const taskResults = await this.postConnect();
+      const taskResults = await this._initialise();
       const errors = taskResults.filter(({ isRejected }) => isRejected).map(({ reason }) => reason);
 
       if (errors.length) {
         if (errors.length === 1) throw errors[0];
-        const error = new Error('Multiple errors in BaseKeystoneAdapter.postConnect():');
+        const error = new Error('Multiple errors in BaseKeystoneAdapter.initialise():');
         error.errors = errors;
         throw error;
       }
@@ -47,7 +54,7 @@ class BaseKeystoneAdapter {
     }
   }
 
-  async postConnect() {}
+  async _initialise() {}
 }
 
 class BaseListAdapter {


### PR DESCRIPTION
Splits out the db initialisation from the connect method so that each can be called independently. Ideally you'd not call initialise in prod.

Question for Tim: If you opt to initialise on create this will attempt to connect twice? Any issues with that?
 