### PR TITLE
Update manypkg default branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,6 +154,9 @@
       "**/cypress-multi-reporters"
     ]
   },
+  "manypkg": {
+    "defaultBranch": "main"
+  },
   "preconstruct": {
     "packages": [
       "packages/arch/packages/*",


### PR DESCRIPTION
Fixes manypkg reported errors when it tries to use `master` instead of the new default branch `main`.