### PR TITLE
Update deployment.md

### DIFF
--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -44,8 +44,13 @@ WORKDIR /home/node
 RUN apk add --no-cache build-base python2 yarn && \
     wget -O dumb-init -q https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_amd64 && \
     chmod +x dumb-init
+ADD ./package.json ./package.json
+
+RUN yarn install 
+
 ADD . /home/node
-RUN yarn install && yarn build && yarn cache clean
+
+RUN yarn build && yarn cache clean
 
 # Runtime container
 FROM node:${NODE_VERSION}-alpine

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -44,7 +44,7 @@ WORKDIR /home/node
 RUN apk add --no-cache build-base python2 yarn && \
     wget -O dumb-init -q https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_amd64 && \
     chmod +x dumb-init
-ADD ./package.json ./package.json
+ADD ./yarn.lock ./yarn.lock
 
 RUN yarn install 
 

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -44,6 +44,7 @@ WORKDIR /home/node
 RUN apk add --no-cache build-base python2 yarn && \
     wget -O dumb-init -q https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_amd64 && \
     chmod +x dumb-init
+ADD ./package.json ./package.json
 ADD ./yarn.lock ./yarn.lock
 
 RUN yarn install 


### PR DESCRIPTION
Doing `ADD . /home/node`  before `yarn install` __invalidates the cache__ of the previous yarn install which would take a few minutes from the build
My suggestion:
```
# after apk add
ADD ./package.json ./package.json
RUN yarn install
ADD . /home/node
RUN yarn build && yarn cache clean
```

This way the installation of packages is done only when new packages are added. (not every built) :wink: