### PR TITLE
Doc improvements

### DIFF
--- a/docs/guides/access-control.md
+++ b/docs/guides/access-control.md
@@ -1,6 +1,7 @@
 <!--[meta]
 section: guides
 title: Access Control
+subSection: advanced
 [meta]-->
 
 # Access Control Guide

--- a/docs/guides/add-lists.md
+++ b/docs/guides/add-lists.md
@@ -1,6 +1,8 @@
 <!--[meta]
 section: guides
 title: Adding Lists To Your Keystone Project
+subSection: setup
+order: 2
 [meta]-->
 
 # Adding Lists To Your Keystone Project

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -1,6 +1,7 @@
 <!--[meta]
 section: guides
 title: Authentication
+subSection: advanced
 [meta]-->
 
 # Authentication

--- a/docs/guides/custom-field-types.md
+++ b/docs/guides/custom-field-types.md
@@ -1,6 +1,7 @@
 <!--[meta]
 section: guides
 title: Custom Field Types
+subSection: advanced
 [meta]-->
 
 # Custom Field Types

--- a/docs/guides/custom-mutations.md
+++ b/docs/guides/custom-mutations.md
@@ -1,6 +1,7 @@
 <!--[meta]
 section: guides
 title: Custom Mutations
+subSection: advanced
 [meta]-->
 
 # Custom Mutations

--- a/docs/guides/custom-server.md
+++ b/docs/guides/custom-server.md
@@ -1,6 +1,7 @@
 <!--[meta]
 section: guides
 title: Custom Server
+subSection: advanced
 [meta]-->
 
 # Custom Server

--- a/docs/guides/custom-server.md
+++ b/docs/guides/custom-server.md
@@ -30,6 +30,30 @@ available in KeystoneJS include:
   The following are some possible ways of setting up a custom server, roughly in
   order of complexity.
 
+## You might not need a custom server if...
+
+If all you want to do is some basic configuration of the default Express instance, you don't need a
+custom server. The KeystoneJS CLI accepts an additional `configureExpress` export in your `index.js` file:
+
+```javascript
+module.exports = {
+  configureExpress: app => {
+    /* ... */
+  },
+};
+```
+
+This function takes a single `app` parameter. The running Express instance will be passed to this function
+before any middlewares are set up, so you can perform any Express configuration you need here. For example:
+
+```javascript
+module.exports = {
+  configureExpress: app => {
+    app.set('view engine', 'pug')
+  },
+};
+```
+
 ## Minimal Custom Server
 
 `package.json`
@@ -51,9 +75,6 @@ const keystone = new Keystone(/* ... */);
 module.exports = {
   keystone,
   apps: [new GraphQLApp()],
-  configureExpress: app => {
-    /* ... */
-  },
 };
 ```
 
@@ -61,13 +82,12 @@ module.exports = {
 
 ```javascript
 const express = require('express');
