### PR TITLE
Return HTTP 425 while Keystone is booting

### DIFF
--- a/.changeset/six-ravens-obey.md
+++ b/.changeset/six-ravens-obey.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/keystone': patch
+---
+
+Return HTTP 425 while Keystone is booting

--- a/packages/keystone/bin/loading.html
+++ b/packages/keystone/bin/loading.html
@@ -128,37 +128,44 @@
 
       function checkAndSetStatus() {
         let cancelled = false;
-        fetch('/', { headers: { Accept: 'application/json' } })
-          .then(result => result.json())
-          .catch(error => {
-            // We can get back an error "Cannot parse JSON" when a HTML
-            // response is returned, so we assume the server is ready
-            onReady();
+        if (!ready) {
+          fetch(window.location.href.replace(window.location.origin, ''), {
+            headers: { Accept: 'application/json' },
           })
-          .then(({ loading, status } = {}) => {
-            if (!loading) {
-              onReady();
-              return;
-            }
-            if (cancelled) {
-              return;
-            }
-            switch (status) {
-              case 'init-keystone': {
-                statusEl.innerHTML = 'initialising...';
-                break;
+            .then(result => {
+              // Will get back HTTP status 425 while still loading
+              if (result.status === 425) {
+                return result.json();
+              } else {
+                // Anything else; 200, 404, etc, means the server is alive
+                return { loading: false };
               }
-              case 'db-connect': {
-                statusEl.innerHTML = 'connecting to the database...';
-                break;
+            })
+            .then(({ loading, status } = {}) => {
+              if (cancelled) {
+                return;
               }
-              case 'start-server':
-              default: {
-                statusEl.innerHTML = 'loading...';
-                break;
+              if (!loading) {
+                onReady();
+                return;
               }
-            }
-          });
+              switch (status) {
+                case 'init-keystone': {
+                  statusEl.innerHTML = 'initialising...';
+                  break;
+                }
+                case 'db-connect': {
+                  statusEl.innerHTML = 'connecting to the database...';
+                  break;
+                }
+                case 'start-server':
+                default: {
+                  statusEl.innerHTML = 'loading...';
+                  break;
+                }
+              }
+            });
+        }
         return () => {
           cancelled = true;
         };
@@ -172,7 +179,7 @@
           return;
         }
         cancelLastCall = checkAndSetStatus();
-      }, 500);
+      }, 1000);
     </script>
   </body>
 </html>

--- a/packages/keystone/bin/utils.js
+++ b/packages/keystone/bin/utils.js
@@ -107,9 +107,9 @@ async function executeDefaultServer(args, entryFile, distDir, spinner) {
       next();
     } else {
       res.format({
-        default: () => res.sendFile(path.resolve(__dirname, './loading.html')),
-        'text/html': () => res.sendFile(path.resolve(__dirname, './loading.html')),
-        'application/json': () => res.json({ loading: true, status }),
+        default: () => res.status(425).sendFile(path.resolve(__dirname, './loading.html')),
+        'text/html': () => res.status(425).sendFile(path.resolve(__dirname, './loading.html')),
+        'application/json': () => res.status(425).json({ loading: true, status }),
       });
     }
   });


### PR DESCRIPTION
This allows easier detection of when the Keystone instance is actually ready; particularly useful when combined with the `start-server-and-test` package which waits for HTTP 200 by default.