### PR TITLE
Doc cleanup - Pass 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ yarn start
 ```
 
 For more details and system requirements, check out the [5 Minute Quick Start
-Guide](https://v5.keystonejs.com/quick-start/).
+Guide](https://keystonejs.com/quick-start/).
 
 ### API
 
-The [API documentation](https://v5.keystonejs.com/api/) contains a reference for all KeystoneJS packages.
+The [API documentation](https://keystonejs.com/api/) contains a reference for all KeystoneJS packages.
 
 ### Demo Projects
 
@@ -150,7 +150,7 @@ _Note that when using a custom server, you will no longer get the formatted
 console output when starting a server._
 
 For more, see the [Custom Server
-Discussion](https://v5.keystonejs.com/guides/custom-server).
+Discussion](https://keystonejs.com/guides/custom-server).
 
 ### Production Build
 
@@ -213,7 +213,7 @@ tightly coupled to the API.
 
 ### Adding Authentication
 
-_See [Authentication docs](https://v5.keystonejs.com/guides/authentication)._
+_See [Authentication docs](https://keystonejs.com/guides/authentication)._
 
 To setup authentication, you must instantiate an _Auth Strategy_, and create a
 list used for authentication in `index.js`:

--- a/demo-projects/README.md
+++ b/demo-projects/README.md
@@ -13,7 +13,7 @@ Minimum requirements for the Demo Projects:
 
 - [Node.js](https://nodejs.org/) >= 10.x
 - [Yarn](https://yarnpkg.com/)
-- [MongoDB](https://v5.keystonejs.com/quick-start/mongodb) >= 4.x
+- [MongoDB](https://www.mongodb.com/) >= 4.x
 
 Download a copy of the Keystone 5 repo, and check out the latest release:
 

--- a/demo-projects/blog/README.md
+++ b/demo-projects/blog/README.md
@@ -25,4 +25,4 @@ PORT=5000 yarn start blog
 
 Although the "Password" auth strategy is enabled for the Admin UI on this project, we haven't implemented any restrictions on the GraphQL API yet. So unauthenticated users are able to create and destroy admin users (!)
 
-See the [Access Control](https://v5.keystonejs.com/guides/access-control) documentation for information on how to do this.
+See the [Access Control](https://keystonejs.com/guides/access-control) documentation for information on how to do this.

--- a/demo-projects/meetup/meetupConfig.js
+++ b/demo-projects/meetup/meetupConfig.js
@@ -36,7 +36,7 @@ const MEETUP = {
 `,
     callToActionButtonLabel: `Join us now`,
     copyrightText: `
-<p>Copyright &copy; Thinkmill Pty Ltd, powered by <a href="https://v5.keystonejs.com">KeystoneJS</a>.</p>
+<p>Copyright &copy; Thinkmill Pty Ltd, powered by <a href="https://keystonejs.com">KeystoneJS</a>.</p>
 <p>If you run a meetup, please feel free to clone our site and make your own!
   <a href="https://github.com/keystonejs/keystone-5/tree/master/demo-projects/meetup">You can find it on GitHub</a>.
 </p>

--- a/docs/api/access-control.md
+++ b/docs/api/access-control.md
@@ -9,8 +9,8 @@ order: 5
 Control who can do what with your GraphQL API.
 
 _Note_: This is the API documentation for Access Control. For getting started,
-see the [Access Control Guide](https://v5.keystonejs.com/guides/access-control) or the
-[Authentication Guide](https://v5.keystonejs.com/guides/authentication).
+see the [Access Control Guide](/guides/access-control) or the
+[Authentication Guide](/guides/authentication).
 
 ## Table of Contents
 

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -6,10 +6,10 @@ order: 4
 
 # Authentication
 
-Authentication strategies allow users to identify themselves to KeystoneJS. This can be used to restrict access to the AdminUI, and to configure [access controls](https://v5.keystonejs.com/guides/access-control/).
+Authentication strategies allow users to identify themselves to KeystoneJS. This can be used to restrict access to the AdminUI, and to configure [access controls](/guides/access-control/).
 
-- For password logins see: [`auth-password`](https://v5.keystonejs.com/keystone-alpha/auth-password/)
-- For social logins using [Passport.js](http://www.passportjs.org/) see: [`auth-passport`](https://v5.keystonejs.com/keystone-alpha/auth-passport/)
+- For password logins see: [`auth-password`](/keystone-alpha/auth-password/)
+- For social logins using [Passport.js](http://www.passportjs.org/) see: [`auth-passport`](/keystone-alpha/auth-passport/)
 
 ## Usage
 

--- a/docs/api/create-list.md
+++ b/docs/api/create-list.md
@@ -23,7 +23,7 @@ keystone.createList('Post', {
 | `hooks`         | `Object`                            | `{}`                          | Specify hooks to execute functions after list actions.                                  |
 | `labelField`    | `String`                            | `name`                        | Specify a field to use as a label for individual list items.                            |
 | `labelResolver` | `Function`                          | Resolves `labelField` or `id` | Function to resolve labels for individual list items.                                   |
-| `access`        | `Function` \| `Object` \| `Boolean` | `true`                        | [Access control](https://v5.keystonejs.com/guides/access-control) options for the list. |
+| `access`        | `Function` \| `Object` \| `Boolean` | `true`                        | [Access control](/guides/access-control) options for the list. |
 | `adapterConfig` | `Object`                            |                               | Override the adapter config options for a specific list.                                |
 | `itemQueryName` | `String`                            |                               | Changes the _item_ name in GraphQL queries and mutations.                               |
 | `listQueryName` | `String`                            |                               | Changes the _list_ name in GraphQL queries and mutations.                               |
@@ -121,9 +121,9 @@ keystone.createList('User', {
 
 ### `access`
 
-[Access control](https://v5.keystonejs.com/guides/access-control) options for the list.
+[Access control](/guides/access-control) options for the list.
 
-Options for `create`, `read`, `update` and `delete` - can be a function, GraphQL where clause or Boolean. See the [access control API documentation](https://v5.keystonejs.com/api/access-control) for more details.
+Options for `create`, `read`, `update` and `delete` - can be a function, GraphQL where clause or Boolean. See the [access control API documentation](/api/access-control) for more details.
 
 #### Usage
 
@@ -297,7 +297,7 @@ This provides a method for packaging features that can be applied to multiple li
 
 Configuration for limiting the kinds of queries that can be made against the list, to avoid queries that might overload the server.
 
-See also [global query limits on the Keystone object](https://v5.keystonejs.com/api/keystone#query-limits).
+See also [global query limits on the Keystone object](/api/keystone#query-limits).
 
 - `maxResults`: maximum number of results that can be returned in a query (or subquery)
 

--- a/docs/api/hooks.md
+++ b/docs/api/hooks.md
@@ -7,8 +7,8 @@ order: 7
 # Hooks
 
 The APIs for each hook are mostly the same across the 3 hook types
-([list hooks](https://v5.keystonejs.com/guides/hooks#list-hooks), [field hooks](https://v5.keystonejs.com/guides/hooks#field-hooks), [field type
-hooks](https://v5.keystonejs.com/guides/hooks#field-type-hooks)).
+([list hooks](/guides/hooks#list-hooks), [field hooks](/guides/hooks#field-hooks), [field type
+hooks](/guides/hooks#field-type-hooks)).
 
 Any differences are called out in the documentation below.
 

--- a/docs/guides/access-control.md
+++ b/docs/guides/access-control.md
@@ -45,7 +45,7 @@ const { Text, Select, Checkbox, Password } = require('@keystone-alpha/fields');
 const keystone = // ...
 
 // Setup the Authentication Strategy.
-// See https://v5.keystonejs.com/guides/authentication for more
+// See /guides/authentication for more
 const authStrategy = // ...
 
 keystone.createList('User', {
@@ -106,4 +106,4 @@ Note that Jess can only read _his own_ email, and cannot read any passwords.
 
 ---
 
-Read more in the [Access Control API docs](https://v5.keystonejs.com/api/access-control).
+Read more in the [Access Control API docs](/api/access-control).

--- a/docs/guides/add-lists.md
+++ b/docs/guides/add-lists.md
@@ -7,7 +7,7 @@ order: 2
 
 # Adding Lists To Your Keystone Project
 
-We've already created one list during [previous tutorial](https://v5.keystonejs.com/quick-start).
+We've already created one list during [previous tutorial](/guides/new-project).
 Now it's the time to dive deeper. Let's make ToDos object a bit more complex.
 
 ## Creating basic list in separate file

--- a/docs/guides/add-lists.md
+++ b/docs/guides/add-lists.md
@@ -71,7 +71,7 @@ module.exports = {
 }
 ```
 