-const { keystone, apps, configureExpress } = require('./index.js');
+const { keystone, apps } = require('./index.js');
 keystone
   .prepare({ apps, dev: process.env.NODE_ENV !== 'production' })
   .then(async ({ middlewares }) => {
     await keystone.connect();
     const app = express();
-    configureExpress(app);
     app.use(middlewares).listen(3000);
   });
 ```
@@ -138,13 +158,11 @@ const preparations = [
   new GraphQLApp(),
   new AdminUIApp()
 ].map(app => app.prepareMiddleware({ keystone, dev }));
-const configureExpress = app => { /* ... */ },
 
 Promise.all(preparations)
   .then(middlewares => {
     await keystone.connect();
     const app = express();
-    configureExpress(app);
     app
       .use(middlewares)
       .listen(3000);
@@ -170,7 +188,6 @@ const { Keystone } = require('@keystone-alpha/keystone');
 const { GraphQLApp } = require('@keystone-alpha/app-graphql');
 const keystone = new Keystone();
 keystone.createList(/* ... */);
-const configureExpress = app => { /* ... */ },
 // ...
 
 // Only setup once per instance
@@ -179,7 +196,6 @@ const setup = keystone
   .then(async ({ middlewares }) => {
     await keystone.connect();
     const app = express();
-    configureExpress(app);
     app.use(middlewares);
     return serverless(app);
   });

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -1,6 +1,7 @@
 <!--[meta]
 section: guides
 title: Deployment Recommendations
+subSection: deployment
 [meta]-->
 
 # Deployment Recommendations

--- a/docs/guides/graphql-philosophy.md
+++ b/docs/guides/graphql-philosophy.md
@@ -1,7 +1,8 @@
 <!--[meta]
-section: quick-start
+section: guides
 title: GraphQL Philosophy
-order: 1
+subSection: graphql
+order: 3
 [meta]-->
 
 # GraphQL Philosophy

--- a/docs/guides/initial-data.md
+++ b/docs/guides/initial-data.md
@@ -1,6 +1,8 @@
 <!--[meta]
 section: guides
 title: Adding initial data
+subSection: setup
+order: 3
 [meta]-->
 
 ## Adding initial data to Lists

--- a/docs/guides/intro-to-graphql.md
+++ b/docs/guides/intro-to-graphql.md
@@ -1,6 +1,8 @@
 <!--[meta]
 section: guides
 title: GraphQL
+subSection: graphql
+order: 1
 [meta]-->
 
 # Introduction to the GraphQL API

--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -1,6 +1,7 @@
 <!--[meta]
 section: guides
 title: Migrations
+subSection: advanced
 [meta]-->
 
 ## Migrations in Keystone

--- a/docs/guides/mutation-lifecycle.md
+++ b/docs/guides/mutation-lifecycle.md
@@ -1,6 +1,7 @@
 <!--[meta]
 section: guides
 title: Mutation Lifecycle
+subSection: graphql
 [meta]-->
 
 # Mutation Lifecycle

--- a/docs/guides/new-project.md
+++ b/docs/guides/new-project.md
@@ -11,7 +11,7 @@ In this guide we will learn how to manually create and run a new KeystoneJS proj
 
 ## Initialization and basic packages
 
-First things first. Create a directory for your future project and init npm package there.
+First things first. Create a directory for your future project and initialize it:
 
 ```
 mkdir new-project
@@ -19,7 +19,7 @@ cd new-project
 yarn init
 ```
 
-Let's start from minimal setup. We will need two packages here:
+Let's start with minimal setup. We will need two packages here:
 `@keystone-alpha/keystone` which is KeystoneJS' core and `@keystone-alpha/adapter-mongoose` which allows our app to connect to MongoDB.
 
 Do
@@ -28,9 +28,9 @@ Do
 yarn add @keystone-alpha/keystone @keystone-alpha/adapter-mongoose
 ```
 
-## First steps in coding
+## First Steps
 
-After installation we can start to write our code. Main entry point of KeystoneJS app is `index.js` file placed in root folder. Create it and type following:
+After installation we can start coding. Main entry point of a KeystoneJS app is the `index.js` file in the root folder. Create it and add the following:
 
 ```javascript
 // import necessary modules
@@ -44,7 +44,7 @@ const keystone = new Keystone({
 });
 ```
 
-You can specify any suitable name for your application. Note that we created an instance of Mongoose adapter and passed it to KeystoneJS' constructor.
+You can specify any suitable name for your application. Note that we created an instance of the [Mongoose Adapter](/keystone-alpha/adapter-mongoose/) and passed it to KeystoneJS' constructor.
 
 Now we can export our instance and make it available for running. Add following to the end of `index.js`:
 
