### PR TITLE
Error with list name

### DIFF
--- a/docs/guides/add-lists.md
+++ b/docs/guides/add-lists.md
@@ -36,7 +36,7 @@ Inside of `index.js` import the defined schema and replace the existing one with
 ```javascript
 const TodosSchema = require('./lists/Todos.js');
 
-keystone.createList('Todos', TodosSchema);
+keystone.createList('Todo', TodosSchema);
 ```
 
 Make sure to relaunch keystone's instance and check, that everything still works fine.


### PR DESCRIPTION
Using `keystone.createList('Todos', TodosSchema);` creates the error `Error: Unable to use Todos as a List name - it has an ambiguous plural (Todos). Please choose another name for your list.`

Should be `keystone.createList('Todo', TodosSchema);`