### PR TITLE
docs: add social media icons to header

### DIFF
--- a/website/src/components/Header.js
+++ b/website/src/components/Header.js
@@ -6,7 +6,7 @@ import { jsx } from '@emotion/core';
 import { colors, gridSize } from '@arch-ui/theme';
 
 import logosvg from '../assets/logo.svg';
-import { Container } from '../components';
+import { Container, SocialIconsNav } from '../components';
 import { media, mediaOnly, mediaMax } from '../utils/media';
 
 export const HEADER_HEIGHT = 60;
@@ -83,7 +83,6 @@ const NavItem = ({ as, lgOnly, ...props }) => {
   return (
     <li>
       <Tag
-        href="https://github.com/keystonejs/keystone-5"
         css={{
           alignItems: 'center',
           background: 0,
@@ -133,14 +132,16 @@ const Nav = ({ toggleMenu }) => (
           {name}
         </NavItem>
       ))}
-      <NavItem
-        href="https://github.com/keystonejs/keystone-5"
-        title="Opens in new window"
-        target="_blank"
-      >
-        GitHub
-        <NewWindowIcon />
-      </NavItem>
+      <li>
+        <SocialIconsNav
+          css={{
+            marginLeft: '2rem',
+            [mediaMax.sm]: {
+              display: 'none',
+            },
+          }}
+        />
+      </li>
       {toggleMenu && (
         <NavItem
           as="button"
@@ -160,26 +161,6 @@ const Nav = ({ toggleMenu }) => (
       )}
     </List>
   </nav>
-);
-const NewWindowIcon = () => (
-  <span css={{ marginLeft: gridSize / 2, opacity: 0.6 }}>
-    <svg x="0px" y="0px" viewBox="0 0 100 100" width="15" height="15" className="css-19vhmgv">
-      <path
-        fill="currentColor"
-        d="
-      M18.8,85.1h56l0,0c2.2,0,4-1.8,4-4v-32h-8v28h-48v-48h28v-8h-32l0,
-      0c-2.2,0-4,1.8-4,4v56C14.8,83.3,16.6,85.1,18.8,85.1z
-    "
-      />
-      <polygon
-        fill="currentColor"
-        points="
-      45.7,48.7 51.3,54.3 77.2,28.5 77.2,37.2 85.2,37.2 85.2,14.9 62.8,
-      14.9 62.8,22.9 71.5,22.9
-      "
-      />
-    </svg>
-  </span>
 );
 
 // ==============================

--- a/website/src/components/Sidebar.js
+++ b/website/src/components/Sidebar.js
@@ -5,7 +5,7 @@ import { jsx } from '@emotion/core';
 import { gridSize } from '@arch-ui/theme';
 import throttle from 'lodash.throttle';
 
-import { Footer, SidebarNav, Search } from '../components';
+import { Footer, SidebarNav, Search, SocialIconsNav } from '../components';
 import { media, mediaMax } from '../utils/media';
 
 const layoutGutter = gridSize * 4;
@@ -85,6 +85,15 @@ export const Sidebar = ({ offsetTop, isVisible, mobileOnly = false }) => {
         },
       }}
     >
+      <SocialIconsNav
+        css={{
+          marginBottom: '2.4em',
+          display: 'none',
+          [mediaMax.sm]: {
+            display: 'block',
+          },
+        }}
+      />
       <Search />
       <SidebarNav />
       <Footer />