@@ -54,29 +54,29 @@ module.exports = {
 };
 ```
 
-That's it. But now our app does nothing, just starting and connecting to database. If you run application now it will display something like that:
+That's it. But now our app does nothing, just starting and connecting to database. If you run application now it will display something like this:
 
 ```
 TypeError: Router.use() requires a middleware function
 ```
 
-Let's create some routes! For this we will use another powerful KeystoneJS' feature - GraphQL explorer UI.
+Let's create some routes! For this we will enable a powerful KeystoneJS feature - the GraphQL explorer UI.
 
-## Setting up GraphQL interface
+## Setting up the GraphQL Interface
 
-As in previous step install necessary package.
+As in the previous step install necessary the package.
 
 ```
 yarn add @keystone-alpha/app-graphql
 ```
 
-Import it.
+Import it...
 
 ```javascript
 const { GraphQLApp } = require('@keystone-alpha/app-graphql');
 ```
 
-And create instance.
+And add a new array export named `apps` with a new instance of `GraphQLApp`, like so.
 
 ```javascript
 module.exports = {
@@ -85,7 +85,7 @@ module.exports = {
 };
 ```
 
-In order to be able to start an app we need to add at least one List. List is a model that is compatible with KeystoneJS' admin UI.
+In order to be able to start an app we need to add at least one List. A List is a model that is compatible with KeystoneJS' admin UI.
 
 ## Adding first List
 
@@ -99,9 +99,9 @@ keystone.createList('Todos', {
 });
 ```
 
-This code snippet creates a List named 'Todos'. Second argument is a config object.
-For now it have only one key - `fields` which is used to attach schema for newly created model.
-That means that we want our Todos item to have only one field - `name` and it should be of type `Text`. To specify type we need to import it:
+This code snippet creates a List named 'Todos'. The second argument is a config object. For now it have only one key (`fields`) which is used to define the schema for newly created model.
+
+In our example, the `Todo` list has a single field called `name` of type `Text`. Note the type is *not* a string; it must be imported like so:
 
 ```
 yarn add @keystone-alpha/fields
@@ -113,7 +113,7 @@ and
 const { Text } = require('@keystone-alpha/fields');
 ```
 
-That's it.
+That's it!
 
 ## Starting application
 
@@ -139,4 +139,4 @@ You should see something like this
 🔗 GraphQL API:          http://localhost:3000/admin/api
 ```
 
-Now it's the time to check those routes in browser to ensure that everything works as expected. And then proceed to second step - [Adding Lists](https://v5.keystonejs.com/guides/add-lists)
+Now it's the time to check those routes in browser to ensure that everything works as expected. Then proceed to second step - [Adding Lists](https://v5.keystonejs.com/guides/add-lists)

--- a/docs/guides/new-project.md
+++ b/docs/guides/new-project.md
@@ -1,6 +1,8 @@
 <!--[meta]
 section: guides
 title: Creating a New KeystoneJS Project
+subSection: setup
+order: 1
 [meta]-->
 
 # Creating a New KeystoneJS Project

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -1,6 +1,8 @@
 <!--[meta]
 section: guides
 title: GraphQL Performance Monitoring
+subSection: graphql
+order: 2
 [meta]-->
 
 # Performance

--- a/docs/guides/production.md
+++ b/docs/guides/production.md
@@ -1,6 +1,7 @@
 <!--[meta]
 section: guides
 title: Production Readiness Checklist
+subSection: deployment
 [meta]-->
 
 # Production Readiness Checklist

--- a/docs/guides/relationships.md
+++ b/docs/guides/relationships.md
@@ -1,6 +1,8 @@
 <!--[meta]
 section: guides
 title: Creating Relationships Between Lists
+subSection: setup
+order: 4
 [meta]-->
 
 # Creating Relationships Between Lists

--- a/docs/quick-start/adapters.md
+++ b/docs/quick-start/adapters.md
@@ -1,21 +1,21 @@
 <!--[meta]
 section: quick-start
-title: Configuring Adapters
+title: Database Setup and Adapters
 [meta]-->
 
-# Adapter Configuration
+## Choosing an Adapter
 
-## Choosing an adapter
+KeystoneJS currently provides two adapters for connecting to either a MongoDB or PostgreSQL database. Choose the [Mongoose Adapter](/keystone-alpha/adapter-mongoose/) for MongoDB or the [Knex Adapter](/keystone-alpha/adapter-knex/) for PostgreSQL.
 
-KeystoneJS currently provides two database adapters. Choose the [Mongoose Adapter](/keystone-alpha/adapter-mongoose/) for MongoDB or the [Knex Adapter](/keystone-alpha/adapter-knex/) for PostgreSQL.
+If you're following the [quick start guide](/quick-start/adapters), simply select the appropriate adapter for your database of choice when prompted. More information on adapter configuration can be found under the *Setup* sections.
 
 _Note_: PostgreSQL requires an additional step to create a database.
 
 ## Installing MongoDB
 
-The simplest way to install [MongoDB](https://www.mongodb.com/) is using [Homebrew](https://brew.sh/).
+### MacOS
 
-### OSX
+The simplest way to install [MongoDB](https://www.mongodb.com/) is using [Homebrew](https://brew.sh/).
 
 ```sh
 brew install mongodb
@@ -24,7 +24,7 @@ brew services start mongodb
 
 ### Other Platforms
 
-Follow the [official MongoDB installation guide](https://www.mongodb.com/download-center/community).
+Follow the [official MongoDB installation guide](https://www.mongodb.com/download-center/community) for your system.
 
 ### Setup
 
@@ -32,9 +32,9 @@ By default the Mongoose Adapter will attempt to connect to MongoDB as the curren
 
 ## Installing Postgres
 
-The simplest way to install [Postgres](https://www.postgresql.org/) is using [Homebrew](https://brew.sh/).
+### MacOS
 
-### OSX
+The simplest way to install [Postgres](https://www.postgresql.org/) is using [Homebrew](https://brew.sh/).
 
 ```sh
 brew install postgres
@@ -50,4 +50,6 @@ By default the Knex Adapter will attempt to connect to a PostgreSQL database as 
 
 To create database run the following command:
 
-`createdb my-database-name`
+```sh
+createdb my-database-name
+```

--- a/docs/quick-start/getting-started.md
+++ b/docs/quick-start/getting-started.md
@@ -21,9 +21,9 @@ Before we start, check that your computer or server meets the following requirem
 
 - [Node.js](https://nodejs.org/) >= 10.x: Node.js is a server platform which runs JavaScript.
 
-And, ONE of the following:
+And ONE of the following databases:
 
-- [MongoDB](https://www.mongodb.com/) >= 4.x: MongoDB is a powerful document store.
+- [MongoDB](https://www.mongodb.com/) >= 4.x: MongoDB is a powerful NoSQL document storage database.
 - [Postgres](https://www.postgresql.org) >= 9.x: PostgreSQL is an open source relational database that uses the SQL language.
 
 Finally, make sure [your database is configured and running](/quick-start/adapters).
@@ -44,9 +44,13 @@ or with yarn:
 yarn create keystone-app my-app
 ```
 
-You'll be prompted with a few questions, like the name of your project. When asked, select the "ToDo" application if you wish to follow this guide.
+You'll be prompted with a few questions:
 
-Once you're done, here's your next step:
+1. **What is your project name?** Pick any name for your project. You can change it later if you like.
+2. **Select a starter project.** Select the `Todo` application if you wish to follow this guide.
+3. **Select an adapter.** We'll go more into database adapters later. For now, simply choose `Mongoose` if you're running a MongoDB database and `Knex` if you're running a Postgres one.
+
+Wait a few minutes for all the project dependencies to install. Once that's finished, run this:
 
 ```sh
 cd my-app
@@ -55,7 +59,7 @@ npm run dev
 
 ## Congratulations! 🎉
 
-You are now running your very own KeystoneJS application. Here's what you get, out of the box:
+You are now running your very own KeystoneJS application! Here's what you get out of the box:
 
 ### A simple todo application
 

--- a/packages/adapter-knex/README.md
+++ b/packages/adapter-knex/README.md
@@ -1,7 +1,7 @@
 <!--[meta]
 section: api
-subSection: adapters
-title: Database Adapter - Knex
+subSection: database-adapters
+title: Knex Adapter
 [meta]-->
 
 The [Knex](https://knexjs.org/#changelog) adapter is a general purpose adapter which can be used to connect to a range of different database backends.

--- a/packages/adapter-mongoose/README.md
+++ b/packages/adapter-mongoose/README.md
@@ -1,7 +1,7 @@
 <!--[meta]
 section: api
-subSection: adapters
-title: Database Adapter - Mongoose
+subSection: database-adapters
+title: Mongoose Adapter
 [meta]-->
 
 # Mongoose Database Adapter


### PR DESCRIPTION
Had a bunch of idea for how the docs could be made more navigable for first time users.

1. Sorted most guides into subsections (hope I did this right). This is most useful for the manual setup-related guides since they're written as if one is supposed to follow them in order.
2. Moved the GraphQL Philosophy page to Guides. This seemed a bit in-depth for a Quick Start section.
3. Spruced up the Getting Started and New Project pages.
4. Renamed the Configuring Adapters page to Database Setup and Adapters
5. Added a suggested method for setting up MongoDB on windows based on my own setup.
6. Added some notes about the `configureExpress` export working without a custom server.