-If you're curious about the usage options you can read more about `CalendarDay` [here](https://v5.keystonejs.com/keystone-alpha/fields/src/types/calendar-day/). Now it's time to explore docs on other field types and get a bit familiar with them. It will help you make your schema cleaner.
+If you're curious about the usage options you can read more about `CalendarDay` [here](/keystone-alpha/fields/src/types/calendar-day/). Now it's time to explore docs on other field types and get a bit familiar with them. It will help you make your schema cleaner.
 
 ## Defining User list
 
@@ -103,8 +103,8 @@ const UsersSchema = require('./lists/Users.js');
 keystone.createList('User', UsersSchema);
 ```
 
-Relaunch your app and check if new list appeared in admin panel. Note, now `type: Password` looks when you're creating new user. But how can we assign a task to specific user? Let's proceed with [Defining Relationships](https://v5.keystonejs.com/guides/relationships)
+Relaunch your app and check if new list appeared in admin panel. Note, now `type: Password` looks when you're creating new user. But how can we assign a task to specific user? Let's proceed with [Defining Relationships](/guides/relationships)
 
 See also:
-[Schema - Lists & Fields](https://v5.keystonejs.com/guides/schema)
-[API - createList](https://v5.keystonejs.com/api/create-list)
+[Schema - Lists & Fields](/guides/schema)
+[API - createList](/api/create-list)

--- a/docs/guides/apps.md
+++ b/docs/guides/apps.md
@@ -65,11 +65,11 @@ In both cases, the `keystone dev` and `keystone start` commands will consume the
 exported `.apps` array, making their middleware available in the order the apps
 are specified.
 
-If you're using a [Custom Server](https://v5.keystonejs.com/guides/custom-server), it will be your
+If you're using a [Custom Server](/guides/custom-server), it will be your
 responsibility to ensure each app's middleware is correctly injected into any
 http server you setup.
 
 Other interesting KeystoneJS compatible Apps are:
 
-- [Static App](https://v5.keystonejs.com/keystone-alpha/app-static) for serving static files.
-- [Next.js App](https://v5.keystonejs.com/keystone-alpha/app-next) for serving a Next.js App on the same server as the API
+- [Static App](/keystone-alpha/app-static) for serving static files.
+- [Next.js App](/keystone-alpha/app-next) for serving a Next.js App on the same server as the API

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -13,7 +13,7 @@ _Note on terminology_:
 - _Access Control_ refers to the specific actions an authenticated or anonymous
   user can take. Often referred to as _authorization_ elsewhere.
   The specifics of how this is done is outside the scope of this document.
-  See [Access Control](https://v5.keystonejs.com/guides/access-control) for more.
+  See [Access Control](/guides/access-control) for more.
 
 ## Admin UI
 
@@ -22,7 +22,7 @@ Username / Password authentication can be enabled on the Admin UI.
 > NOTE: Admin Authentication will only restrict access to the Admin _UI_.
 >
 > To also restrict access to the _API_,
-> you must setup [Access Control](https://v5.keystonejs.com/guides/access-control) config.
+> you must setup [Access Control](/guides/access-control) config.
 
 To setup authentication, you must instantiate an _Auth Strategy_, and create a
 list used for authentication in `index.js`:
@@ -91,4 +91,4 @@ Finally; login with the newly created `User`'s credentials.
 Adding Authentication as above will only enable login to the Admin UI, it _will
 not_ restrict API access.
 
-**To restrict API access, you must setup [Access Control](https://v5.keystonejs.com/guides/access-control).**
+**To restrict API access, you must setup [Access Control](/guides/access-control).**

--- a/docs/guides/custom-mutations.md
+++ b/docs/guides/custom-mutations.md
@@ -10,7 +10,7 @@ Out of the box Keystone provides predictable CRUD operations (Create, Read, Upda
 
 Custom Queries and Mutations may be required if you wish to preform non-CRUD operations or actions that don't relate to a specific List.
 
-See the [GraphQL Philosophy](https://v5.keystonejs.com/guides/graphql-philosophy) for more information on how Keystone implements CRUD operations in GraphQL and when Custom Queries and Mutations may be required.
+See the [GraphQL Philosophy](/guides/graphql-philosophy) for more information on how Keystone implements CRUD operations in GraphQL and when Custom Queries and Mutations may be required.
 
 You can add to Keystone's generated schema with custom types, queries, and mutations using the `keystone.extendGraphQLSchema()` method.
 
@@ -18,7 +18,7 @@ You can add to Keystone's generated schema with custom types, queries, and mutat
 
 A common example where a custom mutation might be beneficial is if you want to increment a value.
 
-Like any problem there are multiple solutions. You can implement an incrementing value with [Hooks](https://v5.keystonejs.com/guides/hooks) but in this example we're going to look at how to do this with a custom mutation.
+Like any problem there are multiple solutions. You can implement an incrementing value with [Hooks](/guides/hooks) but in this example we're going to look at how to do this with a custom mutation.
 
 First let's define a `Page` list. For the sake of simplicity, we'll give it only two fields: `title` and `views`.
 

--- a/docs/guides/custom-server.md
+++ b/docs/guides/custom-server.md
@@ -18,7 +18,7 @@ handles the GraphQL API and Admin UI. Things such as:
 - ... etc
 
 A **Custom Server** can replace the default and act as the entry point to your
-application which consumes your [schema definition](https://v5.keystonejs.com/guides/schema). A Custom
+application which consumes your [schema definition](/guides/schema). A Custom
 Server must handle initialising a http server which correctly executes any given KeystoneJS Apps.
 
 _Note_: Before reaching for a custom server, consider using a KeystoneJS

--- a/docs/guides/graphql-philosophy.md
+++ b/docs/guides/graphql-philosophy.md
@@ -7,7 +7,7 @@ order: 3
 
 # GraphQL Philosophy
 
-> 💡 _This is a conceptural introduction to how the Keystone team think about GraphQL APIs (and hence how Keystone's GraphQL API is generated). For more specific API docs, see [**Introduction to the GraphQL API**](https://v5.keystonejs.com/guides/intro-to-graphql)._
+> 💡 _This is a conceptural introduction to how the Keystone team think about GraphQL APIs (and hence how Keystone's GraphQL API is generated). For more specific API docs, see [**Introduction to the GraphQL API**](/guides/intro-to-graphql)._
 
 ## Goals
 

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -6,7 +6,7 @@ title: Hooks
 # Hooks
 
 > _NOTE: Below is an overview of hooks. For API docs see
-> [Hooks API](https://v5.keystonejs.com/api/hooks)._
+> [Hooks API](/api/hooks)._
 
 KeystoneJS provide a system of hooks on the `create`, `update`, and `delete` mutations which allow developers to customise the behaviour of their system.
 

--- a/docs/guides/intro-to-graphql.md
+++ b/docs/guides/intro-to-graphql.md
@@ -218,13 +218,13 @@ fetch('/admin/api', {
 
 A good next step is to write an `executeQuery` function that accepts a query and variables and returns the results from the API. Take a look at the `todo` sample application in the `cli` for examples of this.
 
-**Note:** If you have configured [Access Control](https://v5.keystonejs.com/api/access-control) it can effect the result of some queries.
+**Note:** If you have configured [Access Control](/api/access-control) it can effect the result of some queries.
 
 ## Executing Queries and Mutations on the Server
 
-In addition to executing queries via the API, you can execute queries and mutations on the server using [the `keystone.executeQuery()` method](https://v5.keystonejs.com/keystone-alpha/keystone/#executequeryquerystring-config).
+In addition to executing queries via the API, you can execute queries and mutations on the server using [the `keystone.executeQuery()` method](/keystone-alpha/keystone/#executequeryquerystring-config).
 
-**Note: ** No access control checks are run when executing queries on the server. Any queries or mutations that checked for `context.req` in the resolver may also return different results as the `req` object is set to `{}`. See: [Keystone executeQuery()](https://v5.keystonejs.com/keystone-alpha/keystone/#executequeryquerystring-config)
+**Note: ** No access control checks are run when executing queries on the server. Any queries or mutations that checked for `context.req` in the resolver may also return different results as the `req` object is set to `{}`. See: [Keystone executeQuery()](/keystone-alpha/keystone/#executequeryquerystring-config)
 
 ## Filter, Limit and Sorting
 

--- a/docs/guides/mutation-lifecycle.md
+++ b/docs/guides/mutation-lifecycle.md
@@ -62,7 +62,7 @@ Each of these mutations is implemented within KeystoneJS by a corresponding reso
 Please refer to the [API documentation](LINK_TODO)) for full details on how to call these mutations either from [GraphQL](LINK_TODO)) or directly from [Keystone](LINK_TODO)).
 -->
 
-KeystoneJS provides [access control](https://v5.keystonejs.com/guides/access-control)) mechanisms and a [hook system](https://v5.keystonejs.com/guides/hooks)) which allows the developer to customise the behaviour of each of these mutations.
+KeystoneJS provides [access control](/guides/access-control)) mechanisms and a [hook system](/guides/hooks)) which allows the developer to customise the behaviour of each of these mutations.
 
 This document details the lifecycle of each mutation, and how the different access control mechanisms and hooks interact.
 
@@ -103,7 +103,7 @@ The first step in all mutations is to check that the user has access to perform 
 
 If access control has been defined statically or imperatively this check can be performed here. An `AccessDeniedError` is returned if the access control failed. If the access control mechanism for this list is defined declaratively (i.e using a GraphQL `where` statement), this check is deferred until the next step.
 
-For more information on how to define access control, please consult the [access control documentation](https://v5.keystonejs.com/guides/access-control)).
+For more information on how to define access control, please consult the [access control documentation](/guides/access-control)).
 
 #### 2. Get item(s) (`update/delete`)
 

--- a/docs/guides/new-project.md
+++ b/docs/guides/new-project.md
@@ -139,4 +139,4 @@ You should see something like this
 🔗 GraphQL API:          http://localhost:3000/admin/api
 ```
 