--- a/website/src/components/SocialIconsNav.js
+++ b/website/src/components/SocialIconsNav.js
@@ -1,0 +1,121 @@
+/** @jsx jsx */
+import { jsx } from '@emotion/core';
+
+import { colors } from '@arch-ui/theme';
+import { mq } from '../utils/media';
+
+const SocialIconsNav = props => (
+  <nav aria-label="Social Media Menu" {...props}>
+    <ul css={mq({ display: 'flex', listStyle: 'none', margin: 0, padding: 0 })}>
+      <li css={{ marginRight: [`1rem`] }}>
+        <IconTwitter href="https://twitter.com/keystonejs" target="_blank" title="Twitter" />
+      </li>
+      <li css={{ marginRight: [`1rem`] }}>
+        <IconGithub
+          href="https://github.com/keystonejs/keystone-5"
+          target="_blank"
+          title="Github"
+        />
+      </li>
+      <li css={{ marginRight: [`0`] }}>
+        <IconSlack href="https://launchpass.com/keystonejs" target="_blank" title="Slack" />
+      </li>
+    </ul>
+  </nav>
+);
+
+// ==============================
+// Social Icons
+// ==============================
+
+const Icon = ({ children, ...props }) => (
+  <a
+    css={{
+      color: colors.N60,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      height: 24,
+      width: 24,
+
+      ':not(:first-of-type)': {
+        marginLeft: '0.5em',
+      },
+      ':not(:last-of-type)': {
+        marginRight: '0.5em',
+      },
+
+      ':hover,:focus': {
+        color: colors.N80,
+      },
+
+      svg: {
+        width: '100%',
+      },
+    }}
+    {...props}
+  >
+    {children}
+  </a>
+);
+const IconGithub = props => (
+  <Icon {...props}>
+    <svg viewBox="0 0 16 16" version="1.1" aria-hidden="true">
+      <path
+        fill="currentColor"
+        fillRule="evenodd"
+        d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"
+      />
+    </svg>
+    <A11yText>KeystoneJS repository on GitHub</A11yText>
+  </Icon>
+);
+const IconTwitter = props => (
+  <Icon {...props}>
+    <svg viewBox="0 0 24 20" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M7.548 20c9.056 0 14.01-7.695 14.01-14.368 0-.219 0-.437-.015-.653.964-.715 1.796-1.6 2.457-2.614a9.638 9.638 0 0 1-2.828.794A5.047 5.047 0 0 0 23.337.366a9.72 9.72 0 0 1-3.127 1.226C18.684-.072 16.258-.48 14.294.598c-1.964 1.078-2.98 3.374-2.475 5.6C7.859 5.994 4.17 4.076 1.67.922.363 3.229 1.031 6.18 3.195 7.662A4.795 4.795 0 0 1 .96 7.032v.064c0 2.403 1.653 4.474 3.95 4.95a4.797 4.797 0 0 1-2.223.087c.645 2.057 2.494 3.466 4.6 3.506A9.725 9.725 0 0 1 0 17.732a13.688 13.688 0 0 0 7.548 2.264"
+        fill="currentColor"
+        fillRule="nonzero"
+      />
+    </svg>
+    <A11yText>Hear about KeystoneJS on Twitter</A11yText>
+  </Icon>
+);
+const IconSlack = props => (
+  <Icon {...props}>
+    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <g fill="currentColor" fillRule="nonzero">
+        <path d="M5.11 15.135a2.503 2.503 0 0 1-2.497 2.497 2.503 2.503 0 0 1-2.497-2.497 2.503 2.503 0 0 1 2.497-2.496H5.11v2.496zM6.368 15.135a2.503 2.503 0 0 1 2.497-2.496 2.503 2.503 0 0 1 2.496 2.496v6.252a2.503 2.503 0 0 1-2.496 2.497 2.503 2.503 0 0 1-2.497-2.497v-6.252zM8.865 5.11a2.503 2.503 0 0 1-2.497-2.497A2.503 2.503 0 0 1 8.865.116a2.503 2.503 0 0 1 2.496 2.497V5.11H8.865zM8.865 6.368a2.503 2.503 0 0 1 2.496 2.497 2.503 2.503 0 0 1-2.496 2.496H2.613A2.503 2.503 0 0 1 .116 8.865a2.503 2.503 0 0 1 2.497-2.497h6.252z" />
+        <path d="M18.89 8.865a2.503 2.503 0 0 1 2.497-2.497 2.503 2.503 0 0 1 2.497 2.497 2.503 2.503 0 0 1-2.497 2.496H18.89V8.865zM17.632 8.865a2.503 2.503 0 0 1-2.497 2.496 2.503 2.503 0 0 1-2.496-2.496V2.613A2.503 2.503 0 0 1 15.135.116a2.503 2.503 0 0 1 2.497 2.497v6.252z" />
+        <path d="M15.135 18.89a2.503 2.503 0 0 1 2.497 2.497 2.503 2.503 0 0 1-2.497 2.497 2.503 2.503 0 0 1-2.496-2.497V18.89h2.496zM15.135 17.632a2.503 2.503 0 0 1-2.496-2.497 2.503 2.503 0 0 1 2.496-2.496h6.252a2.503 2.503 0 0 1 2.497 2.496 2.503 2.503 0 0 1-2.497 2.497h-6.252z" />
+      </g>
+    </svg>
+    <A11yText>Discuss KeystoneJS on Slack</A11yText>
+  </Icon>
+);
+
+// ==============================
+// Misc
+// ==============================
+
+const A11yText = ({ tag: Tag, ...props }) => (
+  <Tag
+    css={{
+      border: 0,
+      clip: 'rect(1px, 1px, 1px, 1px)',
+      height: 1,
+      overflow: 'hidden',
+      padding: 0,
+      position: 'absolute',
+      whiteSpace: 'nowrap',
+      width: 1,
+    }}
+    {...props}
+  />
+);
+A11yText.defaultProps = {
+  tag: 'span',
+};
+
+export { SocialIconsNav };

