### PR TITLE
Update packages to reference Keystone 5 being in active maintenance mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <h1>⚠️ Maintenance Mode</h1>
   <p>Keystone 5 has moved into maintenance mode!</p>
-  <p>Head over to <a href="https://next.keystonejs.com/roadmap">Keystone Next</a> to see what's next on our roadmap.</p>
+  <p>For more information please read our <a href="https://github.com/keystonejs/keystone-5/issues/21">Keystone 5 and beyond</a> post.</p>
   <br>
 </div>
 <br>

--- a/packages/access-control/README.md
+++ b/packages/access-control/README.md
@@ -4,6 +4,8 @@ title: Access Control
 
 # Access Control
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 [![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/@keystonejs/access-control)
 
 This package is an internal helper package used by Keystone to parse and validate access control expressions.

--- a/packages/adapter-knex/README.md
+++ b/packages/adapter-knex/README.md
@@ -6,6 +6,8 @@ title: Knex adapter
 
 # Knex database adapter
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 [![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/@keystonejs/adapter-knex)
 
 The [Knex](https://knexjs.org/#changelog) adapter is a general purpose adapter which can be used to connect to a range of different database backends.

--- a/packages/adapter-mongoose/README.md
+++ b/packages/adapter-mongoose/README.md
@@ -6,6 +6,8 @@ title: Mongoose adapter
 
 # Mongoose database adapter
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 [![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/@keystonejs/adapter-mongoose)
 
 ## Usage

--- a/packages/adapter-prisma/README.md
+++ b/packages/adapter-prisma/README.md
@@ -6,6 +6,8 @@ title: Prisma adapter
 
 # Prisma database adapter
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 [![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/@keystonejs/adapter-prisma)
 
 The Prisma adapter allows Keystone to connect a database using Prisma Client, a type-safe and auto-generated database client. You can learn more about Prisma Client in the [Prisma docs](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client).

--- a/packages/apollo-helpers/README.md
+++ b/packages/apollo-helpers/README.md
@@ -6,6 +6,8 @@ title: Apollo helpers
 
 # Apollo helpers
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 [![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/@keystonejs/apollo-helpers)
 
 A set of functions and components to ease using

--- a/packages/app-admin-ui/README.md
+++ b/packages/app-admin-ui/README.md
@@ -6,6 +6,8 @@ title: Admin UI app
 
 # Admin UI app
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 [![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/@keystonejs/app-admin-ui)
 
 A KeystoneJS app which provides an Admin UI for content management.

--- a/packages/app-graphql-playground/README.md
+++ b/packages/app-graphql-playground/README.md
@@ -7,6 +7,8 @@ draft: true
 
 # GraphQL Playground App
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 [![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/@keystonejs/app-graphql-playground)
 
 A KeystoneJS App that creates an Apollo GraphQL playground.

--- a/packages/app-graphql/README.md
+++ b/packages/app-graphql/README.md
@@ -6,6 +6,8 @@ title: GraphQL app
 
 # GraphQL app
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 [![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/@keystonejs/app-graphql)
 
 A KeystoneJS app that creates a GraphQL API and [GraphiQL](https://github.com/graphql/graphiql/blob/master/packages/graphiql/README.md) playground.

--- a/packages/app-next/README.md
+++ b/packages/app-next/README.md
@@ -6,6 +6,8 @@ title: Next.js app
 
 # Next.js app
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 [![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/@keystonejs/app-next)
 
 A KeystoneJS app for serving a [Next.js](https://nextjs.org/) application.

--- a/packages/app-nuxt/README.md
+++ b/packages/app-nuxt/README.md
@@ -6,6 +6,8 @@ title: Nuxt.js app
 
 # Nuxt.js app
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 [![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/@keystonejs/app-nuxt)
 
 ## Usage

--- a/packages/app-schema-router/README.md
+++ b/packages/app-schema-router/README.md
@@ -6,6 +6,8 @@ title: GraphQL Schema Router
 
 # GraphQL Schema Router
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 [![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/@keystonejs/app-schema-router)
 
 A KeystoneJS App that route requests to different GraphQL schemas.

--- a/packages/app-static/README.md
+++ b/packages/app-static/README.md
@@ -6,6 +6,8 @@ title: Static file app
 
 # Static file app
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 [![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/@keystonejs/app-static)
 
 A KeystoneJS app to serve static files such as images, CSS and JavaScript with support for client side routing.

--- a/packages/app-version/README.md
+++ b/packages/app-version/README.md
@@ -6,6 +6,8 @@ title: App version plugin
 
 # App version plugin
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 [![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/@keystonejs/app-version)
 
 This package provides support for including a version string both as an HTTP response header and as a graphQL query.

--- a/packages/arch/README.md
+++ b/packages/arch/README.md
@@ -5,6 +5,8 @@ title: Arch UI
 
 # Arch - Keystone UI Kit
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 Resources, tooling, and design guidelines by KeystoneJS using [GastbyJS](https://www.gatsbyjs.org/)
 
 ## Getting Started

--- a/packages/auth-passport/README.md
+++ b/packages/auth-passport/README.md
@@ -6,6 +6,8 @@ title: Passport auth strategy
 
 # Passport auth strategy
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 [![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/@keystonejs/auth-passport)
 
 > This feature is currently in progress. While passport works for the `GraphQLApp`, only password authentication is supported for the `AdminUIApp`. Please see [this issue](https://github.com/keystonejs/keystone-5/issues/2581) for more details.

--- a/packages/auth-password/README.md
+++ b/packages/auth-password/README.md
@@ -7,6 +7,8 @@ order: 1
 
 # Password auth strategy
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 [![View changelog](https://img.shields.io/badge/changelogs.xyz-Explore%20Changelog-brightgreen)](https://changelogs.xyz/@keystonejs/auth-password)
 
 Authenticates a party (often a user) based on their presentation of a credential

--- a/packages/create-keystone-app/README.md
+++ b/packages/create-keystone-app/README.md
@@ -6,6 +6,8 @@ title: Create Keystone app
 
 # Create Keystone app
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 A CLI for Keystone to help generate starter apps.
 
 ## Usage

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -6,6 +6,8 @@ title: Keystone email
 
 # Keystone email
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 Send emails via various transports, rendered with Express-compatible
 renderers. Powered by [`keystone-email`](https://github.com/keystonejs/keystone-5-email).
 

--- a/packages/field-views-loader/README.md
+++ b/packages/field-views-loader/README.md
@@ -4,6 +4,8 @@ title: Field Views Loader
 
 # Field Views Loader
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 This packages contains a [webpack loader](https://webpack.js.org/api/loaders) which makes the field type UI components available to the Admin UI.
 
 This package is an internal helper package used by Keystone. It contains a [webpack loader](https://webpack.js.org/api/loaders) which makes the field type UI components available to the Admin UI.

--- a/packages/fields-authed-relationship/README.md
+++ b/packages/fields-authed-relationship/README.md
@@ -6,6 +6,8 @@ title: AuthedRelationship
 
 # AuthedRelationship
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 An extension on the `Relationship` field which is automatically set to the
 currently authenticated item during a create mutation.
 

--- a/packages/fields-auto-increment/README.md
+++ b/packages/fields-auto-increment/README.md
@@ -6,6 +6,8 @@ title: AutoIncrement
 
 # AutoIncrement
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 An automatically incrementing integer with support for the Knex adapter. It's important to note that this type:
 
 - Has [important limitations](#limitations) due to varying support from the underlying DB platform

--- a/packages/fields-cloudinary-image/README.md
+++ b/packages/fields-cloudinary-image/README.md
@@ -6,6 +6,8 @@ title: CloudinaryImage
 
 # CloudinaryImage
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 The `CloudinaryImage` field extends the [`File`](/packages/fields/src/types/File/README.md) field and allows uploading images to Cloudinary. It also exposes additional GraphQL functionality for querying your uploaded images.
 
 ## Usage

--- a/packages/fields-color/README.md
+++ b/packages/fields-color/README.md
@@ -6,6 +6,8 @@ title: Color
 
 # Color
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 Stores hexidecimal RGBA (Red, Green, Blue, Alpha) color values.
 Presents in the Admin UI as an interactive color picker.
 

--- a/packages/fields-content/README.md
+++ b/packages/fields-content/README.md
@@ -6,6 +6,8 @@ title: Content
 
 # Content
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 A Block-based Content Field for composing rich text such as blog posts, wikis,
 and even complete pages.
 

--- a/packages/fields-location-google/README.md
+++ b/packages/fields-location-google/README.md
@@ -6,6 +6,8 @@ title: LocationGoogle
 
 # LocationGoogle
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 The LocationGoogle Field Type enables storing data from the Google Maps API.
 
 ## Usage

--- a/packages/fields-markdown/README.md
+++ b/packages/fields-markdown/README.md
@@ -6,6 +6,8 @@ title: Markdown
 
 # Markdown
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 This field inserts a string path into your schema based on the `Text` field type implementation, and renders a Markdown editor using [CodeMirror](https://codemirror.net/).
 
 ## Usage

--- a/packages/fields-mongoid/README.md
+++ b/packages/fields-mongoid/README.md
@@ -6,6 +6,8 @@ title: MongoId
 
 # MongoId
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 This field allows arbitrary Mongo `ObjectId` fields to be added to your lists.
 
 It supports the core Mongoose and Knex adapters:

--- a/packages/fields-oembed/README.md
+++ b/packages/fields-oembed/README.md
@@ -6,6 +6,8 @@ title: OEmbed
 
 # OEmbed
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 Stores data in the oEmbed format:
 
 > `oEmbed` is a format for allowing an embedded representation of a URL on third party sites.

--- a/packages/fields-unsplash/README.md
+++ b/packages/fields-unsplash/README.md
@@ -6,6 +6,8 @@ title: Unsplash
 
 # Unsplash
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 The Unsplash Field Type enables storing meta data from the Unsplash API and
 generating URLs to dynamically transformed images.
 

--- a/packages/fields-wysiwyg-tinymce/README.md
+++ b/packages/fields-wysiwyg-tinymce/README.md
@@ -6,6 +6,8 @@ title: Wysiwyg
 
 # Wysiwyg
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 This field inserts a string path into your schema based on the `Text` field type implementation, and renders a WYSIWYG editor in the Admin UI using [TinyMCE](https://www.tiny.cloud/)
 
 ## Usage

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -6,6 +6,8 @@ order: 3
 
 # Fields
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 Keystone contains a set of primitive fields types that can be imported from the `@keystonejs/fields` package:
 
 | Field type                                                          | Description                                                                                                                                            |

--- a/packages/file-adapters/README.md
+++ b/packages/file-adapters/README.md
@@ -6,6 +6,8 @@ title: File adapters
 
 # File adapters
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 The `File` field type can support files hosted in a range of different contexts, e.g. in the local filesystem, or on a cloud based file server.
 
 Different contexts are supported by different file adapters. This package contains the built-in file adapters supported by KeystoneJS.

--- a/packages/keystone/README.md
+++ b/packages/keystone/README.md
@@ -6,6 +6,8 @@ order: 1
 
 # Keystone class
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 ## Usage
 
 ```javascript

--- a/packages/list-plugins/README.md
+++ b/packages/list-plugins/README.md
@@ -1,5 +1,7 @@
 # List Plugins
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 # atTracking
 
 Adds `createdAt` and `updatedAt` fields to a list. These fields are read-only by will be updated automatically when items are created or updated.

--- a/packages/server-side-graphql-client/README.md
+++ b/packages/server-side-graphql-client/README.md
@@ -5,6 +5,8 @@ title: Server-side graphQL client
 
 # Server-side graphQL client
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 This library provides wrapper functions around `keystone.executeGraphQL` to make it easier to run server-side queries and mutations without needing to write boilerplate GraphQL.
 
 Creating a new `User` item would be written as follows using `keystone.executeGraphQL`:

--- a/packages/session/README.md
+++ b/packages/session/README.md
@@ -6,6 +6,8 @@ title: Session
 
 # Session
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 <!-- TODO -->
 
 This package contains functions to assist with setting up session management in your KeystoneJS system.

--- a/packages/test-utils/README.md
+++ b/packages/test-utils/README.md
@@ -6,6 +6,8 @@ title: Test utils
 
 # Test utils
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 This package is an internal KeystoneJS package which contains utility functions to assist in running tests against the GraphQL API.
 
 ## Installation

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -4,6 +4,8 @@ title: Utilities
 
 # Utilities
 
+> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
+
 This package is an internal Keystone package which contains various helper functions which are used throughout the monorepo.
 
 You should probably not use this directly in your Keystone projects.


### PR DESCRIPTION
Adds the following to all package README files:

> This is the last active development release of this package as **Keystone 5** is now in a 6 to 12 month active maintenance phase. For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.

Updates the repository README to refer to the [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.