### PR TITLE
iframely adapter: avoid block content duplicate on url change

### DIFF
--- a/packages/oembed-adapters/src/views/preview.js
+++ b/packages/oembed-adapters/src/views/preview.js
@@ -17,6 +17,12 @@ const Preview = ({ url, options }) => {
 
     // Tell iframely to always re-render when the current ref changes
     importPromise.then(() => {
+      while (containerRef.current.lastChild) {
+        // iframely.load is not clearing old content from container,
+        // so we should do it manually
+        // @iframely/embed.js <= 1.3.1
+        containerRef.current.removeChild(containerRef.current.lastChild);
+      }
       window.iframely.load(containerRef.current, url);
     });
   }, [url, containerRef.current]);


### PR DESCRIPTION
iframely.load is not clearing old content from container, so we should do it manually
@iframely/embed.js <= 1.3.1 (we use 1.1.1, but I tested on last 1.3.1 as well)

BUG DEMO: https://drive.google.com/file/d/1psOJaPzxti8EzODY2pGG0NcSGOdaIQXi/view