--- a/website/src/components/homepage/HomepageContent.js
+++ b/website/src/components/homepage/HomepageContent.js
@@ -51,83 +51,7 @@ const HomepageContent = () => (
       </a>{' '}
       around the world.
     </p>
-    <div css={mq({ display: 'flex', margin: [`2em auto`, `1em 0`, `2em 0`] })}>
-      <IconTwitter href="https://twitter.com/keystonejs" target="_blank" title="Twitter" />
-      <IconGithub href="https://github.com/keystonejs/keystone-5" target="_blank" title="Github" />
-      <IconSlack href="https://launchpass.com/keystonejs" target="_blank" title="Slack" />
-    </div>
   </Content>
-);
-
-// ==============================
-// Social Icons
-// ==============================
-
-const Icon = ({ children, ...props }) => (
-  <a
-    css={{
-      color: colors.N80,
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      height: 24,
-      width: 24,
-
-      ':not(:first-of-type)': {
-        marginLeft: '0.5em',
-      },
-      ':not(:last-of-type)': {
-        marginRight: '0.5em',
-      },
-
-      ':hover,:focus': {
-        opacity: 0.8,
-      },
-
-      svg: {
-        width: '100%',
-      },
-    }}
-    {...props}
-  >
-    {children}
-  </a>
-);
-const IconGithub = props => (
-  <Icon {...props}>
-    <svg viewBox="0 0 16 16" version="1.1" aria-hidden="true">
-      <path
-        fill="currentColor"
-        fillRule="evenodd"
-        d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"
-      />
-    </svg>
-    <A11yText>KeystoneJS repository on GitHub</A11yText>
-  </Icon>
-);
-const IconTwitter = props => (
-  <Icon {...props}>
-    <svg viewBox="0 0 24 20" xmlns="http://www.w3.org/2000/svg">
-      <path
-        d="M7.548 20c9.056 0 14.01-7.695 14.01-14.368 0-.219 0-.437-.015-.653.964-.715 1.796-1.6 2.457-2.614a9.638 9.638 0 0 1-2.828.794A5.047 5.047 0 0 0 23.337.366a9.72 9.72 0 0 1-3.127 1.226C18.684-.072 16.258-.48 14.294.598c-1.964 1.078-2.98 3.374-2.475 5.6C7.859 5.994 4.17 4.076 1.67.922.363 3.229 1.031 6.18 3.195 7.662A4.795 4.795 0 0 1 .96 7.032v.064c0 2.403 1.653 4.474 3.95 4.95a4.797 4.797 0 0 1-2.223.087c.645 2.057 2.494 3.466 4.6 3.506A9.725 9.725 0 0 1 0 17.732a13.688 13.688 0 0 0 7.548 2.264"
-        fill="currentColor"
-        fillRule="nonzero"
-      />
-    </svg>
-    <A11yText>Hear about KeystoneJS on Twitter</A11yText>
-  </Icon>
-);
-const IconSlack = props => (
-  <Icon {...props}>
-    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-      <g fill="currentColor" fillRule="nonzero">
-        <path d="M5.11 15.135a2.503 2.503 0 0 1-2.497 2.497 2.503 2.503 0 0 1-2.497-2.497 2.503 2.503 0 0 1 2.497-2.496H5.11v2.496zM6.368 15.135a2.503 2.503 0 0 1 2.497-2.496 2.503 2.503 0 0 1 2.496 2.496v6.252a2.503 2.503 0 0 1-2.496 2.497 2.503 2.503 0 0 1-2.497-2.497v-6.252zM8.865 5.11a2.503 2.503 0 0 1-2.497-2.497A2.503 2.503 0 0 1 8.865.116a2.503 2.503 0 0 1 2.496 2.497V5.11H8.865zM8.865 6.368a2.503 2.503 0 0 1 2.496 2.497 2.503 2.503 0 0 1-2.496 2.496H2.613A2.503 2.503 0 0 1 .116 8.865a2.503 2.503 0 0 1 2.497-2.497h6.252z" />
-        <path d="M18.89 8.865a2.503 2.503 0 0 1 2.497-2.497 2.503 2.503 0 0 1 2.497 2.497 2.503 2.503 0 0 1-2.497 2.496H18.89V8.865zM17.632 8.865a2.503 2.503 0 0 1-2.497 2.496 2.503 2.503 0 0 1-2.496-2.496V2.613A2.503 2.503 0 0 1 15.135.116a2.503 2.503 0 0 1 2.497 2.497v6.252z" />
-        <path d="M15.135 18.89a2.503 2.503 0 0 1 2.497 2.497 2.503 2.503 0 0 1-2.497 2.497 2.503 2.503 0 0 1-2.496-2.497V18.89h2.496zM15.135 17.632a2.503 2.503 0 0 1-2.496-2.497 2.503 2.503 0 0 1 2.496-2.496h6.252a2.503 2.503 0 0 1 2.497 2.496 2.503 2.503 0 0 1-2.497 2.497h-6.252z" />
-      </g>
-    </svg>
-    <A11yText>Discuss KeystoneJS on Slack</A11yText>
-  </Icon>
 );
 
 // ==============================
