### PR TITLE
feat: pass query args to list access control functions

### DIFF
--- a/.changeset/neat-moons-give.md
+++ b/.changeset/neat-moons-give.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/access-control': minor
+'@keystonejs/keystone': minor
+---
+
+Pass query args to list access control functions

--- a/docs/api/access-control.md
+++ b/docs/api/access-control.md
@@ -66,6 +66,7 @@ interface AccessInput {
   gqlName?: string;
   itemId?: string;
   itemIds?: [string];
+  args?: {}
 }
 
 type StaticAccess = boolean;
@@ -91,7 +92,7 @@ the list `User` it would match the input type `UserWhereInput`.
 `AccessInput` has the following properties:
 
 | Property                 | Description                                                                                   |
-| ------------------------ | --------------------------------------------------------------------------------------------- |
+|--------------------------|-----------------------------------------------------------------------------------------------|
 | `authentication`         | The currently authenticated user.                                                             |
 | `authentication.item`    | The details of the current user. Will be `undefined` for anonymous users.                     |
 | `authentication.listKey` | The list key of the currently authenticated user. Will be `undefined` for anonymous users.    |
@@ -102,6 +103,7 @@ the list `User` it would match the input type `UserWhereInput`.
 | `itemId`                 | The `id` of the item being updated/deleted in singular `update` and `delete` operations.      |
 | `itemIds`                | The `ids` of the items being updated/deleted in multiple `update` and `delete` operations.    |
 | `context`                | The `context` of the originating GraphQL operation.                                           |
+| `args`                   | Arguments of GraphQL operation                                                                |
 
 When resolving `StaticAccess`:
 

--- a/packages/access-control/src/access-control.ts
+++ b/packages/access-control/src/access-control.ts
@@ -17,6 +17,7 @@ type ListAccessArgs = {
   originalInput?: any;
   itemId?: any;
   itemIds?: any;
+  args?: any;
 };
 type FieldAccessArgs = {
   operation: keyof FieldAccess<FieldAccessArgs>;
@@ -329,6 +330,7 @@ export async function validateListAccessControl({
   itemId,
   itemIds,
   context,
+  args,
 }: { access: ListAccess<ListAccessArgs> } & ListAccessArgs) {
   // Either a boolean or an object describing a where clause
   let result: Static | Declarative = false;
@@ -345,6 +347,7 @@ export async function validateListAccessControl({
       itemId,
       itemIds,
       context,
+      args,
     });
   }
 

--- a/packages/keystone/lib/Keystone/index.js
+++ b/packages/keystone/lib/Keystone/index.js
@@ -119,7 +119,7 @@ module.exports = class Keystone {
         listKey,
         originalInput,
         operation,
-        { gqlName, itemId, itemIds, context } = {}
+        { gqlName, itemId, itemIds, context, args } = {}
       ) => {
         return validateListAccessControl({
           access: access[schemaName],
@@ -131,6 +131,7 @@ module.exports = class Keystone {
           itemId,
           itemIds,
           context,
+          args,
         });
       },
       { isPromise: true }

--- a/packages/keystone/lib/ListTypes/list.js
+++ b/packages/keystone/lib/ListTypes/list.js
@@ -483,7 +483,7 @@ module.exports = class List {
   }
 
   async listQuery(args, context, gqlName, info, from) {
-    const access = await this.checkListAccess(context, undefined, 'read', { gqlName });
+    const access = await this.checkListAccess(context, undefined, 'read', { gqlName, args });
 
     return this._itemsQuery(mergeWhereClause(args, access), { context, info, from });
   }
@@ -494,7 +494,7 @@ module.exports = class List {
       // on what the user requested
       // Evaluation takes place in ../Keystone/index.js
       getCount: async () => {
-        const access = await this.checkListAccess(context, undefined, 'read', { gqlName });
+        const access = await this.checkListAccess(context, undefined, 'read', { gqlName, args });
 
         const { count } = await this._itemsQuery(mergeWhereClause(args, access), {
           meta: true,


### PR DESCRIPTION
### Hi!

We are using keystone-v5 in our [open source condominium management software](https://github.com/open-condo-software/condo).

We recently encountered the following problem. We want to prevent a certain group of users from filtering on a certain set of fields in queries. 

It turned out that unlike `CustomProvider`, `ListProvider` does not pass query arguments to the access control function, so it becomes impossible to analyse the `where` argument. 

This fix passes query arguments to the access control function, making it possible to analyze arguments when evaluating accesses.

You can find more details inside this [issue](https://github.com/keystonejs/keystone-5/issues/419)