### PR TITLE
disable renovate for keystone-5 repo

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,32 +1,3 @@
 {
-  "extends": ["config:base"],
-  "ignorePaths": ["packages/build-field-tyes/__fixtures__/**/*"],
-  "lockFileMaintenance": { "enabled": true },
-  "separateMinorPatch": true,
-  "prConcurrentLimit": 0,
-  "packageRules": [
-    {
-      "packageNames": ["slate", "slate-react"],
-      "paths": ["packages/**/package.json"],
-      "enabled": false
-    },
-    {
-      "packagePatterns": [
-        "gatsby",
-        "remark",
-        "babel-plugin-remove-graphql-queries",
-        "react-day-picker",
-        "mjml"
-      ],
-      "enabled": false
-    },
-    {
-      "updateTypes": ["patch"],
-      "groupName": "patch dependencies"
-    }
-  ],
-  "rangeStrategy": "bump",
-  "schedule": ["before 7am on Tuesday"],
-  "timezone": "Australia/Sydney",
-  "updateNotScheduled": false
+  "enabled": false
 }


### PR DESCRIPTION
Cursory research, we can't opt out of the renovate service per repo, (or at least i don't have access to it). 
The recommendation is to add `enabled: false` as a property to the renovate.json file. 

This PR does this. 