### PR TITLE
Support configureExpress being returned from an entry file

### DIFF
--- a/.changeset/chilled-ads-learn/changes.json
+++ b/.changeset/chilled-ads-learn/changes.json
@@ -1,1 +1,0 @@
-{ "releases": [{ "name": "@keystone-alpha/keystone", "type": "patch" }], "dependents": [] }

--- a/.changeset/chilled-ads-learn/changes.md
+++ b/.changeset/chilled-ads-learn/changes.md
@@ -1,1 +1,0 @@
-Add trustProxies config option to Keystone object

--- a/.changeset/new-pens-mate.md
+++ b/.changeset/new-pens-mate.md
@@ -1,0 +1,5 @@
+---
+'@keystone-alpha/keystone': minor
+---
+
+The `keystone` cli now accepts a return of `{ keystone, apps, configureExpress }` from the entry file. `configureExpress` will be called on the Express app before applying the keystone middlewares.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ Add a script to your `package.json`:
 Create a file `index.js`:
 
 <!-- prettier-ignore -->
-
 ```javascript
 const { Keystone }        = require('@keystone-alpha/keystone');
 const { MongooseAdapter } = require('@keystone-alpha/adapter-mongoose');
@@ -127,7 +126,6 @@ must handle executing the different parts of Keystone.
 Create the `server.js` file:
 
 <!-- prettier-ignore -->
-
 ```javascript
 const express = require('express');
 const { keystone, apps } = require('./index');
@@ -227,7 +225,6 @@ To setup authentication, you must instantiate an _Auth Strategy_, and create a
 list used for authentication in `index.js`:
 
 <!-- prettier-ignore -->