-Now it's the time to check those routes in browser to ensure that everything works as expected. Then proceed to second step - [Adding Lists](https://v5.keystonejs.com/guides/add-lists)
+Now it's the time to check those routes in browser to ensure that everything works as expected. Then proceed to second step - [Adding Lists](/guides/add-lists)

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -36,7 +36,7 @@ On the second step, you will see a screen such as:
 
 Ignore the `npx apollo service:push` command for now,
 we'll need to upload the schema a slightly different way to account for any
-[Access Control](https://v5.keystonejs.com/guides/access-control.) you may have setup.
+[Access Control](/guides/access-control.) you may have setup.
 
 #### Config
 

--- a/docs/guides/production.md
+++ b/docs/guides/production.md
@@ -12,7 +12,7 @@ Yes, KeystoneJS can be (and is!) used for production websites. Here's a handy li
 
 ### Cookie Secret
 
-Make sure the production deployment sets a long, unguessable value for [KeystoneJS' `cookieSecret`](https://v5.keystonejs.com/keystone-alpha/keystone/#config).
+Make sure the production deployment sets a long, unguessable value for [KeystoneJS' `cookieSecret`](/keystone-alpha/keystone/#config).
 
 A randomly generated value is suitable (but keep it secret):
 
@@ -29,19 +29,19 @@ Sessions are stored inside the KeystoneJS app by default, but in production it's
 
 ## Caching
 
-Improve performance and responsiveness by adding cache hints to your [lists](https://v5.keystonejs.com/api/create-list/#cachehint) and [fields](https://v5.keystonejs.com/keystone-alpha/fields/#cachehint).
+Improve performance and responsiveness by adding cache hints to your [lists](/api/create-list/#cachehint) and [fields](/keystone-alpha/fields/#cachehint).
 
 ## Access Control
 
-Configure [access control](https://v5.keystonejs.com/guides/access-control/) to limit who can do what with your data.
+Configure [access control](/guides/access-control/) to limit who can do what with your data.
 
 ## DoS Hardening
 
-Add [query limits](https://v5.keystonejs.com/api/create-list/#querylimits) and [validation](https://v5.keystonejs.com/api/validation/) to protect your server against maliciously complex queries.
+Add [query limits](/api/create-list/#querylimits) and [validation](/api/validation/) to protect your server against maliciously complex queries.
 
 ## Using Reverse Proxies
 
-NB: If you're using a third-party hosted environment, you might already be using a reverse proxy, but Keystone will need to be [configured for it](https://v5.keystonejs.com/keystone-alpha/keystone/#trustproxies).
+NB: If you're using a third-party hosted environment, you might already be using a reverse proxy, but Keystone will need to be [configured for it](/keystone-alpha/keystone/#trustproxies).
 
 It's recommended to run production Javascript servers behind a reverse proxy such as [Nginx](https://nginx.org/), [HAProxy](https://www.haproxy.org/), a CDN or a cloud-based application (layer 7) load balancer. Doing that can improve performance and protect against [Slowloris Dos attacks](https://en.wikipedia.org/wiki/Slowloris_(computer_security)).
 

--- a/docs/guides/relationships.md
+++ b/docs/guides/relationships.md
@@ -80,5 +80,5 @@ The `many: true` option indicates that `User` can store multiple references to t
 
 See also:
 
-- [Schema - Lists & Fields](https://v5.keystonejs.com/guides/schema)
-- [Field Types - Relationship](https://v5.keystonejs.com/keystone-alpha/fields/src/types/relationship/)
+- [Schema - Lists & Fields](/guides/schema)
+- [Field Types - Relationship](/keystone-alpha/fields/src/types/relationship/)

--- a/docs/guides/schema.md
+++ b/docs/guides/schema.md
@@ -117,15 +117,15 @@ keystone.createList('Todo', {
 
 In this example, the `adminConfig` options will apply only to the `Todo` list
 (setting how many items are shown per page in the [Admin
-UI](https://v5.keystonejs.com/tutorials/admin-ui)). The `isRequired` option will ensure an API error
+UI](/tutorials/admin-ui)). The `isRequired` option will ensure an API error
 is thrown if a `task` value is not provided when creating/updating items.
 
 <!-- TODO: Screenshot -->
 
 _For more List options, see the [`createList()` API
-docs](https://v5.keystonejs.com/api/create-list)._
+docs](/api/create-list)._
 
-_[There are many different field types available](https://v5.keystonejs.com/keystone-alpha/fields/),
+_[There are many different field types available](/keystone-alpha/fields/),
 each specifying their own options._
 
 ### Related Lists

--- a/packages/adapter-knex/README.md
+++ b/packages/adapter-knex/README.md
@@ -4,6 +4,8 @@ subSection: database-adapters
 title: Knex Adapter
 [meta]-->
 
+# Knex Database Adapter
+
 The [Knex](https://knexjs.org/#changelog) adapter is a general purpose adapter which can be used to connect to a range of different database backends.
 At present, the only fully tested backend is `Postgres`, however Knex gives the potential for `MSSQL`, `MySQL`, `MariaDB`, `SQLite3`, `Oracle`, and `Amazon Redshift` to be supported.
 

--- a/packages/app-admin-ui/README.md
+++ b/packages/app-admin-ui/README.md
@@ -38,7 +38,7 @@ module.exports = {
 | `adminPath`          | `String` | `/admin`     | `false`  | The path of the Admin UI.                                                    |
 | `apiPath`            | `String` | `/admin/api` | `false`  | The path of the API provided to the Admin UI.                                |
 | `graphiqlPath`       | `String` | `/admin/api` | `false`  | The path of the graphiql app, an in-browser IDE for exploring GraphQL.       |
-| `authStrategy`       | `Object` | `null`       | `false`  | See [Authentication Guides](https://v5.keystonejs.com/guides/authentication) |
+| `authStrategy`       | `Object` | `null`       | `false`  | See [Authentication Guides](https://keystonejs.com/guides/authentication) |
 | `pages`              | `Array`  | `null`       | `false`  |                                                                              |
 | `enableDefaultRoute` | `Bool`   | `false`      | `false`  | If enabled, the path of the Admin UI app will be set to `/`.                 |
 | `schemaName`         | `String` | `public`     | `false`  |                                                                              |

--- a/packages/app-admin-ui/client/pages/Home/index.js
+++ b/packages/app-admin-ui/client/pages/Home/index.js
@@ -90,7 +90,7 @@ const ListProvider = ({ getListByKey, listKeys, ...props }) => {
         <PageError>
           <p>
             No lists defined.{' '}
-            <Link href="https://v5.keystonejs.com/guides/add-lists">
+            <Link href="https://keystonejs.com/guides/add-lists">
               Get started by creating your first list.
             </Link>
           </p>

--- a/packages/app-graphql/README.md
+++ b/packages/app-graphql/README.md
@@ -9,7 +9,7 @@ draft: true
 
 A KeystoneJS App that creates a GraphQL API and Apollo GraphQL playground.
 
-For information about writing queries and mutations for KeystoneJS see the [Introduction to KeystoneJS' GraphQL API](https://v5.keystonejs.com/guides/intro-to-graphql).
+For information about writing queries and mutations for KeystoneJS see the [Introduction to KeystoneJS' GraphQL API](https://keystonejs.com/guides/intro-to-graphql).
 
 ## Usage
 

--- a/packages/create-keystone-app/example-projects/blank/index.js
+++ b/packages/create-keystone-app/example-projects/blank/index.js
@@ -8,8 +8,8 @@ const PROJECT_NAME = 'My KeystoneJS Project';
 
 /**
  * You've got a new KeystoneJS Project! Things you might want to do next:
- * - Add adapter config options (See: https://v5.keystonejs.com/keystone-alpha/adapter-mongoose/)
- * - Select configure access control and authentication (See: https://v5.keystonejs.com/api/access-control)
+ * - Add adapter config options (See: https://keystonejs.com/keystone-alpha/adapter-mongoose/)
+ * - Select configure access control and authentication (See: https://keystonejs.com/api/access-control)
  */
 
 const keystone = new Keystone({

--- a/packages/create-keystone-app/example-projects/todo/README.md
+++ b/packages/create-keystone-app/example-projects/todo/README.md
@@ -10,4 +10,4 @@ Once running, the Keystone Admin UI is reachable via `localhost:3000/admin`.
 
 ## Next steps
 
-This example has no authentication, meaning anyone can add or remove todo items. You can lean more about access control and authentication at: `https://v5.keystonejs.com/api/access-control`.
+This example has no authentication, meaning anyone can add or remove todo items. You can lean more about access control and authentication at: `https://keystonejs.com/api/access-control`.

--- a/packages/create-keystone-app/lib/show-success-message.js
+++ b/packages/create-keystone-app/lib/show-success-message.js
@@ -12,7 +12,7 @@ const showSuccessMessage = async () => {
 
   - Edit ${c.bold(`${projectDir}${path.sep}index.js`)} to customize your app.
   - ${terminalLink('Open the Admin UI', 'http://localhost:3000/admin')}
-  - ${terminalLink('Read the docs', 'https://v5.keystonejs.com')}
+  - ${terminalLink('Read the docs', 'https://keystonejs.com')}
   - ${terminalLink('Star KeystoneJS on GitHub', 'https://github.com/keystonejs/keystone-5')}
 `);
 };

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -106,14 +106,14 @@ Specifies whether the field is required or not. Will return an error if mutation
 
 ### `access`
 
-[Access control](https://v5.keystonejs.com/guides/access-control) options for fields.
+[Access control](https://keystonejs.com/guides/access-control) options for fields.
 
-Options for `create`, `read`, `update` and `delete` - can be a function or Boolean. See the [access control API documentation](https://v5.keystonejs.com/api/access-control) for more details.
+Options for `create`, `read`, `update` and `delete` - can be a function or Boolean. See the [access control API documentation](https://keystonejs.com/api/access-control) for more details.
 
 _Note_: Field level access control does not accept graphQL where clauses.
 
 ### `cacheHint`
 
-[HTTP cache hint](https://v5.keystonejs.com/api/create-list#cacheHint) for field.
+[HTTP cache hint](https://keystonejs.com/api/create-list#cacheHint) for field.
 
 Only static hints are supported for fields.

--- a/packages/keystone/README.md
+++ b/packages/keystone/README.md
@@ -23,7 +23,7 @@ const keystone = new Keystone({
 | Option                  | Type       | Default    | Description                                                                                                                                       |
 | ----------------------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `name`                  | `String`   | `null`     | The name of the project. Appears in the Admin UI.                                                                                                 |
-| `adapter`               | `Object`   | Required   | The database storage adapter. See the [Adapter Framework](https://v5.keystonejs.com/keystone-alpha/keystone/lib/adapters/) page for more details. |
+| `adapter`               | `Object`   | Required   | The database storage adapter. See the [Adapter Framework](https://keystonejs.com/keystone-alpha/keystone/lib/adapters/) page for more details. |
 | `adapters`              | `Array`    | `[]`       |                                                                                                                                                   |
 | `defaultAdapter`        | `Object`   | `null`     |                                                                                                                                                   |
 | `defaultAccess`         | `Object`   | `{}`       |                                                                                                                                                   |
@@ -39,7 +39,7 @@ const keystone = new Keystone({
 
 Configures global query limits.
 
-These should be used together with [list query limits](https://v5.keystonejs.com/api/create-list#query-limits).
+These should be used together with [list query limits](https://keystonejs.com/api/create-list#query-limits).
 
 #### Usage
 
@@ -104,7 +104,7 @@ Registers a new list with KeystoneJS and returns a `Keystone` list object.
 | Option    | Type     | Default | Description                                                                                                 |
 | --------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------- |
 | `listKey` | `String` | `null`  | The name of the list. This should be singular, E.g. 'User' not 'Users'.                                     |
-| `config`  | `Object` | `{}`    | The list config. See the [createList API](https://v5.keystonejs.com/api/create-list) page for more details. |
+| `config`  | `Object` | `{}`    | The list config. See the [createList API](https://keystonejs.com/api/create-list) page for more details. |
 
 ## extendGraphQLSchema(config)
 
@@ -227,7 +227,7 @@ keystone.connect();
 
 _Note_: `keystone.connect()` is only required for custom servers. Most example projects use the `keystone start` command to start a server and automatically connect.
 
-See: [Custom Server](https://v5.keystonejs.com/guides/custom-server).
+See: [Custom Server](https://keystonejs.com/guides/custom-server).
 
 ## disconnect()
 

--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -38,7 +38,7 @@ async function getGatsbyConfig() {
   return {
     siteMetadata: {
       title: `KeystoneJS`,
-      siteUrl: `https://v5.keystonejs.com`,
+      siteUrl: `https://keystonejs.com`,
       description: `A scalable platform and CMS to build Node.js applications.`,
       twitter: `@keystonejs`,
     },


### PR DESCRIPTION
More things!

* Replaced all v5.keystonejs.com links in `docs/` with relative paths. Before it was a mix of hardcoded and relative. Also fixes certain links at keystonejs.com sending people to v5.keystonejs.com.
* Replaced all other instances of v5.keystonejs.com outside of `docs/` with keystonejs.com. Just did a find/replace on these.
* Few other small things.