### PR TITLE
Revert social links to link back to the main keystonejs repository

### DIFF
--- a/website/src/components/Sidebar.js
+++ b/website/src/components/Sidebar.js
@@ -303,7 +303,7 @@ export const Footer = () => (
     <br />
     amazing{' '}
     <FooterAnchor
-      href="https://github.com/keystonejs/keystone-5/graphs/contributors"
+      href="https://github.com/keystonejs/keystone/graphs/contributors"
       target="_blank"
     >
       contributors

--- a/website/src/components/Sidebar.js
+++ b/website/src/components/Sidebar.js
@@ -302,10 +302,7 @@ export const Footer = () => (
     and
     <br />
     amazing{' '}
-    <FooterAnchor
-      href="https://github.com/keystonejs/keystone/graphs/contributors"
-      target="_blank"
-    >
+    <FooterAnchor href="https://github.com/keystonejs/keystone/graphs/contributors" target="_blank">
       contributors
     </FooterAnchor>
   </footer>

--- a/website/src/components/SocialIconsNav.js
+++ b/website/src/components/SocialIconsNav.js
@@ -11,11 +11,7 @@ const SocialIconsNav = props => (
         <IconTwitter href="https://twitter.com/keystonejs" target="_blank" title="Twitter" />
       </li>
       <li css={{ marginRight: [`1rem`] }}>
-        <IconGithub
-          href="https://github.com/keystonejs/keystone"
-          target="_blank"
-          title="Github"
-        />
+        <IconGithub href="https://github.com/keystonejs/keystone" target="_blank" title="Github" />
       </li>
       <li css={{ marginRight: [`0`] }}>
         <IconSlack href="http://community.keystonejs.com/" target="_blank" title="Slack" />

--- a/website/src/components/SocialIconsNav.js
+++ b/website/src/components/SocialIconsNav.js
@@ -12,7 +12,7 @@ const SocialIconsNav = props => (
       </li>
       <li css={{ marginRight: [`1rem`] }}>
         <IconGithub
-          href="https://github.com/keystonejs/keystone-5"
+          href="https://github.com/keystonejs/keystone"
           target="_blank"
           title="Github"
         />

--- a/website/src/components/homepage/HomepageFooter.js
+++ b/website/src/components/homepage/HomepageFooter.js
@@ -16,7 +16,7 @@ const HomepageFooter = () => (
   >
     <Container>
       <GitHubButton
-        href="https://github.com/keystonejs/keystone-5"
+        href="https://github.com/keystonejs/keystone"
         data-size="large"
         data-show-count="true"
         aria-label="Star keystonejs/keystone on GitHub"

--- a/website/src/components/homepage/SectionHero.js
+++ b/website/src/components/homepage/SectionHero.js
@@ -50,7 +50,7 @@ const SectionHero = () => (
           </Button>
           <Button
             variant="link"
-            href="https://github.com/keystonejs/keystone-5"
+            href="https://github.com/keystonejs/keystone"
             rel="noopener noreferrer"
             target="_blank"
             css={{


### PR DESCRIPTION
Revert social links to link back to the main keystonejs repository for the time being.