-
 ```javascript
 const { Keystone } = require('@keystone-alpha/keystone');
 const { PasswordAuthStrategy } = require('@keystone-alpha/auth-password');

--- a/docs/api/hooks.md
+++ b/docs/api/hooks.md
@@ -52,7 +52,6 @@ _Note_: `resolveInput` is not executed for deleted items.
 #### Usage:
 
 <!-- prettier-ignore -->
-
 ```javascript
 const resolveInput = ({
   resolvedData,
@@ -70,7 +69,6 @@ Executed after `resolveInput`. Should throw if `resolvedData` is invalid.
 #### Usage
 
 <!-- prettier-ignore -->
-
 ```javascript
 const validateInput = ({
   resolvedData,
@@ -99,7 +97,6 @@ Executed once the mutation has been completed and all transactions finalised.
 #### Usage
 
 <!-- prettier-ignore -->
-
 ```javascript
 const afterChange = ({
   updatedItem,
@@ -121,7 +118,6 @@ Executed after access control checks. Should throw if delete operation is invali
 #### Usage
 
 <!-- prettier-ignore -->
-
 ```javascript
 const validateDelete = ({
   existingItem,
@@ -140,7 +136,6 @@ Executed after `validateDelete`.
 #### Usage
 
 <!-- prettier-ignore -->
-
 ```javascript
 const beforeDelete = ({
   existingItem,
@@ -158,7 +153,6 @@ Executed once the delete mutation has been completed and all transactions finali
 #### Usage
 
 <!-- prettier-ignore -->
-
 ```javascript
 const afterDelete = ({
   existingItem,

--- a/docs/guides/custom-server.md
+++ b/docs/guides/custom-server.md
@@ -50,6 +50,9 @@ const keystone = new Keystone(/* ... */);
 module.exports = {
   keystone,
   apps: [new GraphQLApp()],
+  configureExpress: app => {
+    /* ... */
+  },
 };
 ```
 
@@ -57,16 +60,14 @@ module.exports = {
 
 ```javascript
 const express = require('express');
-const { keystone, apps } = require('./index.js');
+const { keystone, apps, configureExpress } = require('./index.js');
 keystone
   .prepare({ apps, dev: process.env.NODE_ENV !== 'production' })
   .then(async ({ middlewares }) => {
     await keystone.connect();
     const app = express();
-    keystone
-      .configureServerApp(app)
-      .use(middlewares)
-      .listen(3000);
+    configureExpress(app);
+    keystone.use(middlewares).listen(3000);
   });
 ```
 
@@ -101,10 +102,7 @@ keystone
   .then(async ({ middlewares }) => {
     await keystone.connect();
     const app = express();
-    keystone
-      .configureServerApp(app)
-      .use(middlewares)
-      .listen(3000);
+    keystone.use(middlewares).listen(3000);
   });
 ```
 
@@ -139,12 +137,14 @@ const preparations = [
   new GraphQLApp(),
   new AdminUIApp()
 ].map(app => app.prepareMiddleware({ keystone, dev }));
+const configureExpress = app => { /* ... */ },
 
 Promise.all(preparations)
   .then(middlewares => {
     await keystone.connect();
     const app = express();
-    keystone.configureServerApp(app)
+    configureExpress(app);
+    keystone
       .use(middlewares)
       .listen(3000);
   });
@@ -169,7 +169,7 @@ const { Keystone } = require('@keystone-alpha/keystone');
 const { GraphQLApp } = require('@keystone-alpha/app-graphql');
 const keystone = new Keystone();
 keystone.createList(/* ... */);
-
+const configureExpress = app => { /* ... */ },
 // ...
 
 // Only setup once per instance
@@ -178,7 +178,8 @@ const setup = keystone
   .then(async ({ middlewares }) => {
     await keystone.connect();
     const app = express();
-    keystone.configureServerApp(app).use(middlewares);
+    configureExpress(app);
+    keystone.use(middlewares);
     return serverless(app);
   });
 

--- a/packages/arch/packages/alert/README.md
+++ b/packages/arch/packages/alert/README.md
@@ -145,11 +145,7 @@ An alert that is full width; removes border and border radius.
 MIT © [Thinkmill](https://www.thinkmill.com.au/)
 
 [source]: https://github.com/keystonejs/arch
-
 [docs]: http://arch.keystonejs.com/
-
 [npm]: https://www.npmjs.com/
-
 [install-npm]: https://docs.npmjs.com/getting-started/installing-node
-
 [theme]: http://npmjs.com/package/@arch-ui/theme

--- a/packages/fields/src/types/Relationship/README.md
+++ b/packages/fields/src/types/Relationship/README.md
@@ -68,7 +68,6 @@ Use the `create` nested mutation to create and append an item to a to-many
 relationship:
 
 <!-- prettier-ignore -->
-
 ```graphql
 # Replace all posts of a given User
 mutation replaceAllPosts {
@@ -94,7 +93,6 @@ Use the `connect` nested mutation to append an existing item to a to-many
 relationship:
 
 <!-- prettier-ignore -->
-
 ```graphql
 # Replace the company of a given User
 mutation replaceAllPosts {
@@ -121,7 +119,6 @@ the value of a to-single relationship (it's not necessary to use `disconnectAll`
 as is the case for [to-many relationships](#overriding-a-to-many-relationship)):
 
 <!-- prettier-ignore -->
-
 ```graphql
 # Replace the company of a given User
 mutation replaceAllPosts {
@@ -148,7 +145,6 @@ To completely replace the related items in a to-many list, you can perform a
 mutation (thanks to the [order of execution](#order-of-execution)):
 
 <!-- prettier-ignore -->
-
 ```graphql
 # Replace all posts related to a given User
 mutation replaceAllPosts {

--- a/packages/keystone/README.md
+++ b/packages/keystone/README.md
@@ -32,18 +32,9 @@ const keystone = new Keystone({
 | `cookieSecret`          | `String`   | `qwerty`   |                                                                                                                                                   |
 | `cookieMaxAge`          | `Int`      | 30 days    |                                                                                                                                                   |
 | `secureCookies`         | `Boolean`  | Variable   | Defaults to true in production mode, false otherwise.                                                                                             |
-| `trustProxies`          | `Int`      | `0`        | Number of reverse proxies to trust                                                                                                                |
 | `sessionStore`          | `Object`   | `null`     |                                                                                                                                                   |
 | `schemaNames`           | `Array`    | `[public]` |                                                                                                                                                   |
 | `queryLimits`           | `Object`   | `{}`       | Configures global query limits                                                                                                                    |
-
-### `trustProxies`
-
-This needs to be configured if running Keystone behind a reverse proxy (such as a CDN or load balancer).
-
-It's recommended to set it to the number of reverse proxies in your deployment (e.g., 1 CDN + 1 load balancer, or just 1 load balancer). Most hosting environments need at least 1 for sessions to work properly. Warning: values that are too high will "work" but allow users to fake their IP addresses.
-
-In rare cases, you might need to use [the more complex proxy settings supported by Express](https://expressjs.com/en/api.html#trust.proxy.options.table).
 
 ### `queryLimits`
 

--- a/packages/keystone/bin/utils.js
+++ b/packages/keystone/bin/utils.js
@@ -93,9 +93,9 @@ async function executeDefaultServer(args, entryFile, distDir, spinner) {
   // Allow the spinner time to flush its output to the console.
   await new Promise(resolve => setTimeout(resolve, 100));
 
-  const { keystone, apps = [] } = require(path.resolve(entryFile));
+  const { keystone, apps = [], configureExpress = () => {} } = require(path.resolve(entryFile));
 
-  keystone.configureServerApp(app);
+  configureExpress(app);
 
   spinner.succeed('Initialised Keystone instance');
   spinner.start('Connecting to database');

--- a/packages/keystone/lib/Keystone/index.js
+++ b/packages/keystone/lib/Keystone/index.js
@@ -58,7 +58,6 @@ module.exports = class Keystone {
     secureCookies = process.env.NODE_ENV === 'production', // Default to true in production
     cookieMaxAge = 1000 * 60 * 60 * 24 * 30, // 30 days
     schemaNames = ['public'],
-    trustProxies = 0,
   }) {
     this.name = name;
     this.adapterConnectOptions = adapterConnectOptions;
@@ -78,7 +77,6 @@ module.exports = class Keystone {
     this.eventHandlers = { onConnect };
     this.registeredTypes = new Set();
     this._schemaNames = schemaNames;
-    this._trustProxies = trustProxies;
 
     if (adapters) {
       this.adapters = adapters;
@@ -652,12 +650,6 @@ module.exports = class Keystone {
 
     // 4. Merge the data back together again
     return mergeRelationships(createdItems, createdRelationships);
-  }
-
-  // Configures an Express server app
-  configureServerApp(app) {
-    app.set('trust proxy', this._trustProxies);
-    return app;
   }
 
   async prepare({

--- a/packages/keystone/tests/bin/dev-command.test.js
+++ b/packages/keystone/tests/bin/dev-command.test.js
@@ -63,7 +63,6 @@ describe('dev command', () => {
           auth: {},
           prepare: () => Promise.resolve({ middlewares: (req, res, next) => res.send(200) }),
           connect: () => Promise.resolve(),
-          configureServerApp: app => app,
         }
       }`
     );
@@ -90,7 +89,6 @@ describe('dev command', () => {
           auth: {},
           prepare: () => Promise.resolve({ middlewares: (req, res, next) => res.send(200) }),
           connect: () => Promise.resolve(),
-          configureServerApp: app => app,
         }
       }`
     );

--- a/test-projects/basic/custom-fields/Stars/README.md
+++ b/test-projects/basic/custom-fields/Stars/README.md
@@ -5,7 +5,7 @@ Finally this is available in Keystone 5 🎉.
 
 In this post we will be creating a simple custom Field Type for star ratings ⭐️ ⭐️ ⭐️ ⭐️ ⭐️!
 
-![Screenshot of the Stars input field in Keystone Admin UI](<>)
+![Screenshot of the Stars input field in Keystone Admin UI]()
 
 For this component, our data requirements are simple. We need to store an Integer in the database
 to represent the number of stars on a blog post. This makes things easy because Integer is a built


### PR DESCRIPTION
Reverts #1758 and supersedes #1683.

This PR provides a general mechanism providing the system designer a chance to configure the `app()` used in the `keystone` CLI helper scripts.

The behaviour will be equivalent to:

```js
const { keystone, apps, configureExpress } = require('./index.js');

keystone.prepare().then(({ middlewares }) => {
  const app = express();
  configureExpress(app);
  app.use(middlewares);
  app.listen(3000);
});
```