### PR TITLE
Removed adapterConnectOptions key (unused as of 144e6e86)

### DIFF
--- a/.changeset/curly-paws-beg/changes.json
+++ b/.changeset/curly-paws-beg/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/keystone", "type": "patch" }], "dependents": [] }

--- a/.changeset/curly-paws-beg/changes.md
+++ b/.changeset/curly-paws-beg/changes.md
@@ -1,0 +1,1 @@
+Removed adapterConnectOptions key (unused as of 144e6e86)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,14 +19,14 @@ x-job-setup: &job-setup
 # Download and cache dependencies
 x-restore-cache: &restore-cache
   keys:
-    - v12-dependencies-{{ checksum "yarn.lock" }}
+    - v13-dependencies-{{ checksum "yarn.lock" }}
       # fallback to using the latest cache if no exact match is found
-    - v12-dependencies-
+    - v13-dependencies-
 
 x-save-cache: &save-cache
   paths:
     - node_modules
-  key: v12-dependencies-{{ checksum "yarn.lock" }}
+  key: v13-dependencies-{{ checksum "yarn.lock" }}
 
 x-integration-steps: &integration-steps
   steps:

--- a/packages/keystone/README.md
+++ b/packages/keystone/README.md
@@ -26,7 +26,6 @@ const keystone = new Keystone({
 | `adapter`               | `Object`   | Required   | The database storage adapter. See the [Adapter Framework](https://v5.keystonejs.com/keystone-alpha/keystone/lib/adapters/) page for more details. |
 | `adapters`              | `Array`    | `[]`       |                                                                                                                                                   |
 | `defaultAdapter`        | `Object`   | `null`     |                                                                                                                                                   |
-| `adapterConnectOptions` | `Object`   | `{}`       |                                                                                                                                                   |
 | `defaultAccess`         | `Object`   | `{}`       |                                                                                                                                                   |
 | `onConnect`             | `Function` | `null`     |                                                                                                                                                   |
 | `cookieSecret`          | `String`   | `qwerty`   |                                                                                                                                                   |

--- a/packages/keystone/lib/Keystone/index.js
+++ b/packages/keystone/lib/Keystone/index.js
@@ -50,7 +50,6 @@ module.exports = class Keystone {
     adapter,
     defaultAdapter,
     name,
-    adapterConnectOptions = {},
     onConnect,
     cookieSecret = 'qwerty',
     sessionStore,
@@ -61,7 +60,6 @@ module.exports = class Keystone {
     trustProxies = 0,
   }) {
     this.name = name;
-    this.adapterConnectOptions = adapterConnectOptions;
     this.defaultAccess = { list: true, field: true, custom: true, ...defaultAccess };
     this.auth = {};
     this.lists = {};


### PR DESCRIPTION
`adapterConnectOptions` doesn't seem to be used anywhere anymore as of 144e6e8.