### PR TITLE
Avoid hanging the build command

### DIFF
--- a/.changeset/flat-hornets-float/changes.json
+++ b/.changeset/flat-hornets-float/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/keystone", "type": "patch" }], "dependents": [] }

--- a/.changeset/flat-hornets-float/changes.md
+++ b/.changeset/flat-hornets-float/changes.md
@@ -1,0 +1,1 @@
+Avoid the build command from hanging when an entry file may have a long-running process.

--- a/packages/keystone/bin/cli.js
+++ b/packages/keystone/bin/cli.js
@@ -61,8 +61,16 @@ const spinner = ora({
 }).start();
 
 // Everything else is assumed to be a command we want to execute
-commandRunner.exec(args, commands, spinner).catch(error => {
-  spinner.fail();
-  console.error(error);
-  process.exit(1);
-});
+commandRunner
+  .exec(args, commands, spinner)
+  .then(({ endProcessWithSuccess = false } = {}) => {
+    // Allow commands to forcibly end the process with success
+    if (endProcessWithSuccess) {
+      process.exit(0);
+    }
+  })
+  .catch(error => {
+    spinner.fail();
+    console.error(error);
+    process.exit(1);
+  });

--- a/packages/keystone/bin/commands/build.js
+++ b/packages/keystone/bin/commands/build.js
@@ -60,5 +60,11 @@ module.exports = {
         )}`
       );
     }
+
+    // It's possible the developer's entry file has an accidentally long-lived
+    // process (for example, using 'connect-mongodb-session').
+    // To avoid that long-lived process from making the build command hang, we
+    // signal that we wish the process to end here.
+    return { endProcessWithSuccess: true };
   },
 };


### PR DESCRIPTION
### Motivation

I have my `keystone` instance setup like so:

```javascript
const { Keystone } = require('@keystone-alpha/keystone');
const expressSession = require('express-session');
const MongoStore = require('connect-mongodb-session')(expressSession);

const keystone = new Keystone({
  name: 'Foo',
  sessionStore: new MongoStore({ /* ... */ }),
  // ...
});
```

When a `MongoStore` is instantiated, it creates a persistent connection to a MongoDB instance.

Since the `build` command will execute this as part of instantiating `keystone`, that persistent connection will not allow the `build` process to exit.

> NOTE: The ideal fix here is that `MongoStore` doesn't connect during build, but this is just one example of many ways this could happen.

This PR fixes that kind of situation.