@@ -185,24 +109,5 @@ const Content = props => (
     {...props}
   />
 );
-
-const A11yText = ({ tag: Tag, ...props }) => (
-  <Tag
-    css={{
-      border: 0,
-      clip: 'rect(1px, 1px, 1px, 1px)',
-      height: 1,
-      overflow: 'hidden',
-      padding: 0,
-      position: 'absolute',
-      whiteSpace: 'nowrap',
-      width: 1,
-    }}
-    {...props}
-  />
-);
-A11yText.defaultProps = {
-  tag: 'span',
-};
 
 export { HomepageContent };

--- a/website/src/components/index.js
+++ b/website/src/components/index.js
@@ -2,6 +2,7 @@ export { Button } from './Button';
 export { Container } from './Container';
 export { Header } from './Header';
 export { Footer } from './Footer';
+export { SocialIconsNav } from './SocialIconsNav';
 export { Sidebar } from './Sidebar';
 export { SidebarNav } from './SidebarNav';
 export { Search } from './Search';


### PR DESCRIPTION
Currently we only show the Github link in the header, so that means that if you are on a documentation page (`/quick-start/`, `/guides/access-control` etc) you can't get a link to the KeystoneJS Slack or 
Twitter without visiting the home page.

I've removed the social media icons from the homepage, split them into their own component and displayed them in the header on all pages and in the sidebar on small devices.

[Preview Link](https://deploy-preview-1788--v5keystonejs.netlify.com/)

### Screenshots

**Docs page**

<img width="1440" alt="Screen Shot 2019-10-21 at 8 01 06 am" src="https://user-images.githubusercontent.com/6265154/67167126-7a7d5e00-f3d9-11e9-8a77-c0a40640e45a.png">

**Home page**

<img width="1440" alt="Screen Shot 2019-10-21 at 8 00 57 am" src="https://user-images.githubusercontent.com/6265154/67167124-7a7d5e00-f3d9-11e9-9a03-943659c6060a.png">

**Mobile** 

<img width="499" alt="Screen Shot 2019-10-21 at 8 01 26 am" src="https://user-images.githubusercontent.com/6265154/67167127-7b15f480-f3d9-11e9-9c37-d6f2f4aa9671.png">

<img width="499" alt="Screen Shot 2019-10-21 at 8 01 35 am" src="https://user-images.githubusercontent.com/6265154/67167128-7b15f480-f3d9-11e9-9c03-125c8af4eb79.png">



